### PR TITLE
Fix integer decoding overflow issue.

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "2.6.0"
+version       = "2.6.1"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"


### PR DESCRIPTION
Switch to stew.base10 procedures.
Adjust tests to follow new behavior.
Bump version to 2.6.1.