### PR TITLE
[WIP] Initial cancellation proposal.

### DIFF
--- a/chronos.nim
+++ b/chronos.nim
@@ -6,5 +6,5 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import chronos/[asyncloop, asyncfutures2, asyncsync, handles, transport,
-                timer, version]
+                timer]
 export asyncloop, asyncfutures2, asyncsync, handles, transport, timer, version

--- a/chronos.nim
+++ b/chronos.nim
@@ -6,5 +6,5 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import chronos/[asyncloop, asyncfutures2, asyncsync, handles, transport,
-                timer]
-export asyncloop, asyncfutures2, asyncsync, handles, transport, timer
+                timer, version]
+export asyncloop, asyncfutures2, asyncsync, handles, transport, timer, version

--- a/chronos.nim
+++ b/chronos.nim
@@ -7,4 +7,4 @@
 #              MIT license (LICENSE-MIT)
 import chronos/[asyncloop, asyncfutures2, asyncsync, handles, transport,
                 timer]
-export asyncloop, asyncfutures2, asyncsync, handles, transport, timers
+export asyncloop, asyncfutures2, asyncsync, handles, transport, timer

--- a/chronos.nim
+++ b/chronos.nim
@@ -7,4 +7,4 @@
 #              MIT license (LICENSE-MIT)
 import chronos/[asyncloop, asyncfutures2, asyncsync, handles, transport,
                 timer]
-export asyncloop, asyncfutures2, asyncsync, handles, transport, timer, version
+export asyncloop, asyncfutures2, asyncsync, handles, transport, timers

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "2.2.6"
+version       = "2.2.7"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"

--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -420,7 +420,7 @@ proc injectStacktrace[T](future: Future[T]) =
 
 proc read*[T](future: Future[T] | FutureVar[T]): T =
   ## Retrieves the value of ``future``. Future must be finished otherwise
-  ## this function will fail with a ``FutureError`` exception.
+  ## this function will fail with a ``ValueError`` exception.
   ##
   ## If the result of the future is an error then that error will be raised.
   {.push hint[ConvFromXtoItselfNotNeeded]: off.}
@@ -434,17 +434,18 @@ proc read*[T](future: Future[T] | FutureVar[T]): T =
       return fut.value
   else:
     # TODO: Make a custom exception type for this?
-    raise newException(FutureError, "Future still in progress.")
+    raise newException(ValueError, "Future still in progress.")
 
 proc readError*[T](future: Future[T]): ref Exception =
   ## Retrieves the exception stored in ``future``.
   ##
-  ## An ``FutureError`` exception will be thrown if no exception exists
+  ## An ``ValueError`` exception will be thrown if no exception exists
   ## in the specified Future.
   if not(isNil(future.error)):
     return future.error
   else:
-    raise newException(FutureError, "No error in future.")
+    # TODO: Make a custom exception type for this?
+    raise newException(ValueError, "No error in future.")
 
 proc mget*[T](future: FutureVar[T]): var T =
   ## Returns a mutable value stored in ``future``.
@@ -648,7 +649,7 @@ proc oneIndex*[T](futs: varargs[Future[T]]): Future[int] =
     fut.addCallback(cb)
 
   if len(nfuts) == 0:
-    retFuture.fail(newException(FutureError, "Empty Future[T] list"))
+    retFuture.fail(newException(ValueError, "Empty Future[T] list"))
 
   retFuture.cancelCallback = cancel
   return retFuture
@@ -697,7 +698,7 @@ proc oneValue*[T](futs: varargs[Future[T]]): Future[T] =
     fut.addCallback(cb)
 
   if len(nfuts) == 0:
-    retFuture.fail(newException(FutureError, "Empty Future[T] list"))
+    retFuture.fail(newException(ValueError, "Empty Future[T] list"))
 
   retFuture.cancelCallback = cancel
   return retFuture

--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -26,13 +26,19 @@ type
     deleted*: bool
 
   # ZAH: This can probably be stored with a cheaper representation
-  # until the moment it needs to be printed to the screen (e.g. seq[StackTraceEntry])
+  # until the moment it needs to be printed to the screen
+  # (e.g. seq[StackTraceEntry])
   StackTrace = string
+
+  FutureState* {.pure.} = enum
+    Pending, Finished, Cancelled, Failed
 
   FutureBase* = ref object of RootObj ## Untyped future.
     location: array[2, ptr SrcLoc]
     callbacks: Deque[AsyncCallback]
-    finished: bool
+    cancelcb*: CallbackFunc
+    child*: FutureBase
+    state*: FutureState
     error*: ref Exception ## Stored exception
     errorStackTrace*: StackTrace
     stackTrace: StackTrace ## For debugging purposes only.
@@ -58,6 +64,8 @@ type
   FutureError* = object of Exception
     cause*: FutureBase
 
+  CancelledError* = object of FutureError
+
 var currentID* {.threadvar.}: int
 currentID = 0
 
@@ -79,7 +87,7 @@ proc callSoon*(c: CallbackFunc, u: pointer = nil) =
 
 template setupFutureBase(loc: ptr SrcLoc) =
   new(result)
-  result.finished = false
+  result.state = FutureState.Pending
   result.stackTrace = getStackTrace()
   result.id = currentID
   result.location[LocCreateIndex] = loc
@@ -135,13 +143,30 @@ template newFutureVar*[T](fromProc: static[string] = ""): auto =
 
 proc clean*[T](future: FutureVar[T]) =
   ## Resets the ``finished`` status of ``future``.
-  Future[T](future).finished = false
+  Future[T](future).state = FutureState.Pending
   Future[T](future).error = nil
+
+proc finished*(future: FutureBase | FutureVar): bool {.inline.} =
+  ## Determines whether ``future`` has completed.
+  ##
+  ## ``True`` may indicate an error or a value. Use ``failed`` to distinguish.
+  when future is FutureVar:
+    result = (FutureBase(future).state != FutureState.Pending)
+  else:
+    result = (future.state != FutureState.Pending)
+
+proc cancelled*(future: FutureBase): bool {.inline.} =
+  ## Determines whether ``future`` has cancelled.
+  result = (future.state == FutureState.Cancelled)
+
+proc failed*(future: FutureBase): bool {.inline.} =
+  ## Determines whether ``future`` completed with an error.
+  result = (future.state == FutureState.Failed)
 
 proc checkFinished[T](future: Future[T], loc: ptr SrcLoc) =
   ## Checks whether `future` is finished. If it is then raises a
   ## ``FutureError``.
-  if future.finished:
+  if future.finished():
     var msg = ""
     msg.add("An attempt was made to complete a Future more than once. ")
     msg.add("Details:")
@@ -170,7 +195,7 @@ proc call(callbacks: var Deque[AsyncCallback]) =
   var count = len(callbacks)
   while count > 0:
     var item = callbacks.popFirst()
-    if not item.deleted:
+    if not(item.deleted):
       callSoon(item.function, item.udata)
     dec(count)
 
@@ -188,7 +213,7 @@ proc complete[T](future: Future[T], val: T, loc: ptr SrcLoc) =
   checkFinished(future, loc)
   doAssert(isNil(future.error))
   future.value = val
-  future.finished = true
+  future.state = FutureState.Finished
   future.callbacks.call()
 
 template complete*[T](future: Future[T], val: T) =
@@ -199,7 +224,7 @@ proc complete(future: Future[void], loc: ptr SrcLoc) =
   ## Completes a void ``future``.
   checkFinished(future, loc)
   doAssert(isNil(future.error))
-  future.finished = true
+  future.state = FutureState.Finished
   future.callbacks.call()
 
 template complete*(future: Future[void]) =
@@ -209,7 +234,7 @@ proc complete[T](future: FutureVar[T], loc: ptr SrcLoc) =
   template fut: untyped = Future[T](future)
   checkFinished(fut, loc)
   doAssert(isNil(fut.error))
-  fut.finished = true
+  fut.state = FutureState.Finished
   fut.callbacks.call()
 
 template complete*[T](futvar: FutureVar[T]) =
@@ -220,7 +245,7 @@ proc complete[T](futvar: FutureVar[T], val: T, loc: ptr SrcLoc) =
   template fut: untyped = Future[T](futvar)
   checkFinished(fut, loc)
   doAssert(isNil(fut.error))
-  fut.finished = true
+  fut.state = FutureState.Finished
   fut.value = val
   fut.callbacks.call()
 
@@ -232,7 +257,7 @@ template complete*[T](futvar: FutureVar[T], val: T) =
 
 proc fail[T](future: Future[T], error: ref Exception, loc: ptr SrcLoc) =
   checkFinished(future, loc)
-  future.finished = true
+  future.state = FutureState.Failed
   future.error = error
   future.errorStackTrace =
     if getStackTrace(error) == "": getStackTrace() else: getStackTrace(error)
@@ -241,6 +266,26 @@ proc fail[T](future: Future[T], error: ref Exception, loc: ptr SrcLoc) =
 template fail*[T](future: Future[T], error: ref Exception) =
   ## Completes ``future`` with ``error``.
   fail(future, error, getSrcLocation())
+
+proc cancel[T](future: Future[T], loc: ptr SrcLoc) =
+  if future.finished():
+    checkFinished(future, loc)
+  else:
+    var first = FutureBase(future)
+    var last = first
+    while (not isNil(last.child)) and (not(last.child.finished())):
+      last = last.child
+    if last == first:
+      checkFinished(future, loc)
+    last.state = FutureState.Cancelled
+    last.error = newException(CancelledError, "")
+    if not(isNil(last.cancelcb)):
+      last.cancelcb(cast[pointer](last))
+    last.callbacks.call()
+
+template cancel*[T](future: Future[T]) =
+  ## Cancel ``future``.
+  cancel(future, getSrcLocation())
 
 proc clearCallbacks(future: FutureBase) =
   var count = len(future.callbacks)
@@ -253,8 +298,7 @@ proc addCallback*(future: FutureBase, cb: CallbackFunc, udata: pointer = nil) =
   ##
   ## If future has already completed then ``cb`` will be called immediately.
   doAssert(not isNil(cb))
-  if future.finished:
-    # ZAH: it seems that the Future needs to know its associated Dispatcher
+  if future.finished():
     callSoon(cb, udata)
   else:
     let acb = AsyncCallback(function: cb, udata: udata)
@@ -291,6 +335,12 @@ proc `callback=`*[T](future: Future[T], cb: CallbackFunc) =
   ##
   ## If future has already completed then ``cb`` will be called immediately.
   `callback=`(future, cb, cast[pointer](future))
+
+proc `cancelCallback=`*[T](future: Future[T], cb: CallbackFunc) =
+  ## Sets the callback procedure to be called when the future is cancelled.
+  ##
+  ## This callback will be called immediately as ``future.cancel()`` invoked.
+  future.cancelcb = cb
 
 proc getHint(entry: StackTraceEntry): string =
   ## We try to provide some hints about stack trace entries that the user
@@ -365,30 +415,31 @@ proc injectStacktrace[T](future: Future[T]) =
 
 proc read*[T](future: Future[T] | FutureVar[T]): T =
   ## Retrieves the value of ``future``. Future must be finished otherwise
-  ## this function will fail with a ``ValueError`` exception.
+  ## this function will fail with a ``FutureError`` exception.
   ##
   ## If the result of the future is an error then that error will be raised.
   {.push hint[ConvFromXtoItselfNotNeeded]: off.}
   let fut = Future[T](future)
   {.pop.}
-  if fut.finished:
-    if not isNil(fut.error):
+  if fut.finished():
+    if not(isNil(fut.error)):
       injectStacktrace(fut)
       raise fut.error
     when T isnot void:
       return fut.value
   else:
     # TODO: Make a custom exception type for this?
-    raise newException(ValueError, "Future still in progress.")
+    raise newException(FutureError, "Future still in progress.")
 
 proc readError*[T](future: Future[T]): ref Exception =
   ## Retrieves the exception stored in ``future``.
   ##
-  ## An ``ValueError`` exception will be thrown if no exception exists
+  ## An ``FutureError`` exception will be thrown if no exception exists
   ## in the specified Future.
-  if not isNil(future.error): return future.error
+  if not(isNil(future.error)):
+    return future.error
   else:
-    raise newException(ValueError, "No error in future.")
+    raise newException(FutureError, "No error in future.")
 
 proc mget*[T](future: FutureVar[T]): var T =
   ## Returns a mutable value stored in ``future``.
@@ -397,19 +448,6 @@ proc mget*[T](future: FutureVar[T]): var T =
   ## Future has not been finished.
   result = Future[T](future).value
 
-proc finished*(future: FutureBase | FutureVar): bool =
-  ## Determines whether ``future`` has completed.
-  ##
-  ## ``True`` may indicate an error or a value. Use ``failed`` to distinguish.
-  when future is FutureVar:
-    result = (FutureBase(future)).finished
-  else:
-    result = future.finished
-
-proc failed*(future: FutureBase): bool =
-  ## Determines whether ``future`` completed with an error.
-  return (not isNil(future.error))
-
 proc asyncCheck*[T](future: Future[T]) =
   ## Sets a callback on ``future`` which raises an exception if the future
   ## finished with an error.
@@ -417,7 +455,7 @@ proc asyncCheck*[T](future: Future[T]) =
   ## This should be used instead of ``discard`` to discard void futures.
   doAssert(not isNil(future), "Future is nil")
   proc cb(data: pointer) =
-    if future.failed:
+    if future.failed() or future.cancelled():
       injectStacktrace(future)
       raise future.error
   future.callback = cb
@@ -425,47 +463,67 @@ proc asyncCheck*[T](future: Future[T]) =
 proc asyncDiscard*[T](future: Future[T]) = discard
   ## This is async workaround for discard ``Future[T]``.
 
-# ZAH: The return type here could be a Future[(T, Y)]
 proc `and`*[T, Y](fut1: Future[T], fut2: Future[Y]): Future[void] =
   ## Returns a future which will complete once both ``fut1`` and ``fut2``
   ## complete.
-  # ZAH: The Rust implementation of futures is making the case that the
-  # `and` combinator can be implemented in a more efficient way without
-  # resorting to closures and callbacks. I haven't thought this through
-  # completely yet, but here is their write-up:
-  # http://aturon.github.io/2016/09/07/futures-design/
-  #
-  # We should investigate this further, before settling on the final design.
-  # The same reasoning applies to `or` and `all`.
+  ##
+  ## TODO: In case when `fut1` or `fut2` got cancelled, what result Future[void]
+  ## should return?
   var retFuture = newFuture[void]("chronos.`and`")
   proc cb(data: pointer) =
-    if not retFuture.finished:
-      if (fut1.failed or fut1.finished) and (fut2.failed or fut2.finished):
+    if not(retFuture.finished()):
+      if fut1.finished() and fut2.finished():
         if cast[pointer](fut1) == data:
-          if fut1.failed: retFuture.fail(fut1.error)
-          elif fut2.finished: retFuture.complete()
+          if fut1.failed():
+            retFuture.fail(fut1.error)
+          else:
+            retFuture.complete()
         else:
-          if fut2.failed: retFuture.fail(fut2.error)
-          elif fut1.finished: retFuture.complete()
+          if fut2.failed():
+            retFuture.fail(fut2.error)
+          else:
+            retFuture.complete()
   fut1.callback = cb
   fut2.callback = cb
+
+  proc cancel(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      fut1.removeCallback(cb)
+      fut2.removeCallback(cb)
+      if not(fut1.finished()):
+        fut1.cancel()
+      if not(fut2.finished()):
+        fut2.cancel()
+
+  retFuture.cancelCallback = cancel
   return retFuture
 
 proc `or`*[T, Y](fut1: Future[T], fut2: Future[Y]): Future[void] =
   ## Returns a future which will complete once either ``fut1`` or ``fut2``
   ## complete.
   var retFuture = newFuture[void]("chronos.`or`")
-  proc cb(data: pointer) {.gcsafe.} =
-    if not retFuture.finished:
-      var fut = cast[FutureBase](data)
-      if cast[pointer](fut1) == data:
+  proc cb(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      var fut = cast[FutureBase](udata)
+      if cast[pointer](fut1) == udata:
         fut2.removeCallback(cb)
       else:
         fut1.removeCallback(cb)
-      if fut.failed: retFuture.fail(fut.error)
+      if fut.failed(): retFuture.fail(fut.error)
       else: retFuture.complete()
   fut1.callback = cb
   fut2.callback = cb
+
+  proc cancel(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      fut1.removeCallback(cb)
+      fut2.removeCallback(cb)
+      if not(fut1.finished()):
+        fut1.cancel()
+      if not(fut2.finished()):
+        fut2.cancel()
+
+  retFuture.cancelCallback = cancel
   return retFuture
 
 proc all*[T](futs: varargs[Future[T]]): auto =
@@ -480,6 +538,11 @@ proc all*[T](futs: varargs[Future[T]]): auto =
   ##
   ## Note, that if one of the futures in ``futs`` will fail, result of ``all()``
   ## will also be failed with error from failed future.
+  ##
+  ## TODO: This procedure has bug on handling cancelled futures from ``futs``.
+  ## So if future from ``futs`` list become cancelled, what must be returned?
+  ## You can't cancel result ``retFuture`` because in such way infinite
+  ## recursion will happen.
   let totalFutures = len(futs)
   var completedFutures = 0
 
@@ -488,42 +551,63 @@ proc all*[T](futs: varargs[Future[T]]): auto =
 
   when T is void:
     var retFuture = newFuture[void]("chronos.all(void)")
-    for fut in nfuts:
-      fut.addCallback proc (data: pointer) =
+    proc cb(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
         inc(completedFutures)
-        if not retFuture.finished:
-          if completedFutures == totalFutures:
-            for nfut in nfuts:
-              if nfut.failed:
-                retFuture.fail(nfut.error)
-                break
-            if not retFuture.failed:
-              retFuture.complete()
+        if completedFutures == totalFutures:
+          for nfut in nfuts:
+            if nfut.failed():
+              retFuture.fail(nfut.error)
+              break
+          if not(retFuture.failed()):
+            retFuture.complete()
+
+    proc cancel(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        for i in 0..<len(nfuts):
+          if not(nfuts[i].finished()):
+            nfuts[i].removeCallback(cb)
+            nfuts[i].cancel()
+
+    for fut in nfuts:
+      fut.addCallback(cb)
 
     if len(nfuts) == 0:
       retFuture.complete()
 
+    retFuture.cancelCallback = cancel
     return retFuture
   else:
     var retFuture = newFuture[seq[T]]("chronos.all(T)")
     var retValues = newSeq[T](totalFutures)
-    for fut in nfuts:
-      fut.addCallback proc (data: pointer) =
+
+    proc cb(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
         inc(completedFutures)
-        if not retFuture.finished:
-          if completedFutures == totalFutures:
-            for k, nfut in nfuts:
-              if nfut.failed:
-                retFuture.fail(nfut.error)
-                break
-              else:
-                retValues[k] = nfut.read()
-            if not retFuture.failed:
-              retFuture.complete(retValues)
+        if completedFutures == totalFutures:
+          for k, nfut in nfuts:
+            if nfut.failed():
+              retFuture.fail(nfut.error)
+              break
+            else:
+              retValues[k] = nfut.read()
+          if not(retFuture.failed()):
+            retFuture.complete(retValues)
+
+    proc cancel(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        for i in 0..<len(nfuts):
+          if not(nfuts[i].finished()):
+            nfuts[i].removeCallback(cb)
+            nfuts[i].cancel()
+
+    for fut in nfuts:
+      fut.addCallback(cb)
 
     if len(nfuts) == 0:
       retFuture.complete(retValues)
 
+    retFuture.cancelCallback = cancel
     return retFuture
 
 proc oneIndex*[T](futs: varargs[Future[T]]): Future[int] =
@@ -537,10 +621,10 @@ proc oneIndex*[T](futs: varargs[Future[T]]): Future[int] =
   var nfuts = @futs
   var retFuture = newFuture[int]("chronos.oneIndex(T)")
 
-  proc cb(data: pointer) {.gcsafe.} =
+  proc cb(udata: pointer) {.gcsafe.} =
     var res = -1
-    if not retFuture.finished:
-      var rfut = cast[FutureBase](data)
+    if not(retFuture.finished()):
+      var rfut = cast[FutureBase](udata)
       for i in 0..<len(nfuts):
         if cast[FutureBase](nfuts[i]) != rfut:
           nfuts[i].removeCallback(cb)
@@ -548,12 +632,20 @@ proc oneIndex*[T](futs: varargs[Future[T]]): Future[int] =
           res = i
       retFuture.complete(res)
 
+  proc cancel(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      for i in 0..<len(nfuts):
+        if not(nfuts[i].finished()):
+          nfuts[i].removeCallback(cb)
+          nfuts[i].cancel()
+
   for fut in nfuts:
     fut.addCallback(cb)
 
   if len(nfuts) == 0:
-    retFuture.fail(newException(ValueError, "Empty Future[T] list"))
+    retFuture.fail(newException(FutureError, "Empty Future[T] list"))
 
+  retFuture.cancelCallback = cancel
   return retFuture
 
 proc oneValue*[T](futs: varargs[Future[T]]): Future[T] =
@@ -564,19 +656,24 @@ proc oneValue*[T](futs: varargs[Future[T]]): Future[T] =
   ##
   ## Returned future will hold value of completed ``futs`` future, or error
   ## if future was failed.
+  ##
+  ## TODO: This procedure has bug on handling cancelled futures from ``futs``.
+  ## So if future from ``futs`` list become cancelled, what must be returned?
+  ## You can't cancel result ``retFuture`` because in such way infinite
+  ## recursion will happen.
   var nfuts = @futs
   var retFuture = newFuture[T]("chronos.oneValue(T)")
 
-  proc cb(data: pointer) {.gcsafe.} =
+  proc cb(udata: pointer) {.gcsafe.} =
     var resFut: Future[T]
-    if not retFuture.finished:
-      var rfut = cast[FutureBase](data)
+    if not(retFuture.finished()):
+      var rfut = cast[FutureBase](udata)
       for i in 0..<len(nfuts):
         if cast[FutureBase](nfuts[i]) != rfut:
           nfuts[i].removeCallback(cb)
         else:
           resFut = nfuts[i]
-      if resFut.failed:
+      if resFut.failed():
         retFuture.fail(resFut.error)
       else:
         when T is void:
@@ -584,10 +681,30 @@ proc oneValue*[T](futs: varargs[Future[T]]): Future[T] =
         else:
           retFuture.complete(resFut.read())
 
+  proc cancel(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      for i in 0..<len(nfuts):
+        if not(nfuts[i].finished()):
+          nfuts[i].removeCallback(cb)
+          nfuts[i].cancel()
+
   for fut in nfuts:
     fut.addCallback(cb)
 
   if len(nfuts) == 0:
-    retFuture.fail(newException(ValueError, "Empty Future[T] list"))
+    retFuture.fail(newException(FutureError, "Empty Future[T] list"))
 
+  retFuture.cancelCallback = cancel
+  return retFuture
+
+proc cancelAndWait*[T](future: Future[T]): Future[void] =
+  ## Cancel future ``future`` and wait until it completes.
+  var retFuture = newFuture[void]("chronos.cancelAndWait(T)")
+
+  proc continuation(udata: pointer) {.gcsafe.} =
+    if not(retFuture.finished()):
+      retFuture.complete()
+
+  future.addCallback(continuation)
+  future.cancel()
   return retFuture

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -66,7 +66,7 @@ template createCb(retFutureSym, iteratorNameSym,
   #{.pop.}
 
 template useVar(result: var NimNode, futureVarNode: NimNode, valueReceiver,
-                rootReceiver: untyped, fromNode: NimNode) =
+                rootReceiver: untyped, fromNode: NimNode, isawait: bool) =
   ## Params:
   ##    futureVarNode: The NimNode which is a symbol identifying the Future[T]
   ##                   variable to yield.
@@ -75,16 +75,22 @@ template useVar(result: var NimNode, futureVarNode: NimNode, valueReceiver,
   ##                   future's value.
   ##
   ##    rootReceiver: ??? TODO
-  # -> yield future<x>
-  result.add newNimNode(nnkYieldStmt, fromNode).add(futureVarNode)
-  # -> future<x>.read
-  valueReceiver = newDotExpr(futureVarNode, newIdentNode("read"))
-  result.add rootReceiver
+  if isawait:
+    # -> yield future<x>
+    result.add newNimNode(nnkYieldStmt, fromNode).add(futureVarNode)
+    # -> future<x>.read
+    valueReceiver = newDotExpr(futureVarNode, newIdentNode("read"))
+    result.add rootReceiver
+  else:
+    # -> yield future<x>
+    result.add newNimNode(nnkYieldStmt, fromNode).add(futureVarNode)
+    valueReceiver = futureVarNode
+    result.add rootReceiver
 
 template createVar(result: var NimNode, futSymName: string,
                    asyncProc: NimNode,
                    valueReceiver, rootReceiver, retFutSym: untyped,
-                   fromNode: NimNode) =
+                   fromNode: NimNode, isawait: bool) =
   result = newNimNode(nnkStmtList, fromNode)
   var futSym = genSym(nskVar, "future")
   result.add newVarStmt(futSym, asyncProc) # -> var future<x> = y
@@ -96,7 +102,7 @@ template createVar(result: var NimNode, futSymName: string,
     ),
     newCall(newIdentNode("FutureBase"), copyNimNode(futSym))
   )
-  useVar(result, futSym, valueReceiver, rootReceiver, fromNode)
+  useVar(result, futSym, valueReceiver, rootReceiver, fromNode, isawait)
 
 proc createFutureVarCompletions(futureVarIdents: seq[NimNode],
     fromNode: NimNode): NimNode {.compileTime.} =
@@ -144,7 +150,8 @@ proc processBody(node, retFutureSym: NimNode,
     result.add newNimNode(nnkReturnStmt, node).add(newNilLit())
     return # Don't process the children of this return stmt
   of nnkCommand, nnkCall:
-    if node[0].kind == nnkIdent and node[0].eqIdent("await"):
+    if node[0].kind == nnkIdent and
+       (node[0].eqIdent("await") or node[0].eqIdent("awaitne")):
       case node[1].kind
       of nnkIdent, nnkInfix, nnkDotExpr, nnkCall, nnkCommand:
         # await x
@@ -153,41 +160,48 @@ proc processBody(node, retFutureSym: NimNode,
         # await foo p, x
         var futureValue: NimNode
         result.createVar("future" & $node[1][0].toStrLit, node[1], futureValue,
-                         futureValue, retFutureSym, node)
+                         futureValue, retFutureSym, node,
+                         node[0].eqIdent("await"))
       else:
         error("Invalid node kind in 'await', got: " & $node[1].kind)
     elif node.len > 1 and node[1].kind == nnkCommand and
-         node[1][0].kind == nnkIdent and node[1][0].eqIdent("await"):
+         node[1][0].kind == nnkIdent and
+         (node[1][0].eqIdent("await") or node[1][0].eqIdent("awaitne")):
       # foo await x
       var newCommand = node
       result.createVar("future" & $node[0].toStrLit, node[1][1], newCommand[1],
-                       newCommand, retFutureSym, node)
+                       newCommand, retFutureSym, node,
+                       node[1][0].eqIdent("await"))
 
   of nnkVarSection, nnkLetSection:
     case node[0][2].kind
     of nnkCommand:
-      if node[0][2][0].kind == nnkIdent and node[0][2][0].eqIdent("await"):
+      if node[0][2][0].kind == nnkIdent and
+         (node[0][2][0].eqIdent("await") or node[0][2][0].eqIdent("awaitne")):
         # var x = await y
         var newVarSection = node # TODO: Should this use copyNimNode?
         result.createVar("future" & node[0][0].strVal, node[0][2][1],
-                         newVarSection[0][2], newVarSection, retFutureSym, node)
+                         newVarSection[0][2], newVarSection, retFutureSym, node,
+                         node[0][2][0].eqIdent("await"))
     else: discard
   of nnkAsgn:
     case node[1].kind
     of nnkCommand:
-      if node[1][0].eqIdent("await"):
+      if node[1][0].eqIdent("await") or node[1][0].eqIdent("awaitne"):
         # x = await y
         var newAsgn = node
         result.createVar("future" & $node[0].toStrLit, node[1][1], newAsgn[1],
-                         newAsgn, retFutureSym, node)
+                         newAsgn, retFutureSym, node,
+                         node[1][0].eqIdent("await"))
     else: discard
   of nnkDiscardStmt:
     # discard await x
     if node[0].kind == nnkCommand and node[0][0].kind == nnkIdent and
-          node[0][0].eqIdent("await"):
+       (node[0][0].eqIdent("await") or node[0][0].eqIdent("awaitne")):
       var newDiscard = node
       result.createVar("futureDiscard_" & $toStrLit(node[0][1]), node[0][1],
-                       newDiscard[0], newDiscard, retFutureSym, node)
+                       newDiscard[0], newDiscard, retFutureSym, node,
+                       node[0][0].eqIdent("await"))
   else: discard
 
   for i in 0 ..< result.len:

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -567,11 +567,12 @@ proc write*(wstream: AsyncStreamWriter, pbytes: pointer,
     raise newAsyncStreamIncorrectError("Zero length message")
 
   if isNil(wstream.wsource):
-    var resFut = write(wstream.tsource, pbytes, nbytes)
-    yield resFut
-    if resFut.failed():
-      raise newAsyncStreamWriteError(resFut.error)
-    if resFut.read() != nbytes:
+    var res: int
+    try:
+      res = await write(wstream.tsource, pbytes, nbytes)
+    except:
+      raise newAsyncStreamWriteError(getCurrentException())
+    if res != nbytes:
       raise newAsyncStreamIncompleteError()
   else:
     if isNil(wstream.writerLoop):
@@ -582,8 +583,9 @@ proc write*(wstream: AsyncStreamWriter, pbytes: pointer,
       item.size = nbytes
       item.future = newFuture[void]("async.stream.write(pointer)")
       await wstream.queue.put(item)
-      yield item.future
-      if item.future.failed():
+      try:
+        await item.future
+      except:
         raise newAsyncStreamWriteError(item.future.error)
 
 proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
@@ -604,11 +606,12 @@ proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
     raise newAsyncStreamIncorrectError("Zero length message")
 
   if isNil(wstream.wsource):
-    var resFut = write(wstream.tsource, sbytes, msglen)
-    yield resFut
-    if resFut.failed():
-      raise newAsyncStreamWriteError(resFut.error)
-    if resFut.read() != length:
+    var res: int
+    try:
+      res = await write(wstream.tsource, sbytes, msglen)
+    except:
+      raise newAsyncStreamWriteError(getCurrentException())
+    if res != length:
       raise newAsyncStreamIncompleteError()
   else:
     if isNil(wstream.writerLoop):
@@ -622,8 +625,9 @@ proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
       item.size = length
       item.future = newFuture[void]("async.stream.write(seq)")
       await wstream.queue.put(item)
-      yield item.future
-      if item.future.failed():
+      try:
+        await item.future
+      except:
         raise newAsyncStreamWriteError(item.future.error)
 
 proc write*(wstream: AsyncStreamWriter, sbytes: string,
@@ -643,11 +647,12 @@ proc write*(wstream: AsyncStreamWriter, sbytes: string,
     raise newAsyncStreamIncorrectError("Zero length message")
 
   if isNil(wstream.wsource):
-    var resFut = write(wstream.tsource, sbytes, msglen)
-    yield resFut
-    if resFut.failed():
-      raise newAsyncStreamWriteError(resFut.error)
-    if resFut.read() != length:
+    var res: int
+    try:
+      res = await write(wstream.tsource, sbytes, msglen)
+    except:
+      raise newAsyncStreamWriteError(getCurrentException())
+    if res != length:
       raise newAsyncStreamIncompleteError()
   else:
     if isNil(wstream.writerLoop):
@@ -661,8 +666,9 @@ proc write*(wstream: AsyncStreamWriter, sbytes: string,
       item.size = length
       item.future = newFuture[void]("async.stream.write(string)")
       await wstream.queue.put(item)
-      yield item.future
-      if item.future.failed():
+      try:
+        await item.future
+      except:
         raise newAsyncStreamWriteError(item.future.error)
 
 proc finish*(wstream: AsyncStreamWriter) {.async.} =
@@ -678,8 +684,9 @@ proc finish*(wstream: AsyncStreamWriter) {.async.} =
       item.size = 0
       item.future = newFuture[void]("async.stream.finish")
       await wstream.queue.put(item)
-      yield item.future
-      if item.future.failed():
+      try:
+        await item.future
+      except:
         raise newAsyncStreamWriteError(item.future.error)
 
 proc join*(rw: AsyncStreamRW): Future[void] =

--- a/chronos/streams/chunkstream.nim
+++ b/chronos/streams/chunkstream.nim
@@ -128,7 +128,9 @@ proc chunkedReadLoop(stream: AsyncStreamReader) {.async.} =
           break
 
         rstream.buffer.update(toRead)
-        await rstream.buffer.transfer() or exitFut
+
+        await oneOf(rstream.buffer.transfer(), exitFut)
+
         if exitFut.finished():
           rstream.state = AsyncStreamState.Stopped
           break
@@ -169,7 +171,9 @@ proc chunkedReadLoop(stream: AsyncStreamReader) {.async.} =
         break
 
       rstream.state = AsyncStreamState.Finished
-      await rstream.buffer.transfer() or exitFut
+
+      await oneOf(rstream.buffer.transfer(), exitFut)
+
       if exitFut.finished():
         rstream.state = AsyncStreamState.Stopped
       break

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -5,6 +5,6 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import testsync, testsoon, testtime, testfut, testsignal, testaddress,
-       testdatagram, teststream, testserver, testbugs, testnet,
+import testmacro, testsync, testsoon, testtime, testfut, testsignal,
+       testaddress, testdatagram, teststream, testserver, testbugs, testnet,
        testasyncstream

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -830,7 +830,7 @@ suite "Future[T] behavior test suite":
 
     var fut = client1(100.milliseconds)
     fut.cancel()
-    waitFor(sleepAsync(500.seconds))
+    waitFor(sleepAsync(500.milliseconds))
 
     if not(fut.cancelled()):
       return false

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -1,0 +1,80 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import unittest
+import ../chronos
+
+proc asyncRetValue(n: int): Future[int] {.async.} =
+  await sleepAsync(n.milliseconds)
+  result = n * 10
+
+proc asyncRetVoid(n: int) {.async.} =
+  await sleepAsync(n.milliseconds)
+
+proc asyncRetExceptionValue(n: int): Future[int] {.async.} =
+  await sleepAsync(n.milliseconds)
+  result = n * 10
+  if true:
+    raise newException(ValueError, "Test exception")
+
+proc asyncRetExceptionVoid(n: int) {.async.} =
+  await sleepAsync(n.milliseconds)
+  if true:
+    raise newException(ValueError, "Test exception")
+
+proc testAwait(): Future[bool] {.async.} =
+  var res: int
+  await asyncRetVoid(100)
+  res = await asyncRetValue(100)
+  if res != 1000:
+    return false
+  if (await asyncRetValue(100)) != 1000:
+    return false
+  try:
+    await asyncRetExceptionVoid(100)
+    return false
+  except ValueError:
+    discard
+  res = 0
+  try:
+    var res = await asyncRetExceptionValue(100)
+    return false
+  except ValueError:
+    discard
+  if res != 0:
+    return false
+  return true
+
+proc testAwaitne(): Future[bool] {.async.} =
+  var res1: Future[void]
+  var res2: Future[int]
+
+  res1 = awaitne asyncRetVoid(100)
+  res2 = awaitne asyncRetValue(100)
+  if res1.failed():
+    return false
+  if res2.read() != 1000:
+    return false
+
+  res1 = awaitne asyncRetExceptionVoid(100)
+  if not(res1.failed()):
+    return false
+
+  res2 = awaitne asyncRetExceptionValue(100)
+  try:
+    var res = res2.read()
+    return false
+  except ValueError:
+    discard
+
+  return true
+
+suite "Macro transformations test suite":
+  test "`await` command test":
+    check waitFor(testAwait()) == true
+  test "`awaitne` command test":
+    check waitFor(testAwaitne()) == true

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -687,7 +687,7 @@ suite "Stream Transport test suite":
     server.stop
     server.close()
     try:
-      await wait(server.join(), 1.seconds)
+      await wait(server.join(), 10.seconds)
       result = 1
     except:
       discard

--- a/tests/testsync.nim
+++ b/tests/testsync.nim
@@ -95,7 +95,7 @@ suite "Asynchronous sync primitives test suite":
 
   proc test4(): int =
     var queue = newAsyncQueue[int](queueSize)
-    waitFor(task3(queue) and task4(queue))
+    waitFor(allFutures(task3(queue), task4(queue)))
     result = testQueue2Result
 
   proc task51(aq: AsyncQueue[int]) {.async.} =


### PR DESCRIPTION
This is initial Future[T] cancellation proposal and implementation.

* The most significant changes were made in `asyncfutures2.nim` and `asyncmacro2.nim`.

* `asyncloop.nim` has 2 examples on how cancellation can be handled for simple procedures (which are not transformed with `async` macro).

* `asyncfutures2.nim` also has most problematic places such as `all()` and `and()` which is marked with `# TODO` comments. I really think that this procedures needs some care or deprecation.

* Most of other places are just `if not future.finished(): future.finish/fail()` because when cancellation happens, you must not `complete()` or `fail()` Future[T].

* Also there present fix for recently discovered `EINTR + connect` problem.
