### PR TITLE
Ensures that asyncmacro2 does not raise exceptions

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -1073,11 +1073,7 @@ proc wait*[T](fut: Future[T], timeout = -1): Future[T] {.
   else:
     wait(fut, timeout.milliseconds())
 
-{.pop.}
-
 include asyncmacro2
-
-{.push raises: [Defect].}
 
 proc runForever*() {.raises: [Defect, CatchableError].} =
   ## Begins a never ending global dispatcher poll loop.

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -10,8 +10,6 @@
 
 {.push raises: [Defect].}
 
-include "system/inclrtl"
-
 import std/[os, tables, strutils, heapqueue, lists, options, nativesockets, net,
         deques]
 import ./timer


### PR DESCRIPTION
Changed all places where asyncmacro2 might raise an exception:
- calls to `macros.$` are replaced by calls to `strVal`
- `%` formatting is replaced by string concatenation
- call to `parseExpr` (which might raise `ValueError`) is replaced by `newNimNode`

These changes also ensure that chronos works with Nim 1.4.4.