### PR TITLE
Fix cancellation race when one of the ancestors are already Finished/Failed/Cancelled.

### DIFF
--- a/chronos/apps/http/httpbodyrw.nim
+++ b/chronos/apps/http/httpbodyrw.nim
@@ -6,7 +6,6 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import std/strutils
 import ../../asyncloop, ../../asyncsync
 import ../../streams/[asyncstream, boundstream]
 

--- a/chronos/apps/http/multipart.nim
+++ b/chronos/apps/http/multipart.nim
@@ -283,7 +283,7 @@ proc closeWait*(mp: MultiPart) {.async.} =
   ## Close and release MultiPart's ``mp`` stream and resources.
   case mp.kind
   of MultiPartSource.Stream:
-    await closeWait(mp.stream)
+    awaitrc mp.stream.closeWait()
   else:
     discard
 
@@ -291,7 +291,7 @@ proc closeWait*(mpr: MultiPartReaderRef) {.async.} =
   ## Close and release MultiPartReader's ``mpr`` stream and resources.
   case mpr.kind
   of MultiPartSource.Stream:
-    await mpr.stream.closeWait()
+    awaitrc mpr.stream.closeWait()
   else:
     discard
 

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std/[macros, strutils]
+import std/macros
 
 proc skipUntilStmtList(node: NimNode): NimNode {.compileTime.} =
   # Skips a nest of StmtList's.

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -59,6 +59,7 @@ type
     Error,    ## Stream has stored error
     Stopped,  ## Stream was closed while working
     Finished, ## Stream was properly finished
+    Closing,  ## Stream is closing
     Closed    ## Stream was closed
 
   StreamReaderLoop* = proc (stream: AsyncStreamReader): Future[void] {.gcsafe, raises: [Defect].}
@@ -223,10 +224,6 @@ proc raiseAsyncStreamIncompleteError*() {.
     noinline, noreturn, raises: [Defect, AsyncStreamIncompleteError].} =
   raise newAsyncStreamIncompleteError()
 
-proc raiseAsyncStreamIncorrectDefect*(m: string) {.
-    noinline, noreturn, raises: [Defect].} =
-  raise newException(AsyncStreamIncorrectDefect, m)
-
 proc raiseEmptyMessageDefect*() {.noinline, noreturn.} =
   raise newException(AsyncStreamIncorrectDefect,
                      "Could not write empty message")
@@ -244,7 +241,7 @@ proc atEof*(rstream: AsyncStreamReader): bool =
     else:
       rstream.rsource.atEof()
   else:
-    rstream.state in {AsyncStreamState.Stopped, Finished, Closed, Error} and
+    (rstream.state != AsyncStreamState.Running) and
       (rstream.buffer.dataLen() == 0)
 
 proc atEof*(wstream: AsyncStreamWriter): bool =
@@ -255,11 +252,11 @@ proc atEof*(wstream: AsyncStreamWriter): bool =
     else:
       wstream.wsource.atEof()
   else:
-    wstream.state in {AsyncStreamState.Stopped, Finished, Closed, Error}
+    (wstream.state != AsyncStreamState.Running)
 
 proc closed*(reader: AsyncStreamReader): bool =
-  ## Returns ``true`` is reading/writing stream is closed.
-  (reader.state == AsyncStreamState.Closed)
+  ## Returns ``true`` is reading/writing stream is closing or closed.
+  (reader.state in {AsyncStreamState.Closing, Closed})
 
 proc finished*(reader: AsyncStreamReader): bool =
   ## Returns ``true`` is reading/writing stream is finished (completed).
@@ -301,8 +298,8 @@ proc failed*(reader: AsyncStreamReader): bool =
     (reader.state == AsyncStreamState.Error)
 
 proc closed*(writer: AsyncStreamWriter): bool =
-  ## Returns ``true`` is reading/writing stream is closed.
-  (writer.state == AsyncStreamState.Closed)
+  ## Returns ``true`` is reading/writing stream is closing or closed.
+  (writer.state in {AsyncStreamState.Closing, Closed})
 
 proc finished*(writer: AsyncStreamWriter): bool =
   ## Returns ``true`` is reading/writing stream is finished (completed).
@@ -965,39 +962,40 @@ proc close*(rw: AsyncStreamRW) =
   ## Close and frees resources of stream ``rw``.
   ##
   ## Note close() procedure is not completed immediately!
-  if rw.closed():
-    raiseAsyncStreamIncorrectDefect("Stream is already closed!")
+  if not(rw.closed()):
+    rw.state = AsyncStreamState.Closing
 
-  rw.state = AsyncStreamState.Closed
+    proc continuation(udata: pointer) {.raises: [Defect].} =
+      if not isNil(rw.udata):
+        GC_unref(cast[ref int](rw.udata))
 
-  proc continuation(udata: pointer) {.raises: [Defect].} =
-    if not isNil(rw.udata):
-      GC_unref(cast[ref int](rw.udata))
-    if not(rw.future.finished()):
-      rw.future.complete()
+      rw.state = AsyncStreamState.Closed
+
+      if not(rw.future.finished()):
+        rw.future.complete()
+      when rw is AsyncStreamReader:
+        untrackAsyncStreamReader(rw)
+      elif rw is AsyncStreamWriter:
+        untrackAsyncStreamWriter(rw)
+
     when rw is AsyncStreamReader:
-      untrackAsyncStreamReader(rw)
+      if isNil(rw.rsource) or isNil(rw.readerLoop) or isNil(rw.future):
+        callSoon(continuation)
+      else:
+        if rw.future.finished():
+          callSoon(continuation)
+        else:
+          rw.future.addCallback(continuation)
+          rw.future.cancel()
     elif rw is AsyncStreamWriter:
-      untrackAsyncStreamWriter(rw)
-
-  when rw is AsyncStreamReader:
-    if isNil(rw.rsource) or isNil(rw.readerLoop) or isNil(rw.future):
-      callSoon(continuation)
-    else:
-      if rw.future.finished():
+      if isNil(rw.wsource) or isNil(rw.writerLoop) or isNil(rw.future):
         callSoon(continuation)
       else:
-        rw.future.addCallback(continuation)
-        rw.future.cancel()
-  elif rw is AsyncStreamWriter:
-    if isNil(rw.wsource) or isNil(rw.writerLoop) or isNil(rw.future):
-      callSoon(continuation)
-    else:
-      if rw.future.finished():
-        callSoon(continuation)
-      else:
-        rw.future.addCallback(continuation)
-        rw.future.cancel()
+        if rw.future.finished():
+          callSoon(continuation)
+        else:
+          rw.future.addCallback(continuation)
+          rw.future.cancel()
 
 proc closeWait*(rw: AsyncStreamRW): Future[void] =
   ## Close and frees resources of stream ``rw``.

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -178,7 +178,7 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async.} =
       # Send `EOF` state to the consumer and wait until it will be received.
       await rstream.buffer.transfer()
       break
-    of AsyncStreamState.Closed:
+    of AsyncStreamState.Closing, AsyncStreamState.Closed:
       break
 
 proc boundedWriteLoop(stream: AsyncStreamWriter) {.async.} =
@@ -232,7 +232,8 @@ proc boundedWriteLoop(stream: AsyncStreamWriter) {.async.} =
         if not(item.future.finished()):
           item.future.fail(error)
       break
-    of AsyncStreamState.Finished, AsyncStreamState.Closed:
+    of AsyncStreamState.Finished, AsyncStreamState.Closing,
+       AsyncStreamState.Closed:
       error = newAsyncStreamUseClosedError()
       break
 

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -110,7 +110,8 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async.} =
       if toRead == 0:
         # When ``rstream.boundSize`` is set and we already readed
         # ``rstream.boundSize`` bytes.
-        rstream.state = AsyncStreamState.Finished
+        if rstream.state == AsyncStreamState.Running:
+          rstream.state = AsyncStreamState.Finished
       else:
         let res = await readUntilBoundary(rstream.rsource, addr buffer[0],
                                           toRead, rstream.boundary)
@@ -123,7 +124,8 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async.} =
               # consumer and declaring stream EOF. Otherwise could not be
               # consumed.
               await upload(addr rstream.buffer, addr buffer[0], length)
-              rstream.state = AsyncStreamState.Finished
+              if rstream.state == AsyncStreamState.Running:
+                rstream.state = AsyncStreamState.Finished
             else:
               rstream.offset = rstream.offset + uint64(res)
               # There should be one step between transferring last bytes to the
@@ -134,10 +136,12 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async.} =
               if (res < toRead) and rstream.rsource.atEof():
                 case rstream.cmpop
                 of BoundCmp.Equal:
-                  rstream.state = AsyncStreamState.Error
-                  rstream.error = newBoundedStreamIncompleteError()
+                  if rstream.state == AsyncStreamState.Running:
+                    rstream.state = AsyncStreamState.Error
+                    rstream.error = newBoundedStreamIncompleteError()
                 of BoundCmp.LessOrEqual:
-                  rstream.state = AsyncStreamState.Finished
+                  if rstream.state == AsyncStreamState.Running:
+                    rstream.state = AsyncStreamState.Finished
           else:
             rstream.offset = rstream.offset + uint64(res)
             # There should be one step between transferring last bytes to the
@@ -148,24 +152,30 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async.} =
             if (res < toRead) and rstream.rsource.atEof():
               case rstream.cmpop
               of BoundCmp.Equal:
-                rstream.state = AsyncStreamState.Error
-                rstream.error = newBoundedStreamIncompleteError()
+                if rstream.state == AsyncStreamState.Running:
+                  rstream.state = AsyncStreamState.Error
+                  rstream.error = newBoundedStreamIncompleteError()
               of BoundCmp.LessOrEqual:
-                rstream.state = AsyncStreamState.Finished
+                if rstream.state == AsyncStreamState.Running:
+                  rstream.state = AsyncStreamState.Finished
         else:
           case rstream.cmpop
           of BoundCmp.Equal:
-            rstream.state = AsyncStreamState.Error
-            rstream.error = newBoundedStreamIncompleteError()
+            if rstream.state == AsyncStreamState.Running:
+              rstream.state = AsyncStreamState.Error
+              rstream.error = newBoundedStreamIncompleteError()
           of BoundCmp.LessOrEqual:
-            rstream.state = AsyncStreamState.Finished
+            if rstream.state == AsyncStreamState.Running:
+              rstream.state = AsyncStreamState.Finished
 
     except AsyncStreamError as exc:
-      rstream.state = AsyncStreamState.Error
-      rstream.error = exc
+      if rstream.state == AsyncStreamState.Running:
+        rstream.state = AsyncStreamState.Error
+        rstream.error = exc
     except CancelledError:
-      rstream.state = AsyncStreamState.Error
-      rstream.error = newAsyncStreamUseClosedError()
+      if rstream.state == AsyncStreamState.Running:
+        rstream.state = AsyncStreamState.Error
+        rstream.error = newAsyncStreamUseClosedError()
 
     case rstream.state
     of AsyncStreamState.Running:
@@ -203,26 +213,32 @@ proc boundedWriteLoop(stream: AsyncStreamWriter) {.async.} =
           wstream.offset = wstream.offset + uint64(item.size)
           item.future.complete()
         else:
-          wstream.state = AsyncStreamState.Error
-          error = newBoundedStreamOverflowError()
+          if wstream.state == AsyncStreamState.Running:
+            wstream.state = AsyncStreamState.Error
+            error = newBoundedStreamOverflowError()
       else:
         if wstream.offset == wstream.boundSize:
-          wstream.state = AsyncStreamState.Finished
-          item.future.complete()
+          if wstream.state == AsyncStreamState.Running:
+            wstream.state = AsyncStreamState.Finished
+            item.future.complete()
         else:
           case wstream.cmpop
           of BoundCmp.Equal:
-            wstream.state = AsyncStreamState.Error
-            error = newBoundedStreamIncompleteError()
+            if wstream.state == AsyncStreamState.Running:
+              wstream.state = AsyncStreamState.Error
+              error = newBoundedStreamIncompleteError()
           of BoundCmp.LessOrEqual:
-            wstream.state = AsyncStreamState.Finished
-            item.future.complete()
+            if wstream.state == AsyncStreamState.Running:
+              wstream.state = AsyncStreamState.Finished
+              item.future.complete()
     except CancelledError:
-      wstream.state = AsyncStreamState.Stopped
-      error = newAsyncStreamUseClosedError()
+      if wstream.state == AsyncStreamState.Running:
+        wstream.state = AsyncStreamState.Stopped
+        error = newAsyncStreamUseClosedError()
     except AsyncStreamError as exc:
-      wstream.state = AsyncStreamState.Error
-      error = exc
+      if wstream.state == AsyncStreamState.Running:
+        wstream.state = AsyncStreamState.Error
+        error = exc
 
     case wstream.state
     of AsyncStreamState.Running:

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -146,10 +146,12 @@ proc tlsWriteRec(engine: ptr SslEngineContext,
     sslEngineSendrecAck(engine, length)
     return TLSResult.Success
   except AsyncStreamError as exc:
-    writer.state = AsyncStreamState.Error
-    writer.error = exc
+    if writer.state == AsyncStreamState.Running:
+      writer.state = AsyncStreamState.Error
+      writer.error = exc
   except CancelledError:
-    writer.state = AsyncStreamState.Stopped
+    if writer.state == AsyncStreamState.Running:
+      writer.state = AsyncStreamState.Stopped
   return TLSResult.Error
 
 proc tlsWriteApp(engine: ptr SslEngineContext,
@@ -180,7 +182,8 @@ proc tlsWriteApp(engine: ptr SslEngineContext,
       item.future.complete()
       return TLSResult.Success
   except CancelledError:
-    writer.state = AsyncStreamState.Stopped
+    if writer.state == AsyncStreamState.Running:
+      writer.state = AsyncStreamState.Stopped
   return TLSResult.Error
 
 proc tlsReadRec(engine: ptr SslEngineContext,
@@ -197,10 +200,12 @@ proc tlsReadRec(engine: ptr SslEngineContext,
     else:
       return TLSResult.Success
   except CancelledError:
-    reader.state = AsyncStreamState.Stopped
+    if reader.state == AsyncStreamState.Running:
+      reader.state = AsyncStreamState.Stopped
   except AsyncStreamError as exc:
-    reader.state = AsyncStreamState.Error
-    reader.error = exc
+    if reader.state == AsyncStreamState.Running:
+      reader.state = AsyncStreamState.Error
+      reader.error = exc
   return TLSResult.Error
 
 proc tlsReadApp(engine: ptr SslEngineContext,
@@ -212,7 +217,8 @@ proc tlsReadApp(engine: ptr SslEngineContext,
     sslEngineRecvappAck(engine, length)
     return TLSResult.Success
   except CancelledError:
-    reader.state = AsyncStreamState.Stopped
+    if reader.state == AsyncStreamState.Running:
+      reader.state = AsyncStreamState.Stopped
   return TLSResult.Error
 
 template readAndReset(fut: untyped) =
@@ -224,11 +230,13 @@ template readAndReset(fut: untyped) =
       continue
     of TLSResult.Error:
       fut = nil
-      loopState = AsyncStreamState.Error
+      if loopState == AsyncStreamState.Running:
+        loopState = AsyncStreamState.Error
       break
     of TLSResult.EOF:
       fut = nil
-      loopState = AsyncStreamState.Finished
+      if loopState == AsyncStreamState.Running:
+        loopState = AsyncStreamState.Finished
       break
 
 proc cancelAndWait*(a, b, c, d: Future[TLSResult]): Future[void] =
@@ -285,7 +293,8 @@ proc tlsLoop*(stream: TLSAsyncStream) {.async.} =
     var state = sslEngineCurrentState(engine)
 
     if (state and SSL_CLOSED) == SSL_CLOSED:
-      loopState = AsyncStreamState.Finished
+      if loopState == AsyncStreamState.Running:
+        loopState = AsyncStreamState.Finished
       break
 
     if isNil(sendRecFut):
@@ -332,7 +341,8 @@ proc tlsLoop*(stream: TLSAsyncStream) {.async.} =
       try:
         discard await one(waiting)
       except CancelledError:
-        loopState = AsyncStreamState.Stopped
+        if loopState == AsyncStreamState.Running:
+          loopState = AsyncStreamState.Stopped
 
     if loopState != AsyncStreamState.Running:
       break

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -8,4 +8,4 @@
 import testmacro, testsync, testsoon, testtime, testfut, testsignal,
        testaddress, testdatagram, teststream, testserver, testbugs, testnet,
        testasyncstream, testhttpserver, testshttpserver, testhttpclient
-import testutils
+import testcancel, testutils

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -6,6 +6,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import testmacro, testsync, testsoon, testtime, testfut, testsignal,
-       testaddress, testdatagram, teststream, testserver, testbugs, testnet,
-       testasyncstream, testhttpserver, testshttpserver, testhttpclient
-import testcancel, testutils
+       testaddress, testdatagram, teststream, testserver, testbugs, testnet
+import testasyncstream
+import testhttpserver, testshttpserver, testhttpclient
+import testcancel
+import testutils

--- a/tests/testcancel.nim
+++ b/tests/testcancel.nim
@@ -1,0 +1,366 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+import unittest2
+import ../chronos
+
+when defined(nimHasUsed): {.used.}
+
+suite "Cancellation test suite":
+  test "cancel() async procedure test":
+    var completed = 0
+
+    proc client1() {.async.} =
+      await sleepAsync(1.seconds)
+      inc(completed)
+
+    proc client2() {.async.} =
+      await client1()
+      inc(completed)
+
+    proc client3() {.async.} =
+      await client2()
+      inc(completed)
+
+    proc client4() {.async.} =
+      await client3()
+      inc(completed)
+
+    var fut = client4()
+    fut.cancel()
+
+    # Future must not be cancelled immediately, because it has many nested
+    # futures.
+    check:
+      not fut.cancelled()
+
+    expect(CancelledError):
+      waitFor fut
+
+    check: completed == 0
+
+  test "cancelAndWait() test":
+    var completed = 0
+
+    proc client1() {.async.} =
+      await sleepAsync(1.seconds)
+      inc(completed)
+
+    proc client2() {.async.} =
+      await client1()
+      inc(completed)
+
+    proc client3() {.async.} =
+      await client2()
+      inc(completed)
+
+    proc client4() {.async.} =
+      await client3()
+      inc(completed)
+
+    var fut = client4()
+    waitFor cancelAndWait(fut)
+    check:
+      fut.cancelled()
+
+  test "Break cancellation propagation test":
+    var completed = 0
+
+    proc client1() {.async.} =
+      await sleepAsync(1.seconds)
+      inc(completed)
+
+    proc client2() {.async.} =
+      try:
+        await client1()
+      except CancelledError:
+        discard
+      inc(completed)
+
+    var fut1 = client2()
+    var fut2 = client2()
+    fut1.cancel()
+    waitFor fut1
+    waitFor cancelAndWait(fut2)
+
+    check:
+      not fut1.cancelled()
+      not fut2.cancelled()
+      completed == 2
+
+  test "Cancellation callback test":
+    var completed = 0
+    var cancelled = 0
+
+    proc client1(duration: Duration): Future[void] =
+      ## Suspends the execution of the current async procedure for the next
+      ## ``duration`` time.
+      var retFuture = newFuture[void]()
+      let moment = Moment.fromNow(duration)
+
+      proc completion(data: pointer) {.gcsafe.} =
+        inc(completed)
+        if not(retFuture.finished()):
+          retFuture.complete()
+
+      proc cancel(udata: pointer) {.gcsafe.} =
+        inc(cancelled)
+        if not(retFuture.finished()):
+          removeTimer(moment, completion, cast[pointer](retFuture))
+
+      retFuture.cancelCallback = cancel
+      discard setTimer(moment, completion, cast[pointer](retFuture))
+      return retFuture
+
+    var fut = client1(100.milliseconds)
+    fut.cancel()
+    waitFor(sleepAsync(500.milliseconds))
+
+    check:
+      fut.cancelled()
+      completed == 0
+      cancelled == 1
+
+  test "Cancellation wait() test":
+    proc testWaitAsync(): Future[bool] {.async.} =
+      var neverFlag1, neverFlag2, neverFlag3: bool
+      var waitProc1, waitProc2: bool
+      proc neverEndingProc(): Future[void] =
+        var res = newFuture[void]()
+        proc continuation(udata: pointer) {.gcsafe.} =
+          neverFlag2 = true
+        proc cancellation(udata: pointer) {.gcsafe.} =
+          neverFlag3 = true
+        res.addCallback(continuation)
+        res.cancelCallback = cancellation
+        result = res
+        neverFlag1 = true
+
+      proc waitProc() {.async.} =
+        try:
+          await wait(neverEndingProc(), 100.milliseconds)
+        except CancelledError:
+          waitProc1 = true
+        finally:
+          waitProc2 = true
+
+      var fut = waitProc()
+      await cancelAndWait(fut)
+      return (fut.state == FutureState.Finished) and
+             neverFlag1 and neverFlag2 and neverFlag3 and
+             waitProc1 and waitProc2
+
+    check: waitFor(testWaitAsync())
+
+  test "Cancellation withTimeout() test":
+    proc testWithTimeoutAsync(): Future[bool] {.async.} =
+      var neverFlag1, neverFlag2, neverFlag3: bool
+      var waitProc1, waitProc2: bool
+      proc neverEndingProc(): Future[void] =
+        var res = newFuture[void]()
+        proc continuation(udata: pointer) {.gcsafe.} =
+          neverFlag2 = true
+        proc cancellation(udata: pointer) {.gcsafe.} =
+          neverFlag3 = true
+        res.addCallback(continuation)
+        res.cancelCallback = cancellation
+        result = res
+        neverFlag1 = true
+
+      proc withTimeoutProc() {.async.} =
+        try:
+          discard await withTimeout(neverEndingProc(), 100.milliseconds)
+          doAssert(false)
+        except CancelledError:
+          waitProc1 = true
+        finally:
+          waitProc2 = true
+
+      var fut = withTimeoutProc()
+      await cancelAndWait(fut)
+      result = (fut.state == FutureState.Finished) and
+               neverFlag1 and neverFlag2 and neverFlag3 and
+               waitProc1 and waitProc2
+    check: waitFor(testWithTimeoutAsync())
+
+  test "Cancellation race test":
+    proc testCancellationRaceAsync() {.async.} =
+
+      proc raceProc1(someFut: Future[void]) {.async.} =
+        await someFut
+
+      proc raceProc2(someFut: Future[void], otherFut: Future[void]) {.async.} =
+        await someFut
+        await otherFut
+
+      proc raceProc3(someFut: Future[void],
+                     otherFut: Future[void]): Future[int] {.async.} =
+        try:
+          await someFut
+        except ValueError:
+          return 1
+        except CancelledError:
+          return 2
+        try:
+          await otherFut
+        except ValueError:
+          return 3
+        except CancelledError:
+          return 4
+        return 5
+
+      proc getOrDefault(future: Future[int], default: int = -1): int =
+        if future.done():
+          future.read()
+        else:
+          default
+
+      # Ancestor Future is already completed before cancellation.
+      let res1 =
+        block:
+          var someFut = newFuture[void]()
+          var raceFut = raceProc1(someFut)
+          someFut.complete()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state)
+
+      # Ancestor Future is already failed before cancellation.
+      let res2 =
+        block:
+          var someFut = newFuture[void]()
+          var raceFut = raceProc1(someFut)
+          someFut.fail(newException(ValueError, ""))
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state)
+
+      # Ancestor Future is already cancelled before cancellation.
+      let res3 =
+        block:
+          var someFut = newFuture[void]()
+          var raceFut = raceProc1(someFut)
+          someFut.cancel()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state)
+
+      # Ancestor Future is pending before cancellation.
+      let res4 =
+        block:
+          var someFut = newFuture[void]()
+          var raceFut = raceProc1(someFut)
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state)
+
+      # Ancestor Future is completed before cancellation and other Future is
+      # not yet started. Because raceProc2() do not have any `try/except` it
+      # will become `Cancelled` too, while `otherFut` which is not executed yet
+      # and must be `Pending`.
+      let res5 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc2(someFut, otherFut)
+          someFut.complete()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state)
+
+      # Ancestor Future is failed before cancellation and other Future is not
+      # yet started. Because `raceProc2` do not have any `try/except` it
+      # will fail to and become `Failed`, while `otherFut` is not executed yet
+      # and must be `Pending`.
+      let res6 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc2(someFut, otherFut)
+          someFut.fail(newException(ValueError, ""))
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state)
+
+      # Ancestor Future is cancelled before cancellation and other Future is not
+      # yet started. Because `raceProc2` do not have any `try/except` it
+      # will become `Cancelled`, while `otherFut` is not executed yet and must
+      # be `Pending`.
+      let res7 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc2(someFut, otherFut)
+          someFut.cancel()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state)
+
+      # Ancestor Future is pending before cancellation. Other Future is not
+      # yet started. Because `raceProc2` do not have any `try/except` it
+      # will become `Cancelled`, while `otherFut` is not executed yet and must
+      # be `Pending`.
+      let res8 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc2(someFut, otherFut)
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state)
+
+      let res9 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc3(someFut, otherFut)
+          someFut.complete()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+
+      let res10 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc3(someFut, otherFut)
+          someFut.fail(newException(ValueError, ""))
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+
+      let res11 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc3(someFut, otherFut)
+          someFut.cancel()
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+
+      let res12 =
+        block:
+          var someFut = newFuture[void]()
+          var otherFut = newFuture[void]()
+          var raceFut = raceProc3(someFut, otherFut)
+          await cancelAndWait(raceFut)
+          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+
+      check:
+        res1 == (FutureState.Finished, FutureState.Finished)
+        res2 == (FutureState.Failed, FutureState.Failed)
+        res3 == (FutureState.Cancelled, FutureState.Cancelled)
+        res4 == (FutureState.Cancelled, FutureState.Cancelled)
+        res5 == (FutureState.Cancelled, FutureState.Finished,
+                 FutureState.Pending)
+        res6 == (FutureState.Failed, FutureState.Failed,
+                 FutureState.Pending)
+        res7 == (FutureState.Cancelled, FutureState.Cancelled,
+                 FutureState.Pending)
+        res8 == (FutureState.Cancelled, FutureState.Cancelled,
+                 FutureState.Pending)
+        res9 == (FutureState.Finished, FutureState.Finished,
+                 FutureState.Pending, 4)
+        res10 == (FutureState.Finished, FutureState.Failed,
+                  FutureState.Pending, 1)
+        res11 == (FutureState.Finished, FutureState.Cancelled,
+                  FutureState.Pending, 2)
+        res12 == (FutureState.Finished, FutureState.Cancelled,
+                  FutureState.Pending, 2)
+
+    waitFor(testCancellationRaceAsync())

--- a/tests/testcancel.nim
+++ b/tests/testcancel.nim
@@ -266,7 +266,9 @@ suite "Cancellation test suite":
           var raceFut = raceProc2(someFut, otherFut)
           someFut.complete()
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state)
+          let res = (raceFut.state, someFut.state, otherFut.state)
+          await cancelAndWait(otherFut)
+          res
 
       # Ancestor Future is failed before cancellation and other Future is not
       # yet started. Because `raceProc2` do not have any `try/except` it
@@ -279,7 +281,9 @@ suite "Cancellation test suite":
           var raceFut = raceProc2(someFut, otherFut)
           someFut.fail(newException(ValueError, ""))
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state)
+          let res = (raceFut.state, someFut.state, otherFut.state)
+          await cancelAndWait(otherFut)
+          res
 
       # Ancestor Future is cancelled before cancellation and other Future is not
       # yet started. Because `raceProc2` do not have any `try/except` it
@@ -292,7 +296,9 @@ suite "Cancellation test suite":
           var raceFut = raceProc2(someFut, otherFut)
           someFut.cancel()
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state)
+          let res = (raceFut.state, someFut.state, otherFut.state)
+          await cancelAndWait(otherFut)
+          res
 
       # Ancestor Future is pending before cancellation. Other Future is not
       # yet started. Because `raceProc2` do not have any `try/except` it
@@ -304,7 +310,9 @@ suite "Cancellation test suite":
           var otherFut = newFuture[void]()
           var raceFut = raceProc2(someFut, otherFut)
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state)
+          let res = (raceFut.state, someFut.state, otherFut.state)
+          await cancelAndWait(otherFut)
+          res
 
       let res9 =
         block:
@@ -313,7 +321,10 @@ suite "Cancellation test suite":
           var raceFut = raceProc3(someFut, otherFut)
           someFut.complete()
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+          let res = (raceFut.state, someFut.state, otherFut.state,
+                     raceFut.getOrDefault())
+          await cancelAndWait(otherFut)
+          res
 
       let res10 =
         block:
@@ -322,7 +333,10 @@ suite "Cancellation test suite":
           var raceFut = raceProc3(someFut, otherFut)
           someFut.fail(newException(ValueError, ""))
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+          let res = (raceFut.state, someFut.state, otherFut.state,
+                     raceFut.getOrDefault())
+          await cancelAndWait(otherFut)
+          res
 
       let res11 =
         block:
@@ -331,7 +345,10 @@ suite "Cancellation test suite":
           var raceFut = raceProc3(someFut, otherFut)
           someFut.cancel()
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+          let res = (raceFut.state, someFut.state, otherFut.state,
+                     raceFut.getOrDefault())
+          await cancelAndWait(otherFut)
+          res
 
       let res12 =
         block:
@@ -339,7 +356,10 @@ suite "Cancellation test suite":
           var otherFut = newFuture[void]()
           var raceFut = raceProc3(someFut, otherFut)
           await cancelAndWait(raceFut)
-          (raceFut.state, someFut.state, otherFut.state, raceFut.getOrDefault())
+          let res = (raceFut.state, someFut.state, otherFut.state,
+                     raceFut.getOrDefault())
+          await cancelAndWait(otherFut)
+          res
 
       check:
         res1 == (FutureState.Finished, FutureState.Finished)

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -856,8 +856,19 @@ suite "HTTP server testing suite":
       check toString(table) == vector[2]
 
   test "Leaks test":
+    proc getTrackerLeaks(trackerName: string): bool =
+      let tracker = getTracker(trackerName)
+      if isNil(tracker):
+        false
+      else:
+        if tracker.isLeaked():
+          echo tracker.dump()
+          true
+        else:
+          false
+
     check:
-      getTracker("async.stream.reader").isLeaked() == false
-      getTracker("async.stream.writer").isLeaked() == false
-      getTracker("stream.server").isLeaked() == false
-      getTracker("stream.transport").isLeaked() == false
+      getTrackerLeaks("async.stream.reader") == false
+      getTrackerLeaks("async.stream.writer") == false
+      getTrackerLeaks("stream.server") == false
+      getTrackerLeaks("stream.transport") == false


### PR DESCRIPTION
* Add tests for this new behavior.
* Move cancellation tests from `testfut.nim` to `testcancel.nim`.
* Fix cancellation tests to follow new behavior.
* Fix HTTP server to follow new cancellation behavior.
* Add one more HTTP client test.