### PR TITLE
fix future completing twice in `wait`

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -875,7 +875,7 @@ proc wait*[T](fut: Future[T], timeout = InfiniteDuration): Future[T] =
 
   proc continuation(udata: pointer) {.gcsafe.} =
     if not(retFuture.finished()):
-      if isNil(udata):
+      if not(fut.finished()):
         # Timer exceeded first.
         fut.removeCallback(continuation)
         fut.cancel()

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -84,6 +84,13 @@ suite "Future[T] behavior test suite":
     except:
       result = -6
 
+    ## Test for future not completing twice
+    try:
+      await wait(sleepAsync(5.millis), 5.millis)
+      result = 7
+    except:
+      result = -7
+
   proc test1(): bool =
     var fut = testFuture1()
     poll()
@@ -779,7 +786,7 @@ suite "Future[T] behavior test suite":
   test "Future[T] callbacks not changing order after removeCallback()":
     check test4() == "1245"
   test "wait[T]() test":
-    check test5() == 6
+    check test5() == 7
 
   test "asyncDiscard() test":
     check testAsyncDiscard() == 10


### PR DESCRIPTION
This should fix https://github.com/status-im/nim-beacon-chain/issues/693. 

With this snippet, I can reproduce the `Feature` completing twice consistently on my machine. Both the `udata` parameter as well as the `fut.finished()` are `true` when running the snippet.

```nim
import chronos

proc main() {.async.} =
  while true:
    try:
      await wait(sleepAsync(4.millis), 4.millis)
    except:
      echo "EXCEPTION ", getCurrentExceptionMsg()

waitFor(main())
```