### PR TITLE
Add ServerFlag to control dualstack behaviour

### DIFF
--- a/chronos/handles.nim
+++ b/chronos/handles.nim
@@ -25,6 +25,8 @@ when defined(windows):
     ERROR_PIPE_CONNECTED = 535
     ERROR_PIPE_BUSY = 231
     pipeHeaderName = r"\\.\pipe\chronos\"
+  var IPV6_V6ONLY* {.importc, nodecl, header: "<ws2tcpip.h>".}: cint
+  var IPPROTO_IPV6* {.importc, nodecl.}: cint
 
   proc connectNamedPipe(hNamedPipe: Handle, lpOverlapped: pointer): WINBOOL
        {.importc: "ConnectNamedPipe", stdcall, dynlib: "kernel32".}
@@ -34,6 +36,8 @@ else:
     asyncInvalidSocket* = AsyncFD(posix.INVALID_SOCKET)
     TCP_NODELAY* = 1
     IPPROTO_TCP* = 6
+  var IPV6_V6ONLY* = posix.IPV6_V6ONLY
+  var IPPROTO_IPV6* = posix.IPPROTO_IPV6
 
 const
   asyncInvalidPipe* = asyncInvalidSocket

--- a/chronos/handles.nim
+++ b/chronos/handles.nim
@@ -25,8 +25,8 @@ when defined(windows):
     ERROR_PIPE_CONNECTED = 535
     ERROR_PIPE_BUSY = 231
     pipeHeaderName = r"\\.\pipe\chronos\"
-  var IPV6_V6ONLY* {.importc, nodecl, header: "<ws2tcpip.h>".}: cint
-  var IPPROTO_IPV6* {.importc, nodecl.}: cint
+    IPV6_V6ONLY* = 27
+    IPPROTO_IPV6* = 41
 
   proc connectNamedPipe(hNamedPipe: Handle, lpOverlapped: pointer): WINBOOL
        {.importc: "ConnectNamedPipe", stdcall, dynlib: "kernel32".}
@@ -36,8 +36,8 @@ else:
     asyncInvalidSocket* = AsyncFD(posix.INVALID_SOCKET)
     TCP_NODELAY* = 1
     IPPROTO_TCP* = 6
-  var IPV6_V6ONLY* = posix.IPV6_V6ONLY
-  var IPPROTO_IPV6* = posix.IPPROTO_IPV6
+    IPV6_V6ONLY* = posix.IPV6_V6ONLY
+    IPPROTO_IPV6* = posix.IPPROTO_IPV6
 
 const
   asyncInvalidPipe* = asyncInvalidSocket

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -28,7 +28,7 @@ type
   ServerFlags* = enum
     ## Server's flags
     ReuseAddr, ReusePort, TcpNoDelay, NoAutoRead, GCUserData, FirstPipe,
-    NoPipeFlash, Broadcast
+    NoPipeFlash, Broadcast, Dualstack, NoDualstack
 
   AddressFamily* {.pure.} = enum
     None, IPv4, IPv6, Unix


### PR DESCRIPTION
This adds two new server flags, `ServerFlag.Dualstack`  and `ServerFlag.NoDualstack`. When used with `::` as the bind address, this will allow to choose if the server should be dualstack or IPv6 only. If neither is set, the OS default behaviour will be used.

Should I add tests for this? It depends on IPv6 support, so not sure whether you want that failing when IPv6 is not available.