### PR TITLE
ORC build (experiment)

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -23,3 +23,14 @@ task test, "Run all tests":
       let curcmd = cmd & testname
       echo "\n" & curcmd
       exec curcmd
+
+task test_orc, "Run all tests":
+  var commands = [
+    "nim c -r --gc:orc tests/",
+    "nim c -r --gc:orc -d:release tests/",
+  ]
+  for testname in ["testall"]:
+    for cmd in commands:
+      let curcmd = cmd & testname
+      echo "\n" & curcmd
+      exec curcmd

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -676,10 +676,7 @@ proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
       await write(wstream.wsource, sbytes, msglen)
     else:
       var item = WriteItem(kind: Sequence)
-      if not isLiteral(sbytes):
-        shallowCopy(item.data2, sbytes)
-      else:
-        item.data2 = sbytes
+      item.data2 = sbytes
       item.size = length
       item.future = newFuture[void]("async.stream.write(seq)")
       await wstream.queue.put(item)
@@ -721,10 +718,7 @@ proc write*(wstream: AsyncStreamWriter, sbytes: string,
       await write(wstream.wsource, sbytes, msglen)
     else:
       var item = WriteItem(kind: String)
-      if not isLiteral(sbytes):
-        shallowCopy(item.data3, sbytes)
-      else:
-        item.data3 = sbytes
+      item.data3 = sbytes
       item.size = length
       item.future = newFuture[void]("async.stream.write(string)")
       await wstream.queue.put(item)

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -508,16 +508,6 @@ proc raiseTransportOsError*(err: OSErrorCode) =
   ## Raises transport specific OS error.
   raise getTransportOsError(err)
 
-type
-  SeqHeader = object
-    length, reserved: int
-
-proc isLiteral*(s: string): bool {.inline.} =
-  (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
-proc isLiteral*[T](s: seq[T]): bool {.inline.} =
-  (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
 when defined(windows):
   import winlean
 

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -728,10 +728,7 @@ proc send*(transp: DatagramTransport, msg: string, msglen = -1): Future[void] =
   ## address which was bounded on transport.
   var retFuture = newFutureStr[void]("datagram.transport.send(string)")
   transp.checkClosed(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: len(msg) else: msglen
   let vector = GramVector(kind: WithoutAddress, buf: addr retFuture.gcholder[0],
                           buflen: length,
@@ -747,10 +744,7 @@ proc send*[T](transp: DatagramTransport, msg: seq[T],
   ## address which was bounded on transport.
   var retFuture = newFutureSeq[void, T]("datagram.transport.send(seq)")
   transp.checkClosed(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: (len(msg) * sizeof(T)) else: (msglen * sizeof(T))
   let vector = GramVector(kind: WithoutAddress, buf: addr retFuture.gcholder[0],
                           buflen: length,
@@ -779,10 +773,7 @@ proc sendTo*(transp: DatagramTransport, remote: TransportAddress,
   ## address ``remote``.
   var retFuture = newFutureStr[void]("datagram.transport.sendTo(string)")
   transp.checkClosed(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: len(msg) else: msglen
   let vector = GramVector(kind: WithAddress, buf: addr retFuture.gcholder[0],
                           buflen: length,
@@ -799,10 +790,7 @@ proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
   ## address ``remote``.
   var retFuture = newFutureSeq[void, T]("datagram.transport.sendTo(seq)")
   transp.checkClosed(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: (len(msg) * sizeof(T)) else: (msglen * sizeof(T))
   let vector = GramVector(kind: WithAddress, buf: addr retFuture.gcholder[0],
                           buflen: length,

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1911,10 +1911,7 @@ proc write*(transp: StreamTransport, msg: string, msglen = -1): Future[int] =
   var retFuture = newFutureStr[int]("stream.transport.write(string)")
   transp.checkClosed(retFuture)
   transp.checkWriteEof(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: len(msg) else: msglen
   var vector = StreamVector(kind: DataBuffer,
                             writer: cast[Future[int]](retFuture),
@@ -1929,10 +1926,7 @@ proc write*[T](transp: StreamTransport, msg: seq[T], msglen = -1): Future[int] =
   var retFuture = newFutureSeq[int, T]("stream.transport.write(seq)")
   transp.checkClosed(retFuture)
   transp.checkWriteEof(retFuture)
-  if not isLiteral(msg):
-    shallowCopy(retFuture.gcholder, msg)
-  else:
-    retFuture.gcholder = msg
+  retFuture.gcholder = msg
   let length = if msglen <= 0: (len(msg) * sizeof(T)) else: (msglen * sizeof(T))
   var vector = StreamVector(kind: DataBuffer,
                             writer: cast[Future[int]](retFuture),


### PR DESCRIPTION
Removed the old incompatible code for now, but maybe @Araq has a better solution.
All tests almost pass, but it's failing in asyncstream.. I think it's bad codegen by looking at `C` code.
```c
nimln_(801, "E:\\develop\\status\\nim-chronos\\chronos\\streams\\asyncstream.nim");
nimln_(335, "E:\\develop\\status\\nim-chronos\\chronos\\asyncfutures2.nim");
nimln_(801, "E:\\develop\\status\\nim-chronos\\chronos\\streams\\asyncstream.nim");
colontmpD_ = 0;
nimln_(240, "E:\\develop\\status\\nim-chronos\\chronos\\asyncfutures2.nim");
eqcopy___WVHzlBztR3durWxAW3awcg_2(&colontmpD_, (*(*colonenv_).rw1).Sup.future);
if (NIM_UNLIKELY(*nimErr_)) goto LA1_;
T27_ = (tyObject_FutureBasecolonObjectType___V9aHQccB2Pyjfqk9bdE5ZRnw*)0;
T27_ = &colontmpD_->Sup;
nimln_(335, "E:\\develop\\status\\nim-chronos\\chronos\\asyncfutures2.nim");
T28_ = (tyObject_SrcLoc__9cugm8iqHlSb5d0xCTLlcbg*)0;
T28_ = srcLocImpl__9aKv9c9bPL5yWoiTwJ0le1uqQ();
if (NIM_UNLIKELY(*nimErr_)) goto LA1_;
T29_ = (NIM_BOOL)0;
T29_ = cancel__ZYuu0FydmjOOjOhwx69cq1w(T27_, T28_);
if (NIM_UNLIKELY(*nimErr_)) goto LA1_;
(void)(T29_);
```
`colontmpD_ = 0;` -> `eqcopy___WVHzlBztR3durWxAW3awcg_2(&colontmpD_, (*(*colonenv_).rw1).Sup.future);` 
is not really correct I think.