### PR TITLE
fix endian conversion issues

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "2.5.0"
+version       = "2.5.1"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"
@@ -7,7 +7,8 @@ skipDirs      = @["tests"]
 
 ### Dependencies
 
-requires "nim > 1.2.0" 
+requires "nim > 1.2.0",
+         "stew",
          "bearssl"
 
 task test, "Run all tests":

--- a/tests/testnet.nim
+++ b/tests/testnet.nim
@@ -6,7 +6,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import unittest
-import ../chronos
+import ../chronos/transports/[osnet, ipnet]
 
 when defined(nimHasUsed): {.used.}
 
@@ -480,3 +480,20 @@ suite "Network utilities test suite":
       route.dest.isUnspecified() == false
       route.ifIndex != 0
     echo route
+
+  test "TransportAddress arithmetic operations test":
+    var ip4 = initTAddress("192.168.1.0:1024")
+    var ip6 = initTAddress("[::1]:1024")
+    when sizeof(int) == 8:
+      ip4 = ip4 + uint(0xFFFF_FFFF_FFFF_FFFF'u64)
+      ip6 = ip6 + uint(0xFFFF_FFFF_FFFF_FFFF'u64)
+      var ip6e = initTAddress("[::1:0000:0000:0000:1]:1024")
+    else:
+      ip4 = ip4 + uint(0xFFFF_FFFF'u32)
+      ip6 = ip6 + uint(0xFFFF_FFFF'u32)
+      var ip6e = initTAddress("[::1:0000:1]:1024")
+    inc(ip4)
+    inc(ip6)
+    check:
+      ip4 == initTAddress("192.168.1.0:1024")
+      ip6 == ip6e


### PR DESCRIPTION
* fixes call to `bigEndian32` on a uint64 which breaks on big endian
platforms
* prefer endians2 for less and safer code