### PR TITLE
Fix possible race condition in asyncstream close

### DIFF
--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -768,10 +768,11 @@ proc close*(rw: AsyncStreamRW) =
   if rw.closed():
     raise newAsyncStreamIncorrectError("Stream is already closed!")
 
+  rw.state = AsyncStreamState.Closed
+
   proc continuation(udata: pointer) =
     if not isNil(rw.udata):
       GC_unref(cast[ref int](rw.udata))
-    rw.state = AsyncStreamState.Closed
     if not(rw.future.finished()):
       rw.future.complete()
     when rw is AsyncStreamReader:


### PR DESCRIPTION
The close state was written sometimes too late.
Fixed some issue with https://github.com/status-im/nim-libp2p/pull/131