### PR TITLE
Revert back some exception changes.

### DIFF
--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -53,8 +53,10 @@ type
 
   FutureVar*[T] = distinct Future[T]
 
-  FutureError* = object of CatchableError
+  FutureDefect* = object of Exception
     cause*: FutureBase
+
+  FutureError* = object of CatchableError
 
   CancelledError* = object of FutureError
 
@@ -141,7 +143,7 @@ proc failed*(future: FutureBase): bool {.inline.} =
 
 proc checkFinished[T](future: Future[T], loc: ptr SrcLoc) =
   ## Checks whether `future` is finished. If it is then raises a
-  ## ``FutureError``.
+  ## ``FutureDefect``.
   if future.finished():
     var msg = ""
     msg.add("An attempt was made to complete a Future more than once. ")
@@ -161,7 +163,7 @@ proc checkFinished[T](future: Future[T], loc: ptr SrcLoc) =
     msg.add("\n  Stack trace to moment of secondary completion:")
     msg.add("\n" & indent(getStackTrace().strip(), 4))
     msg.add("\n\n")
-    var err = newException(FutureError, msg)
+    var err = newException(FutureDefect, msg)
     err.cause = future
     raise err
   else:

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -42,8 +42,8 @@ template createCb(retFutureSym, iteratorNameSym,
 
         if next == nil:
           if not(retFutureSym.finished()):
-            let msg = "Async procedure ($1) yielded `nil`, are you await'ing a " &
-                    "`nil` Future?"
+            let msg = "Async procedure ($1) yielded `nil`, " &
+                      "are you await'ing a `nil` Future?"
             raise newException(AssertionError, msg % strName)
         else:
           {.gcsafe.}:
@@ -52,7 +52,7 @@ template createCb(retFutureSym, iteratorNameSym,
             {.pop.}
     except CancelledError:
       retFutureSym.cancel()
-    except CatchableError as exc:
+    except Exception as exc:
       futureVarCompletions
 
       if retFutureSym.finished():


### PR DESCRIPTION
This is rename of `FutureError` to `FutureDefect` because it is used only to raise "double Future[T] completion" error, so its exactly `Defect`.

`FutureError` will be still `CatchableError` and so `CancelledError` will be `CatchableError` too.

We also want to catch all exceptions in iterator's code, because otherwise exceptions will start leaking through `poll()` call and it will be hard to obtain proper stack trace for it.