### PR TITLE
Make Future tracking and stack traces optional

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -13,7 +13,7 @@ requires "nim > 0.19.4",
 task test, "Run all tests":
   var commands = [
     "nim c -r -d:useSysAssert -d:useGcAssert tests/",
-    "nim c -r tests/",
+    "nim c -r -d:chronosStackTrace tests/",
     "nim c -r -d:release tests/",
     "nim c -r -d:release -d:chronosFutureTracking tests/"
   ]

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -14,7 +14,8 @@ task test, "Run all tests":
   var commands = [
     "nim c -r -d:useSysAssert -d:useGcAssert tests/",
     "nim c -r tests/",
-    "nim c -r -d:release tests/"
+    "nim c -r -d:release tests/",
+    "nim c -r -d:release -d:chronosFutureTracking tests/"
   ]
   for testname in ["testall"]:
     for cmd in commands:

--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -16,7 +16,7 @@ const
   LocCreateIndex* = 0
   LocCompleteIndex* = 1
 
-when defined(getStackTraceEntries):
+when defined(chronosStackTrace):
   type StackTrace = string
 
 type
@@ -80,7 +80,7 @@ when defined(chronosFutureTracking):
 template setupFutureBase(loc: ptr SrcLoc) =
   new(result)
   result.state = FutureState.Pending
-  when defined(getStackTraceEntries):
+  when defined(chronosStackTrace):
     result.stackTrace = getStackTrace()
   result.id = currentID
   result.location[LocCreateIndex] = loc

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -959,18 +959,19 @@ proc getTracker*(id: string): TrackerBase =
   let loop = getGlobalDispatcher()
   result = loop.trackers.getOrDefault(id, nil)
 
-iterator pendingFutures*(): FutureBase =
-  ## Iterates over the list of pending Futures (Future[T] objects which not yet
-  ## completed, cancelled or failed).
-  var slider = futureList.head
-  while not(isNil(slider)):
-    yield slider
-    slider = slider.next
+when defined(chronosFutureTracking):
+  iterator pendingFutures*(): FutureBase =
+    ## Iterates over the list of pending Futures (Future[T] objects which not
+    ## yet completed, cancelled or failed).
+    var slider = futureList.head
+    while not(isNil(slider)):
+      yield slider
+      slider = slider.next
 
-proc pendingFuturesCount*(): int =
-  ## Returns number of pending Futures (Future[T] objects which not yet
-  ## completed, cancelled or failed).
-  futureList.count
+  proc pendingFuturesCount*(): int =
+    ## Returns number of pending Futures (Future[T] objects which not yet
+    ## completed, cancelled or failed).
+    futureList.count
 
 # Perform global per-module initialization.
 globalInit()

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -275,7 +275,7 @@ template await*[T](f: Future[T]): auto =
     yield chronosInternalTmpFuture
     chronosInternalRetFuture.child = nil
     if chronosInternalRetFuture.mustCancel:
-      raise newException(CancelledError, "")
+      raise newCancelledError()
     chronosInternalTmpFuture.internalCheckComplete()
     cast[type(f)](chronosInternalTmpFuture).internalRead()
   else:
@@ -290,7 +290,7 @@ template awaitne*[T](f: Future[T]): Future[T] =
     yield chronosInternalTmpFuture
     chronosInternalRetFuture.child = nil
     if chronosInternalRetFuture.mustCancel:
-      raise newException(CancelledError, "")
+      raise newCancelledError()
     cast[type(f)](chronosInternalTmpFuture)
   else:
     unsupported "awaitne is only available within {.async.}"

--- a/tests/testutils.nim
+++ b/tests/testutils.nim
@@ -5,72 +5,82 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import unittest, strutils
+import unittest
 import ../chronos
 
 when defined(nimHasUsed): {.used.}
 
 suite "Asynchronous utilities test suite":
-  proc getCount(): int =
-    # This procedure counts number of Future[T] in double-linked list via list
-    # iteration.
-    result = 0
-    for item in pendingFutures():
-      inc(result)
+  when defined(chronosFutureTracking):
+    proc getCount(): int =
+      # This procedure counts number of Future[T] in double-linked list via list
+      # iteration.
+      result = 0
+      for item in pendingFutures():
+        inc(result)
 
   test "Future clean and leaks test":
-    if pendingFuturesCount(WithoutFinished) == 0:
-      if pendingFuturesCount(OnlyFinished) > 0:
-        poll()
-      check pendingFuturesCount() == 0
+    when defined(chronosFutureTracking):
+      if pendingFuturesCount(WithoutFinished) == 0:
+        if pendingFuturesCount(OnlyFinished) > 0:
+          poll()
+        check pendingFuturesCount() == 0
+      else:
+        echo dumpPendingFutures()
+        check false
     else:
-      echo dumpPendingFutures()
-      check false
+      skip()
 
   test "FutureList basics test":
-    var fut1 = newFuture[void]()
-    check:
-      getCount() == 1
-      pendingFuturesCount() == 1
-    var fut2 = newFuture[void]()
-    check:
-      getCount() == 2
-      pendingFuturesCount() == 2
-    var fut3 = newFuture[void]()
-    check:
-      getCount() == 3
-      pendingFuturesCount() == 3
-    fut1.complete()
-    poll()
-    check:
-      getCount() == 2
-      pendingFuturesCount() == 2
-    fut2.fail(newException(ValueError, ""))
-    poll()
-    check:
-      getCount() == 1
-      pendingFuturesCount() == 1
-    fut3.cancel()
-    poll()
-    check:
-      getCount() == 0
-      pendingFuturesCount() == 0
+    when defined(chronosFutureTracking):
+      var fut1 = newFuture[void]()
+      check:
+        getCount() == 1
+        pendingFuturesCount() == 1
+      var fut2 = newFuture[void]()
+      check:
+        getCount() == 2
+        pendingFuturesCount() == 2
+      var fut3 = newFuture[void]()
+      check:
+        getCount() == 3
+        pendingFuturesCount() == 3
+      fut1.complete()
+      poll()
+      check:
+        getCount() == 2
+        pendingFuturesCount() == 2
+      fut2.fail(newException(ValueError, ""))
+      poll()
+      check:
+        getCount() == 1
+        pendingFuturesCount() == 1
+      fut3.cancel()
+      poll()
+      check:
+        getCount() == 0
+        pendingFuturesCount() == 0
+    else:
+      skip()
 
   test "FutureList async procedure test":
-    proc simpleProc() {.async.} =
-      await sleepAsync(10.milliseconds)
+    when defined(chronosFutureTracking):
+      proc simpleProc() {.async.} =
+        await sleepAsync(10.milliseconds)
 
-    var fut = simpleProc()
-    check:
-      getCount() == 2
-      pendingFuturesCount() == 2
+      var fut = simpleProc()
+      check:
+        getCount() == 2
+        pendingFuturesCount() == 2
 
-    waitFor fut
-    check:
-      getCount() == 1
-      pendingFuturesCount() == 1
+      waitFor fut
+      check:
+        getCount() == 1
+        pendingFuturesCount() == 1
 
-    poll()
-    check:
-      getCount() == 0
-      pendingFuturesCount() == 0
+      poll()
+      check:
+        getCount() == 0
+        pendingFuturesCount() == 0
+    else:
+      skip()


### PR DESCRIPTION
- Make Future tracking optional via `-d:chronosFutureTracking` compilation flag.
- Make Future stack traces optional via `-d:chronosStackTraces` compilation flag.
- Address review comment https://github.com/status-im/nim-chronos/pull/107#pullrequestreview-442368768