### PR TITLE
Optimize timers processing

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -472,6 +472,9 @@ when defined(windows) or defined(nimdoc):
     # poll() call.
     loop.processCallbacks()
 
+    # Cleanup canceled timers
+    loop.removeTimers()
+
   proc closeSocket*(fd: AsyncFD, aftercb: CallbackFunc = nil) =
     ## Closes a socket and ensures that it is unregistered.
     let loop = getGlobalDispatcher()
@@ -755,6 +758,8 @@ else:
 proc setTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil): TimerHandle =
   ## Arrange for the callback ``cb`` to be called at the given absolute
   ## timestamp ``at``. You can also pass ``udata`` to callback.
+  ## Returns an opaque handle to be passed to ``clearTimer()`` to cancel
+  ## a pending timer.
   let loop = getGlobalDispatcher()
 
   var timer = TimerCallback(finishAt: at,
@@ -770,6 +775,7 @@ proc setTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil): TimerHandle 
     loop.timers.push(timer)
 
 proc clearTimer*(handle: TimerHandle) =
+  ## Clear the timer associated with the passed handle
   var loop = getGlobalDispatcher()
   var timer = loop.timerHandles[handle.Natural]
   loop.timerHandles[handle.Natural] = nil

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -823,7 +823,7 @@ proc withTimeout*[T](fut: Future[T], timeout: Duration): Future[bool] =
     if not(retFuture.finished()):
       if isNil(udata):
         # Timer exceeded first.
-        clearTimer(timer)
+        fut.removeCallback(continuation)
         fut.cancel()
         retFuture.complete(false)
       else:

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -741,7 +741,7 @@ proc setTimer(at: Moment, cb: CallbackFunc, udata: pointer = nil): TimerCallback
                           function: AsyncCallback(function: cb, udata: udata))
   loop.timers.push(result)
 
-proc clearTimer(timer: TimerCallback) =
+proc clearTimer(timer: TimerCallback) {.inline.} =
   timer.deleted = true
 
 proc addTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil)

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -855,7 +855,7 @@ proc wait*[T](fut: Future[T], timeout = InfiniteDuration): Future[T] =
 
   proc continuation(udata: pointer) {.gcsafe.} =
     if not(retFuture.finished()):
-      if isNil(udata):
+      if not(fut.finished()):
         # Timer exceeded first.
         fut.removeCallback(continuation)
         fut.cancel()


### PR DESCRIPTION
This PR addresses two issues:

a) The current check for `isNil` doesn't seem to make much sense in this context. I was running into errors with `fut` completing twice, checking if `fut` finished seems to make much more sense. (546cc36d79d0ed104b95304922cf331fd0ca2f4b)

b) The entire `timers` list (heap), is being scanned on every `removeTimer` invocation, this incurs in a huge performance overhead when the amount of active timers reaches some threshold. For example, introducing timeouts to nim-libp2p would trigger this in tests pretty often, bringing execution to a complete stall. This PR addresses this issue by avoiding removing timers one by one and instead delay timer removal until the end of the `poll` execution and then cleans them up in wholesale. This increases performance and makes timers usable. (b9c534724c05b4891f6cd7d331d2cc160016e8c1)