### PR TITLE
Fixes for cancellation bugs.

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "2.3.4"
+version       = "2.3.5"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -768,7 +768,8 @@ when defined(windows):
           if pipeHandle == INVALID_HANDLE_VALUE:
             let err = osLastError()
             if int32(err) == ERROR_PIPE_BUSY:
-              addTimer(Moment.fromNow(50.milliseconds), pipeContinuation, nil)
+              discard setTimer(Moment.fromNow(50.milliseconds),
+                               pipeContinuation, nil)
             else:
               retFuture.fail(getTransportOsError(err))
           else:


### PR DESCRIPTION
Fix bug cancellation handlers not called in wait() and withTimeout().
Fix double completion bug because of callback race.
Fix deprecation warnings.
Rename some internal procedures.
Bump version to 2.3.5.