### PR TITLE
CI: separate libbacktrace test in its own task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,4 @@ jobs:
           nimble install -y --depsOnly
           nimble install -y libbacktrace
           nimble test
+          nimble test_libbacktrace

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -13,10 +13,10 @@ requires "nim > 1.2.0",
          "httputils",
          "https://github.com/status-im/nim-unittest2.git#head"
 
+var commandStart = "nim c -r --hints:off --verbosity:0 --skipParentCfg:on --warning[ObservableStores]:off"
+
 task test, "Run all tests":
-  var
-    commandStart = "nim c -r --hints:off --verbosity:0 --skipParentCfg:on --warning[ObservableStores]:off"
-    commands = @[
+  var commands = @[
       commandStart & " -d:useSysAssert -d:useGcAssert tests/",
       commandStart & " -d:chronosStackTrace -d:chronosStrictException tests/",
       commandStart & " -d:release tests/",
@@ -33,3 +33,14 @@ task test, "Run all tests":
       exec curcmd
       rmFile "tests/" & testname
 
+task test_libbacktrace, "test with libbacktrace":
+  var commands = @[
+      commandStart & " -d:release --debugger:native -d:chronosStackTrace -d:nimStackTraceOverride --import:libbacktrace tests/",
+    ]
+
+  for testname in ["testall"]:
+    for cmd in commands:
+      let curcmd = cmd & testname
+      echo "\n" & curcmd
+      exec curcmd
+      rmFile "tests/" & testname


### PR DESCRIPTION
This is an alternative to https://github.com/status-im/nim-chronos/pull/230