### PR TITLE
asyncCheck(): don't raise exception on cancellation

### DIFF
--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -531,13 +531,11 @@ proc mget*[T](future: FutureVar[T]): var T =
   result = Future[T](future).value
 
 proc asyncCheck*[T](future: Future[T]) =
-  ## Sets a callback on ``future`` which raises an exception if the future
-  ## finished with an error.
-  ##
-  ## This should be used instead of ``discard`` to discard void futures.
+  ## Sets a callback on ``future`` which raises an exception in ``poll()`` if the
+  ## future failed.
   doAssert(not isNil(future), "Future is nil")
   proc cb(data: pointer) =
-    if future.failed() or future.cancelled():
+    if future.failed():
       when defined(chronosStackTrace):
         injectStacktrace(future)
       raise future.error


### PR DESCRIPTION
When we document this procedure, we need to make it clear that exceptions are being raised in `poll()` by that new callback.

The name doesn't help at all.