### PR TITLE
make `libbacktrace` a proper dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,5 +153,4 @@ jobs:
         working-directory: nim-chronos
         run: |
           nimble install -y --depsOnly
-          nimble install -y libbacktrace
           nimble test

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -11,6 +11,7 @@ requires "nim > 1.2.0",
          "stew",
          "bearssl",
          "httputils",
+         "libbacktrace",
          "https://github.com/status-im/nim-unittest2.git#head"
 
 task test, "Run all tests":


### PR DESCRIPTION
This is why `chronos` was failing on Nim's CI — this change is needed for us to be able to test it and ensure that it keeps working both with Nim 1.2.x and Nim 1.6.x