### PR TITLE
[WIP]: AsyncChannels[T].

### DIFF
--- a/chronos.nim
+++ b/chronos.nim
@@ -6,5 +6,6 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import chronos/[asyncloop, asyncfutures2, asyncsync, handles, transport,
-                timer]
-export asyncloop, asyncfutures2, asyncsync, handles, transport, timer
+                timer, achannels]
+export asyncloop, asyncfutures2, asyncsync, handles, transport, timer,
+       achannels

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -21,3 +21,13 @@ task test, "Run all tests":
   exec commands[1]
   echo "\n" & commands[2]
   exec commands[2]
+
+task channel_helgrind, "Run the channel implementation through helgrind to detect threading or lock errors":
+  var commands = [
+    "nim c -d:useMalloc --threads:on tests/testchannels.nim",
+    "valgrind --tool=helgrind build/achannel"
+  ]
+  echo "\n" & commands[0]
+  exec commands[0]
+  echo "\n" & commands[1]
+  exec commands[1]

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "2.2.8"
+version       = "2.2.9"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"

--- a/chronos/achannels.nim
+++ b/chronos/achannels.nim
@@ -1,0 +1,254 @@
+#
+#    Chronos multi-threading asynchronous channels
+#             (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import strutils
+import asyncloop, handles, transport, asyncsync
+
+const hasThreadSupport* = compileOption("threads")
+
+when hasThreadSupport:
+  import locks
+
+type
+  RawAsyncChannelImpl {.pure, final.} = object
+    rd, wr, count, mask: int
+    maxItems: int
+    refCount: int
+    data: ptr UncheckedArray[byte]
+    when hasThreadSupport:
+      lock: Lock
+    eventNotEmpty: AsyncThreadEvent
+    eventNotFull: AsyncThreadEvent
+
+  RawAsyncChannel = ptr RawAsyncChannelImpl
+  AsyncChannel*[Msg] = RawAsyncChannel
+  AsyncChannelError* = object of CatchableError
+
+proc initLocks(rchan: RawAsyncChannel) {.inline.} =
+  ## Initialize and create OS locks.
+  when hasThreadSupport:
+    initLock(rchan.lock)
+  else:
+    discard
+  rchan.eventNotEmpty = newAsyncThreadEvent()
+  if rchan.maxItems > 0:
+    rchan.eventNotFull = newAsyncThreadEvent()
+
+proc deinitLocks(rchan: RawAsyncChannel) {.inline.} =
+  ## Deinitialize and close OS locks.
+  when hasThreadSupport:
+    deinitLock(rchan.lock)
+  else:
+    discard
+
+  close(rchan.eventNotEmpty)
+  if rchan.maxItems > 0:
+    close(rchan.eventNotFull)
+
+proc acquireLock(rchan: RawAsyncChannel) {.inline.} =
+  ## Acquire lock in multi-threaded mode and do nothing in
+  ## single-threaded mode.
+  when hasThreadSupport:
+    acquire(rchan.lock)
+  else:
+    discard
+
+proc releaseLock(rchan: RawAsyncChannel) {.inline.} =
+  ## Release lock in multi-threaded mode and do nothing in
+  ## single-threaded mode.
+  when hasThreadSupport:
+    release(rchan.lock)
+  else:
+    discard
+
+proc newAsyncChannel*[Msg](maxItems: int = -1): AsyncChannel[Msg] =
+  ## Create new AsyncChannel[Msg] with internal queue size ``maxItems``.
+  ##
+  ## If ``maxItems <= 0`` (default value), then queue size is unlimited.
+  let loop = getGlobalDispatcher()
+  result = cast[AsyncChannel[Msg]](allocShared(sizeof(RawAsyncChannelImpl)))
+  result.mask = -1
+  if maxItems <= 0:
+    result.maxItems = -1
+  else:
+    result.maxItems = maxItems
+  result.count = 0
+  result.wr = 0
+  result.rd = 0
+  result.refCount = 0
+  result.data = cast[ptr UncheckedArray[byte]](0)
+  result.initLocks()
+
+proc raiseChannelClosed() {.inline.} =
+  var err = newException(AsyncChannelError, "Channel closed or not opened")
+  raise err
+
+proc raiseChannelFailed() {.inline.} =
+  var err = newException(AsyncChannelError, "Channel synchronization failed")
+  raise err
+
+proc open*[Msg](chan: AsyncChannel[Msg]) =
+  ## Open channel ``chan``.
+  let loop = getGlobalDispatcher()
+  chan.acquireLock()
+  inc(chan.refCount)
+  chan.releaseLock()
+
+proc close*[Msg](chan: AsyncChannel[Msg]) =
+  ## Close channel ``chan``.
+  chan.acquireLock()
+  if chan.refCount == 0:
+    if not(isNil(chan.data)):
+      deallocShared(cast[pointer](chan.data))
+    chan.deinitLocks()
+    deallocShared(cast[pointer](chan))
+  else:
+    dec(chan.refCount)
+  chan.releaseLock()
+
+proc `$`*[Msg](chan: AsyncChannel[Msg]): string =
+  ## Dump channel ``chan`` debugging information as string.
+  chan.acquireLock()
+  result = "channel 0x" & toHex(cast[uint](chan)) & " ("
+  result.add("eventNotEmpty = 0x" & toHex(cast[uint](chan.eventNotEmpty)))
+  result.add(", eventNotFull = 0x" & toHex(cast[uint](chan.eventNotFull)))
+  result.add(", rd = " & $chan.rd)
+  result.add(", wr = " & $chan.wr)
+  result.add(", count = " & $chan.count)
+  result.add(", mask = 0x" & toHex(chan.mask))
+  result.add(", data = 0x" & toHex(cast[uint](chan.data)))
+  result.add(", maxItems = " & $chan.maxItems)
+  result.add(", refCount = " & $chan.refCount)
+  result.add(")")
+  chan.releaseLock()
+
+proc rawSend(rchan: RawAsyncChannel, pbytes: pointer, nbytes: int) =
+  var cap = rchan.mask + 1
+  if rchan.count >= cap:
+    if cap == 0: cap = 1
+    var n = cast[ptr UncheckedArray[byte]](allocShared0(cap * 2 * nbytes))
+    var z = 0
+    var i = rchan.rd
+    var c = rchan.count
+
+    while c > 0:
+      dec(c)
+      copyMem(addr(n[z * nbytes]), addr(rchan.data[i * nbytes]), nbytes)
+      i = (i + 1) and rchan.mask
+      inc(z)
+
+    if not isNil(rchan.data):
+      deallocShared(rchan.data)
+
+    rchan.data = n
+    rchan.mask = (cap * 2) - 1
+    rchan.wr = rchan.count
+    rchan.rd = 0
+
+  copyMem(addr(rchan.data[rchan.wr * nbytes]), pbytes, nbytes)
+  inc(rchan.count)
+  rchan.wr = (rchan.wr + 1) and rchan.mask
+
+proc send*[Msg](chan: AsyncChannel[Msg], msg: Msg) {.async.} =
+  ## Send message ``msg`` over channel ``chan``. This procedure will wait if
+  ## internal channel queue is full.
+  chan.acquireLock()
+  try:
+    if chan.refCount == 0:
+      raiseChannelClosed()
+
+    if chan.maxItems > 0:
+      # Wait until count is less then `maxItems`.
+      while chan.count >= chan.maxItems:
+        chan.releaseLock()
+        let res = await chan.eventNotFull.wait(InfiniteDuration)
+        chan.acquireLock()
+        if res == WaitFailed:
+          raiseChannelFailed()
+
+    rawSend(chan, unsafeAddr msg, sizeof(Msg))
+    chan.eventNotEmpty.fire()
+
+  finally:
+    chan.releaseLock()
+
+proc sendSync*[Msg](chan: AsyncChannel[Msg], msg: Msg) =
+  ## Immediately send message ``msg`` over channel ``chan``. This procedure will
+  ## block until internal channel's queue is full.
+  chan.acquireLock()
+  try:
+    if chan.refCount == 0:
+      raiseChannelClosed()
+
+    if chan.maxItems > 0:
+      # Wait until count is less then `maxItems`.
+      while chan.count >= chan.maxItems:
+        chan.releaseLock()
+        let res = chan.eventNotFull.waitSync(InfiniteDuration)
+        chan.acquireLock()
+        if res == WaitFailed:
+          raiseChannelFailed()
+
+    rawSend(chan, unsafeAddr msg, sizeof(Msg))
+    chan.eventNotEmpty.fire()
+
+  finally:
+    chan.releaseLock()
+
+proc rawRecv(rchan: RawAsyncChannel, pbytes: pointer, nbytes: int) {.inline.} =
+  doAssert(rchan.count > 0)
+  dec(rchan.count)
+  copyMem(pbytes, addr rchan.data[rchan.rd * nbytes], nbytes)
+  rchan.rd = (rchan.rd + 1) and rchan.mask
+
+proc recv*[Msg](chan: AsyncChannel[Msg]): Future[Msg] {.async.} =
+  ## Wait for message ``Msg`` in channel ``chan`` asynchronously and receive
+  ## it when it become available.
+  var rmsg: Msg
+  chan.acquireLock()
+  try:
+    if chan.refCount == 0:
+      raiseChannelClosed()
+
+    while chan.count <= 0:
+      chan.releaseLock()
+      let res = await chan.eventNotEmpty.wait(InfiniteDuration)
+      chan.acquireLock()
+      if res == WaitFailed:
+        raiseChannelFailed()
+
+    rawRecv(chan, addr rmsg, sizeof(Msg))
+    result = rmsg
+
+    if chan.maxItems > 0:
+      chan.eventNotFull.fire()
+
+  finally:
+    chan.releaseLock()
+
+proc recvSync*[Msg](chan: AsyncChannel[Msg]): Msg =
+  ## Blocking receive message ``Msg`` from channel ``chan``.
+  chan.acquireLock()
+  try:
+    if chan.refCount == 0:
+      raiseChannelClosed()
+
+    while chan.count <= 0:
+      chan.releaseLock()
+      let res = chan.eventNotEmpty.waitSync(InfiniteDuration)
+      chan.acquireLock()
+      if res == WaitFailed:
+        raiseChannelFailed()
+
+    rawRecv(chan, addr result, sizeof(Msg))
+
+    if chan.maxItems > 0:
+      chan.eventNotFull.fire()
+
+  finally:
+    chan.releaseLock()

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -301,6 +301,14 @@ when defined(windows) or defined(nimdoc):
 
     AsyncFD* = distinct int
 
+    RwfsoOverlapped* = object of CustomOverlapped
+      ioPort*: Handle
+      handle*: Handle
+      waitFd*: Handle
+      timerOrWait*: WINBOOL
+
+    RefRwfsoOverlapped* = ref RwfsoOverlapped
+
   proc hash(x: AsyncFD): Hash {.borrow.}
   proc `==`*(x: AsyncFD, y: AsyncFD): bool {.borrow.}
 
@@ -892,6 +900,152 @@ proc wait*[T](fut: Future[T], timeout = -1): Future[T] {.
     wait(fut, ZeroDuration)
   else:
     wait(fut, timeout.milliseconds())
+
+when defined(windows):
+
+  {.push stackTrace:off.}
+  proc waitCallback(param: pointer,
+                    timerOrWaitFired: WINBOOL): void {.stdcall.} =
+    var p = cast[RefRwfsoOverlapped](param)
+    p.timerOrWait = timerOrWaitFired
+    discard postQueuedCompletionStatus(p.ioPort, DWORD(timerOrWaitFired),
+                                       ULONG_PTR(p.handle),
+                                       cast[pointer](p))
+  {.pop.}
+
+  proc awaitForSingleObject*(handle: Handle, timeout: Duration): Future[bool] =
+    ## Wait for Windows' waitable handle (handle which can be waited via
+    ## WaitForSingleObject API call) in asynchronous way.
+    ## Procedure returns ``true`` if state of handle ``handle`` become
+    ## signalled, and ``false`` if timeout ``timeout`` was expired before
+    ## handle ``handle`` become signaled.
+    ##
+    ## ``handle`` can be one of the listed types: Change notification,
+    ## Console input, Event, Memory resource notification, Mutex, Process,
+    ## Semaphore, Thread, Waitable timer.
+    ##
+    ## If timeout ``timeout`` is ``ZeroDuration`` procedure will check if
+    ## handle is signalled and return immediately.
+    var retFuture = newFuture[bool]("chronos.awaitForSingleObject")
+    var loop = getGlobalDispatcher()
+
+    var povl: RefRwfsoOverlapped
+    var flags = DWORD(WT_EXECUTEONLYONCE)
+    var timems: ULONG
+
+    if timeout == ZeroDuration:
+      let res = waitForSingleObject(handle, 0)
+      if res == WAIT_TIMEOUT:
+        retFuture.complete(false)
+        return retFuture
+      elif res == WAIT_OBJECT_0:
+        retFuture.complete(true)
+        return retFuture
+      else:
+        retFuture.fail(newException(AsyncError,
+                       "Mutex object was not released"))
+        return retFuture
+    else:
+      if timeout == InfiniteDuration:
+        timems = INFINITE
+      else:
+        timems = ULONG(timeout.milliseconds)
+
+    povl = RefRwfsoOverlapped()
+    GC_ref(povl)
+
+    proc handleContinuation(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        loop.handles.excl(AsyncFD(handle))
+        if unregisterWait(povl.waitFd) == 0:
+          let err = osLastError()
+          if int(err) != ERROR_IO_PENDING:
+            GC_unref(povl)
+            retFuture.fail(newException(OSError, osErrorMsg(err)))
+            return
+
+        if povl.timerOrWait != 0:
+          GC_unref(povl)
+          retFuture.complete(false)
+        else:
+          GC_unref(povl)
+          retFuture.complete(true)
+
+    proc cancel(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        loop.handles.excl(AsyncFD(handle))
+        discard unregisterWait(povl.waitFd)
+        GC_unref(povl)
+
+    povl.data = CompletionData(fd: AsyncFD(handle), cb: handleContinuation)
+    povl.ioPort = loop.getIoHandler()
+    povl.handle = handle
+    loop.handles.incl(AsyncFD(handle))
+    if not registerWaitForSingleObject(addr povl.waitFd, povl.handle,
+                                       cast[WAITORTIMERCALLBACK](waitCallback),
+                                       cast[pointer](povl), timems, flags):
+      let err = osLastError()
+      GC_unref(povl)
+      loop.handles.excl(AsyncFD(handle))
+      retFuture.fail(newException(OSError, osErrorMsg(err)))
+
+    retFuture.cancelCallback = cancel
+    return retFuture
+
+else:
+
+  proc getFd*(event: SelectEvent): cint =
+    type
+      EventType = object
+        fd: cint
+      PEventType = ptr EventType
+    var e = cast[PEventType](event)
+    result = e.fd
+
+  proc awaitForSelectEvent*(event: SelectEvent,
+                            timeout: Duration): Future[bool] =
+    ## Wait for Selectors' event SelectEvent in asynchronous way.
+    ##
+    ## Procedure returns ``true`` if state of event ``event`` become
+    ## signalled, and ``false`` if timeout ``timeout`` occurs before
+    ## event ``event`` become signaled.
+    var retFuture = newFuture[bool]("chronos.awaitForSelectEvent")
+    let loop = getGlobalDispatcher()
+    var data: SelectorData
+    var moment: Moment
+
+    proc handleContinuation(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        loop.selector.unregister(event)
+        if isNil(udata):
+          retFuture.complete(false)
+        else:
+          retFuture.complete(true)
+
+    proc cancel(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        loop.selector.unregister(event)
+        if timeout != InfiniteDuration:
+          removeTimer(moment, handleContinuation, nil)
+
+    if timeout != InfiniteDuration:
+      moment = Moment.fromNow(timeout)
+      addTimer(moment, handleContinuation, nil)
+
+    let fd = event.getFd()
+    loop.selector.registerEvent(event, data)
+
+    withData(loop.selector, int(fd), adata) do:
+      adata.reader = AsyncCallback(function: handleContinuation,
+                                   udata: addr adata.rdata)
+      adata.rdata.fd = AsyncFD(fd)
+      adata.rdata.udata = nil
+    do:
+      retFuture.fail(newException(ValueError,
+                     "Event descriptor not registered."))
+
+    retFuture.cancelCallback = cancel
+    return retFuture
 
 include asyncmacro2
 

--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -9,7 +9,18 @@
 #                MIT license (LICENSE-MIT)
 
 ## This module implements some core synchronization primitives
-import asyncloop, deques
+import os, deques
+import asyncloop, osapi, handles, timer
+
+const hasThreadSupport* = compileOption("threads")
+
+when hasThreadSupport:
+  import locks
+
+when defined(windows):
+  import winlean
+else:
+  import posix
 
 type
   AsyncLock* = ref object of RootRef
@@ -18,7 +29,7 @@ type
     ## states, ``locked`` or ``unlocked``.
     ##
     ## When more than one coroutine is blocked in ``acquire()`` waiting for
-    ## the state to turn to unlocked, only one coroutine proceeds when a
+    ## the state to turn to unlocked, only ``ONE`` coroutine proceeds when a
     ## ``release()`` call resets the state to unlocked; first coroutine which
     ## is blocked in ``acquire()`` is being processed.
     locked: bool
@@ -32,7 +43,7 @@ type
     ## The ``wait()`` coroutine blocks until the flag is `false`.
     ##
     ## If more than one coroutine blocked in ``wait()`` waiting for event
-    ## state to be signaled, when event get fired, then all coroutines
+    ## state to be signaled, when event get fired, then ``ALL`` coroutines
     ## continue proceeds in order, they have entered waiting state.
     flag: bool
     waiters: seq[Future[void]]
@@ -48,6 +59,35 @@ type
     putters: seq[Future[void]]
     queue: Deque[T]
     maxsize: int
+
+  AsyncThreadEventImpl = object
+    when defined(linux):
+      efd: AsyncFD
+    elif defined(windows):
+      event: Handle
+    else:
+      when hasThreadSupport:
+        # We need this lock to have behavior equal to Windows' event object and
+        # Linux' eventfd descriptor. Otherwise our Event becomes Semaphore on
+        # BSD/MacOS/Solaris.
+        lock: Lock
+      flag: bool
+      rfd: AsyncFD
+      wfd: AsyncFD
+
+  AsyncThreadEvent* = ptr AsyncThreadEventImpl
+    ## A primitive event object which can be shared between threads.
+    ##
+    ## An event manages a flag that can be set to `true` with the ``fire()``
+    ## procedure.
+    ## The ``wait()`` coroutine blocks until the flag is `false`.
+    ## The ``waitSync()`` procedure blocks until the flag is `false`.
+    ##
+    ## If more than one coroutine blocked in ``wait()`` waiting for event state
+    ## to be signalled, when event get fired, only ``ONE`` coroutine proceeds.
+
+  WaitResult* = enum
+    WaitSuccess, WaitTimeout, WaitFailed
 
   AsyncQueueEmptyError* = object of Exception
     ## ``AsyncQueue`` is empty.
@@ -253,7 +293,6 @@ proc addLastNoWait*[T](aq: AsyncQueue[T], item: T) =
   ## Put an item ``item`` at the end of the queue ``aq`` immediately.
   ##
   ## If queue ``aq`` is full, then ``AsyncQueueFullError`` exception raised.
-  var w: Future[void]
   if aq.full():
     raise newException(AsyncQueueFullError, "AsyncQueue is full!")
   aq.queue.addLast(item)
@@ -263,7 +302,6 @@ proc popFirstNoWait*[T](aq: AsyncQueue[T]): T =
   ## Get an item from the beginning of the queue ``aq`` immediately.
   ##
   ## If queue ``aq`` is empty, then ``AsyncQueueEmptyError`` exception raised.
-  var w: Future[void]
   if aq.empty():
     raise newException(AsyncQueueEmptyError, "AsyncQueue is empty!")
   result = aq.queue.popFirst()
@@ -414,3 +452,319 @@ proc `$`*[T](aq: AsyncQueue[T]): string =
     if result.len > 1: result.add(", ")
     result.addQuoted(item)
   result.add("]")
+
+proc newAsyncThreadEvent*(): AsyncThreadEvent =
+  ## Create new AsyncThreadEvent event.
+  when defined(linux):
+    # On Linux we are using `eventfd`.
+    let fd = eventfd(0, 0)
+    if fd == -1:
+      raiseOSError(osLastError())
+    if not(setSocketBlocking(SocketHandle(fd), false)):
+      raiseOSError(osLastError())
+    result = cast[AsyncThreadEvent](allocShared0(sizeof(AsyncThreadEventImpl)))
+    result.efd = AsyncFD(fd)
+  elif defined(windows):
+    # On Windows we are using kernel Event object.
+    let event = osapi.createEvent(nil, DWORD(0), DWORD(0), nil)
+    if event == Handle(0):
+      raiseOSError(osLastError())
+    result = cast[AsyncThreadEvent](allocShared0(sizeof(AsyncThreadEventImpl)))
+    result.event = event
+  else:
+    # On all other posix systems we are using anonymous pipe.
+    var (rfd, wfd) = createAsyncPipe()
+    if rfd == asyncInvalidPipe or wfd == asyncInvalidPipe:
+      raiseOSError(osLastError())
+    if not(setSocketBlocking(SocketHandle(wfd), true)):
+      raiseOSError(osLastError())
+    result = cast[AsyncThreadEvent](allocShared0(sizeof(AsyncThreadEventImpl)))
+    result.rfd = rfd
+    result.wfd = wfd
+    result.flag = false
+    when hasThreadSupport:
+      initLock(result.lock)
+
+proc close*(event: AsyncThreadEvent) =
+  ## Close AsyncThreadEvent ``event`` and free all the resources.
+  when defined(linux):
+    let loop = getGlobalDispatcher()
+    if event.efd in loop:
+      unregister(event.efd)
+    discard posix.close(cint(event.efd))
+  elif defined(windows):
+    discard winlean.closeHandle(event.event)
+  else:
+    let loop = getGlobalDispatcher()
+    when hasThreadSupport:
+      acquire(event.lock)
+    if event.rfd in loop:
+      unregister(event.rfd)
+    discard posix.close(cint(event.rfd))
+    discard posix.close(cint(event.wfd))
+    when hasThreadSupport:
+      deinitLock(event.lock)
+  deallocShared(event)
+
+proc fire*(event: AsyncThreadEvent) =
+  ## Set state of AsyncThreadEvent ``event`` to signalled.
+  when defined(linux):
+    var data = 1'u64
+    while true:
+      if posix.write(cint(event.efd), addr data, sizeof(uint64)) == -1:
+        let err = osLastError()
+        if cint(err) == posix.EINTR:
+          continue
+        raiseOSError(osLastError())
+      break
+  elif defined(windows):
+    if setEvent(event.event) == 0:
+      raiseOSError(osLastError())
+  else:
+    var data = 1'u64
+    when hasThreadSupport:
+      acquire(event.lock)
+      try:
+        if not(event.flag):
+          while true:
+            if posix.write(cint(event.wfd), addr data, sizeof(uint64)) == -1:
+              let err = osLastError()
+              if cint(err) == posix.EINTR:
+                continue
+              raiseOSError(osLastError())
+            break
+          event.flag = true
+      finally:
+        release(event.lock)
+    else:
+      if not(event.flag):
+        while true:
+          if posix.write(cint(event.wfd), addr data, sizeof(uint64)) == -1:
+            let err = osLastError()
+            if cint(err) == posix.EINTR:
+              continue
+            raiseOSError(osLastError())
+          break
+        event.flag = true
+
+when defined(windows):
+  proc wait*(event: AsyncThreadEvent,
+           timeout: Duration = InfiniteDuration): Future[WaitResult] {.async.} =
+    ## Block until the internal flag of ``event`` is `true`. This procedure is
+    ## coroutine.
+    ##
+    ## Procedure returns ``WaitSuccess`` when internal event's state is
+    ## signaled. Returns ``WaitTimeout`` when timeout interval elapsed, and the
+    ## event's state is nonsignaled. Returns ``WaitFailed`` if error happens
+    ## while waiting.
+    try:
+      let res = await awaitForSingleObject(event.event, timeout)
+      if res:
+        result = WaitSuccess
+      else:
+        result = WaitTimeout
+    except OSError:
+      result = WaitFailed
+    except AsyncError:
+      result = WaitFailed
+
+  proc waitSync*(event: AsyncThreadEvent,
+                 timeout: Duration = InfiniteDuration): WaitResult =
+    ## Block until the internal flag of ``event`` is `true`. This procedure is
+    ## ``NOT`` coroutine, so it is actually blocks, but this procedure do not
+    ## need asynchronous event loop to be present.
+    ##
+    ## Procedure returns ``WaitSuccess`` when internal event's state is
+    ## signaled. Returns ``WaitTimeout`` when timeout interval elapsed, and the
+    ## event's state is nonsignaled. Returns ``WaitFailed`` if error happens
+    ## while waiting.
+    var timeoutWin: DWORD
+    if timeout.isInfinite():
+      timeoutWin = INFINITE
+    else:
+      timeoutWin = DWORD(timeout.milliseconds)
+    let res = waitForSingleObject(event.event, timeoutWin)
+    if res == WAIT_OBJECT_0:
+      result = WaitSuccess
+    elif res == winlean.WAIT_TIMEOUT:
+      result = WaitTimeout
+    else:
+      result = WaitFailed
+else:
+  proc wait*(event: AsyncThreadEvent,
+             timeout: Duration = InfiniteDuration): Future[WaitResult] =
+    ## Block until the internal flag of ``event`` is `true`.
+    ##
+    ## Procedure returns ``WaitSuccess`` when internal event's state is
+    ## signaled. Returns ``WaitTimeout`` when timeout interval elapsed, and the
+    ## event's state is nonsignaled. Returns ``WaitFailed`` if error happens
+    ## while waiting.
+    var moment: Moment
+    var retFuture = newFuture[WaitResult]("mtevent.wait")
+    let loop = getGlobalDispatcher()
+
+    when defined(linux):
+      let fd = AsyncFD(event.efd)
+    else:
+      let fd = AsyncFD(event.rfd)
+
+    proc contiunuation(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        var data: uint64 = 0
+        if isNil(udata):
+          removeReader(fd)
+          retFuture.complete(WaitTimeout)
+        else:
+          while true:
+            if posix.read(cint(fd), addr data,
+                          sizeof(uint64)) != sizeof(uint64):
+              let err = osLastError()
+              if cint(err) == posix.EINTR:
+                # This error happens when interrupt signal was received by
+                # process so we need to repeat `read` syscall.
+                continue
+              elif cint(err) == posix.EAGAIN or
+                   cint(err) == posix.EWOULDBLOCK:
+                # This error happens when there already pending `read` syscall
+                # in different thread for this descriptor. This is race
+                # condition, so to avoid it we will wait for another `read`
+                # event from system queue.
+                break
+              else:
+                # All other errors
+                removeReader(fd)
+              retFuture.complete(WaitFailed)
+            else:
+              removeReader(fd)
+              when not(defined(linux)):
+                when hasThreadSupport:
+                  acquire(event.lock)
+                event.flag = false
+                when hasThreadSupport:
+                  release(event.lock)
+              retFuture.complete(WaitSuccess)
+            break
+
+    proc cancel(udata: pointer) {.gcsafe.} =
+      if not(retFuture.finished()):
+        removeTimer(moment, contiunuation, nil)
+        removeReader(fd)
+
+    if fd notin loop:
+      register(fd)
+    addReader(fd, contiunuation, cast[pointer](retFuture))
+    if not(timeout.isInfinite()):
+      moment = Moment.fromNow(timeout)
+      addTimer(moment, contiunuation, nil)
+
+    retFuture.cancelCallback = cancel
+    return retFuture
+
+  proc waitReady(fd: int, timeout: var Duration): WaitResult {.inline.} =
+    var tv: Timeval
+    var ptv: ptr Timeval = addr tv
+    var rset: TFdSet
+    posix.FD_ZERO(rset)
+    posix.FD_SET(SocketHandle(fd), rset)
+    if timeout.isInfinite():
+      ptv = nil
+    else:
+      tv = timeout.toTimeval()
+    while true:
+      let nfd = fd + 1
+      var smoment = Moment.now()
+      let res = posix.select(cint(nfd), addr rset, nil, nil, ptv)
+      var emoment = Moment.now()
+      if res == 1:
+        result = WaitSuccess
+        if not(timeout.isInfinite()):
+          timeout = timeout - (emoment - smoment)
+        break
+      elif res == 0:
+        result = WaitTimeout
+        if not(timeout.isInfinite()):
+          timeout = ZeroDuration
+        break
+      elif res == -1:
+        let err = osLastError()
+        if int(err) == EINTR:
+          if not(timeout.isInfinite()):
+            tv = (emoment - smoment).toTimeval()
+          continue
+
+  proc waitSync*(event: AsyncThreadEvent,
+                 timeout: Duration = InfiniteDuration): WaitResult =
+    ## Block until the internal flag of ``event`` is `true`. This procedure is
+    ## ``NOT`` coroutine, so it is actually blocks, but this procedure do not
+    ## need asynchronous event loop to be present.
+    ##
+    ## Procedure returns ``WaitSuccess`` when internal event's state is
+    ## signaled. Returns ``WaitTimeout`` when timeout interval elapsed, and the
+    ## event's state is nonsignaled. Returns ``WaitFailed`` if error happens
+    ## while waiting.
+    var data = 0'u64
+
+    when defined(linux):
+      var fd = int(event.efd)
+    else:
+      var fd = int(event.rfd)
+
+    var curtimeout = timeout
+
+    while true:
+      var repeat = false
+      let res = waitReady(fd, curtimeout)
+      if res == WaitSuccess:
+        # Updating timeout value for next iteration.
+        when defined(linux):
+          while true:
+            if posix.read(cint(fd), addr data,
+                          sizeof(uint64)) != sizeof(uint64):
+              let err = osLastError()
+              if cint(err) == posix.EINTR:
+                continue
+              elif cint(err) == posix.EAGAIN or
+                   cint(err) == posix.EWOULDBLOCK:
+                # This error happens when there already pending `read` syscall
+                # in different thread for this descriptor.
+                repeat = true
+                break
+              result = WaitFailed
+            else:
+              result = WaitSuccess
+            break
+        else:
+          when hasThreadSupport:
+            acquire(event.lock)
+
+          while true:
+            if posix.read(cint(fd), addr data,
+                          sizeof(uint64)) != sizeof(uint64):
+              let err = osLastError()
+              if cint(err) == posix.EINTR:
+                continue
+              elif cint(err) == posix.EAGAIN or
+                   cint(err) == posix.EWOULDBLOCK:
+                # This error happens when there already pending `read` syscall
+                # in different thread for this descriptor.
+                repeat = true
+                break
+              else:
+                result = WaitFailed
+            else:
+              result = WaitSuccess
+            break
+
+          if repeat:
+            when hasThreadSupport:
+              release(event.lock)
+            discard
+          else:
+            event.flag = false
+            when hasThreadSupport:
+              release(event.lock)
+      else:
+        result = res
+
+      if not(repeat):
+        break

--- a/chronos/osapi.nim
+++ b/chronos/osapi.nim
@@ -1,0 +1,66 @@
+#
+#               Chronos OS API declarations
+#              (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## This module implements a small wrapper for some needed Windows/*nix API
+## procedures, which are not defined in Nim stdlib modules, or its definition
+## is wrong.
+when defined(windows):
+  import winlean
+
+  const
+    TCP_NODELAY* = 1
+    IPPROTO_TCP* = 6
+    PIPE_TYPE_BYTE* = 0x00000000'i32
+    PIPE_READMODE_BYTE* = 0x00000000'i32
+    PIPE_WAIT* = 0x00000000'i32
+    DEFAULT_PIPE_SIZE* = 65536'i32
+    ERROR_PIPE_CONNECTED* = 535
+    ERROR_PIPE_BUSY* = 231
+    ERROR_OPERATION_ABORTED* = 995
+    ERROR_SUCCESS* = 0
+    ERROR_CONNECTION_REFUSED* = 1225
+    PIPE_TYPE_MESSAGE* = 0x4
+    PIPE_READMODE_MESSAGE* = 0x2
+    PIPE_UNLIMITED_INSTANCES* = 255
+    ERROR_BROKEN_PIPE* = 109
+    ERROR_PIPE_NOT_CONNECTED* = 233
+    ERROR_NO_DATA* = 232
+    ERROR_CONNECTION_ABORTED* = 1236
+
+  proc createEvent*(lpEventAttributes: ptr SECURITY_ATTRIBUTES,
+                    bManualReset: DWORD, bInitialState: DWORD,
+                    lpName: ptr Utf16Char): Handle
+       {.stdcall, dynlib: "kernel32", importc: "CreateEventW".}
+
+  proc connectNamedPipe*(hNamedPipe: Handle, lpOverlapped: pointer): WINBOOL
+       {.importc: "ConnectNamedPipe", stdcall, dynlib: "kernel32".}
+
+  proc cancelIo*(hFile: HANDLE): WINBOOL
+       {.stdcall, dynlib: "kernel32", importc: "CancelIo".}
+
+  proc disconnectNamedPipe*(hPipe: HANDLE): WINBOOL
+       {.stdcall, dynlib: "kernel32", importc: "DisconnectNamedPipe".}
+
+  proc setNamedPipeHandleState*(hPipe: HANDLE, lpMode, lpMaxCollectionCount,
+                                lpCollectDataTimeout: ptr DWORD): WINBOOL
+       {.stdcall, dynlib: "kernel32", importc: "SetNamedPipeHandleState".}
+
+  proc resetEvent*(hEvent: HANDLE): WINBOOL
+       {.stdcall, dynlib: "kernel32", importc: "ResetEvent".}
+
+else:
+  import posix
+
+  const
+    TCP_NODELAY* = 1
+    IPPROTO_TCP* = 6
+
+when defined(linux):
+  proc eventfd*(count: cuint, flags: cint): cint
+               {.cdecl, importc: "eventfd", header: "<sys/eventfd.h>".}

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -7,8 +7,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import os, strutils, nativesockets, net
-import ../asyncloop
-export net
+import ../asyncloop, ../osapi
+export net, osapi
 
 when defined(windows):
   import winlean
@@ -484,35 +484,3 @@ proc isLiteral*(s: string): bool {.inline.} =
 
 proc isLiteral*[T](s: seq[T]): bool {.inline.} =
   (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
-when defined(windows):
-  import winlean
-
-  const
-    ERROR_OPERATION_ABORTED* = 995
-    ERROR_PIPE_CONNECTED* = 535
-    ERROR_PIPE_BUSY* = 231
-    ERROR_SUCCESS* = 0
-    ERROR_CONNECTION_REFUSED* = 1225
-    PIPE_TYPE_BYTE* = 0
-    PIPE_READMODE_BYTE* = 0
-    PIPE_TYPE_MESSAGE* = 0x4
-    PIPE_READMODE_MESSAGE* = 0x2
-    PIPE_WAIT* = 0
-    PIPE_UNLIMITED_INSTANCES* = 255
-    ERROR_BROKEN_PIPE* = 109
-    ERROR_PIPE_NOT_CONNECTED* = 233
-    ERROR_NO_DATA* = 232
-    ERROR_CONNECTION_ABORTED* = 1236
-
-  proc cancelIo*(hFile: HANDLE): WINBOOL
-       {.stdcall, dynlib: "kernel32", importc: "CancelIo".}
-  proc connectNamedPipe*(hPipe: HANDLE, lpOverlapped: ptr OVERLAPPED): WINBOOL
-       {.stdcall, dynlib: "kernel32", importc: "ConnectNamedPipe".}
-  proc disconnectNamedPipe*(hPipe: HANDLE): WINBOOL
-       {.stdcall, dynlib: "kernel32", importc: "DisconnectNamedPipe".}
-  proc setNamedPipeHandleState*(hPipe: HANDLE, lpMode, lpMaxCollectionCount,
-                                lpCollectDataTimeout: ptr DWORD): WINBOOL
-       {.stdcall, dynlib: "kernel32", importc: "SetNamedPipeHandleState".}
-  proc resetEvent*(hEvent: HANDLE): WINBOOL
-       {.stdcall, dynlib: "kernel32", importc: "ResetEvent".}

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -7,7 +7,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import net, nativesockets, os, deques
-import ../asyncloop, ../handles, ../sendfile
+import ../asyncloop, ../handles, ../sendfile, ../osapi
 import common
 
 {.deadCodeElim: on.}
@@ -1412,8 +1412,8 @@ proc createStreamServer*(host: TransportAddress,
           raiseTransportOsError(err)
       # TCP flags are not useful for Unix domain sockets.
       if ServerFlags.TcpNoDelay in flags:
-        if not setSockOpt(serverSocket, handles.IPPROTO_TCP,
-                          handles.TCP_NODELAY, 1):
+        if not setSockOpt(serverSocket, osapi.IPPROTO_TCP,
+                          osapi.TCP_NODELAY, 1):
           let err = osLastError()
           if sock == asyncInvalidSocket:
             serverSocket.closeSocket()
@@ -1462,8 +1462,8 @@ proc createStreamServer*(host: TransportAddress,
           raiseTransportOsError(err)
       # TCP flags are not useful for Unix domain sockets.
       if ServerFlags.TcpNoDelay in flags:
-        if not setSockOpt(serverSocket, handles.IPPROTO_TCP,
-                          handles.TCP_NODELAY, 1):
+        if not setSockOpt(serverSocket, osapi.IPPROTO_TCP,
+                          osapi.TCP_NODELAY, 1):
           let err = osLastError()
           if sock == asyncInvalidSocket:
             serverSocket.closeSocket()

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -5,6 +5,6 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import testmacro, testsync, testsoon, testtime, testfut, testsignal,
-       testaddress, testdatagram, teststream, testserver, testbugs, testnet,
-       testasyncstream
+import testmacro, testsync, testchannels, testsoon, testtime, testfut,
+       testsignal, testaddress, testdatagram, teststream, testserver, testbugs,
+       testnet, testasyncstream

--- a/tests/testchannels.nim
+++ b/tests/testchannels.nim
@@ -1,0 +1,184 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import unittest
+import ../chronos
+
+const
+  hasThreadSupport* = compileOption("threads")
+  TestRunsCount = 100
+
+suite "Asynchronous channels test suite":
+
+  proc testStSync(runs: int, queue: int): bool =
+    var tun = newAsyncChannel[int](queue)
+    tun.open()
+    for i in 0..<runs:
+      tun.sendSync(i * 10)
+      var msg = tun.recvSync()
+      if msg != i * 10:
+        tun.close()
+        return false
+    tun.close()
+    return true
+
+  proc testStAsync(runs: int, queue: int): Future[bool] {.async.} =
+    var tun = newAsyncChannel[int](queue)
+    tun.open()
+    for i in 0..<runs:
+      await tun.send(i * 10)
+      var msg = await tun.recv()
+      if msg != i * 10:
+        tun.close()
+        return false
+    tun.close()
+    return true
+
+  proc testStCombined(runs: int, queue: int): Future[bool] {.async.} =
+    var tun = newAsyncChannel[int](queue)
+    tun.open()
+    for i in 0..<runs:
+      tun.sendSync(i * 10)
+      var msg = await tun.recv()
+      if msg != i * 10:
+        tun.close()
+        return false
+    for i in 0..<runs:
+      await tun.send(i * 10)
+      var msg = tun.recvSync()
+      if msg != i * 10:
+        tun.close()
+        return false
+    tun.close()
+    return true
+
+  when hasThreadSupport:
+    type
+      ThreadArg = object
+        runs: int
+        tun: AsyncChannel[int]
+
+    proc threadSyncFunc1(arg: ThreadArg) {.thread.} =
+      # echo "Sending thread started [", getThreadId(), "]"
+      arg.tun.open()
+      for i in 0..<arg.runs:
+        arg.tun.sendSync(i * 10)
+      arg.tun.close()
+      # echo "Sending thread finished [", getThreadId(), "]"
+
+    proc testMtSync(threads: int, runs: int, queue: int): bool =
+      var tun = newAsyncChannel[int](queue)
+      var arg = ThreadArg(tun: tun, runs: runs)
+      var thrs = newSeq[Thread[ThreadArg]](threads)
+      for i in 0..<threads:
+        createThread(thrs[i], threadSyncFunc1, arg)
+      var total = threads * runs
+      tun.open()
+      for i in 0..<total:
+        var msg = arg.tun.recvSync()
+      joinThreads(thrs)
+      tun.close()
+      result = true
+
+    proc threadAsyncFunc(arg: ThreadArg) {.async.} =
+      arg.tun.open()
+      for i in 0..<arg.runs:
+        await arg.tun.send(i * 10)
+      arg.tun.close()
+
+    proc threadSyncFunc2(arg: ThreadArg) {.thread.} =
+      waitFor threadAsyncFunc(arg)
+
+    proc asyncReceiver(arg: ThreadArg, total: int) {.async.} =
+      arg.tun.open()
+      for i in 0..<total:
+        var msg = await arg.tun.recv()
+      arg.tun.close()
+
+    proc testMtAsync(threads: int, runs: int, queue: int): bool =
+      var tun = newAsyncChannel[int](queue)
+      var arg = ThreadArg(tun: tun, runs: runs)
+      var thrs = newSeq[Thread[ThreadArg]](threads)
+      for i in 0..<threads:
+        createThread(thrs[i], threadSyncFunc2, arg)
+      var total = threads * runs
+      waitFor asyncReceiver(arg, total)
+      joinThreads(thrs)
+      result = true
+
+    proc threadCombinedAsyncFunc(arg: ThreadArg) {.async.} =
+      arg.tun.open()
+      for i in 0..<arg.runs:
+        await arg.tun.send(i * 10)
+      arg.tun.close()
+
+    proc threadCombinedFunc(arg: ThreadArg) {.thread.} =
+      arg.tun.open()
+      for i in 0..<arg.runs:
+        arg.tun.sendSync(i * 10)
+      arg.tun.close()
+
+      waitFor threadCombinedAsyncFunc(arg)
+
+    proc testMtCombined(threads: int, runs: int, queue: int): bool =
+      var tun = newAsyncChannel[int](queue)
+      var arg = ThreadArg(tun: tun, runs: runs)
+      var thrs = newSeq[Thread[ThreadArg]](threads)
+      for i in 0..<threads:
+        createThread(thrs[i], threadCombinedFunc, arg)
+      var total = threads * runs
+      tun.open()
+      waitFor asyncReceiver(arg, total)
+      for i in 0..<total:
+        var msg = arg.tun.recvSync()
+      joinThreads(thrs)
+      tun.close()
+      result = true
+
+  test "Single-threaded synchronous with infinite queue test":
+    check testStSync(500, -1) == true
+  test "Single-threaded synchronous with limited queue test":
+    check testStSync(500, 10) == true
+  test "Single-threaded asynchronous with infinite queue test":
+    check waitFor(testStAsync(500, -1)) == true
+  test "Single-threaded synchronous with limited queue test":
+    check waitFor(testStAsync(500, 10)) == true
+  test "Single-threaded sync + async with infinite queue test":
+    check waitFor(testStCombined(250, -1)) == true
+  test "Single-threaded sync + async with limited queue test":
+    check waitFor(testStCombined(250, 10)) == true
+
+  test "Multi-threaded synchronous with infinite queue test":
+    when hasThreadSupport:
+      check testMtSync(10, TestRunsCount, -1) == true
+    else:
+      skip()
+  test "Multi-threaded synchronous with limited queue test":
+    when hasThreadSupport:
+      check testMtSync(10, TestRunsCount, 10) == true
+    else:
+      skip()
+  test "Multi-threaded asynchronous with infinite queue test":
+    when hasThreadSupport:
+      check testMtAsync(10, TestRunsCount, -1) == true
+    else:
+      skip()
+  test "Multi-threaded asynchronous with limited queue test":
+    when hasThreadSupport:
+      check testMtAsync(10, TestRunsCount, 10) == true
+    else:
+      skip()
+  test "Multi-threaded sync + async with infinite queue test":
+    when hasThreadSupport:
+      check testMtCombined(10, TestRunsCount, -1) == true
+    else:
+      skip()
+  test "Multi-threaded sync + async with limited queue test":
+    when hasThreadSupport:
+      check testMtCombined(10, TestRunsCount, 10) == true
+    else:
+      skip()

--- a/tests/testsignal.nim
+++ b/tests/testsignal.nim
@@ -29,13 +29,14 @@ suite "Signal handling test suite":
       discard posix.kill(posix.getpid(), cint(signal))
       waitFor(fut)
       signalCounter == value
-  else:
-    const
-      SIGINT = 0
-      SIGTERM = 0
-    proc test(signal, value: int): bool = true
 
   test "SIGINT test":
-    check test(SIGINT, 31337) == true
+    when defined(windows):
+      skip()
+    else:
+      check test(SIGINT, 31337) == true
   test "SIGTERM test":
-    check test(SIGTERM, 65537) == true
+    when defined(windows):
+      skip()
+    else:
+      check test(SIGTERM, 65537) == true


### PR DESCRIPTION
* Add `AsyncChannel[T]` and tests
* Add `AsyncThreadEvent` and tests.
* Refactor OS API declarations to `osapi.nim`.
* Add `awaitForSingleObject()` and `awaitForSelectEvent()`.
* Add `skip()` to some tests.
* Bump version to 2.2.9.

`AsyncChannel[T]` now support multiple writer single reader mode. It is also possible to use write/read to/from channel with both synchronous and asynchronous API.
