### PR TITLE
work around overload resolution issues

### DIFF
--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -218,7 +218,7 @@ proc finish(fut: FutureBase, state: FutureState) =
   fut.cancelcb = nil # release cancellation callback memory
   for item in fut.callbacks.mitems():
     if not(isNil(item.function)):
-      callSoon(item.function, item.udata)
+      callSoon(item)
     item = default(AsyncCallback) # release memory as early as possible
   fut.callbacks = default(seq[AsyncCallback]) # release seq as well
 


### PR DESCRIPTION
it seems that due to a naming conflict from asyncdispatch, callSoon is
deduced to raise exceptions even if it doesn't in modules that import
both, even indirectly - this patch randomly works around the issue with
some more overloads