### PR TITLE
Improve ram usage

### DIFF
--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -417,6 +417,8 @@ proc futureContinue*[T](fut: Future[T]) {.gcsafe, raises: [Defect].} =
         if fut.closure.finished():
           break
 
+      if fut.closure.finished():
+        fut.closure = nil
       if next == nil:
         if not(fut.finished()):
           raiseAssert "Async procedure (" & ($fut.location[LocCreateIndex]) & ") yielded `nil`, " &

--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -419,10 +419,8 @@ proc futureContinue*[T](fut: Future[T]) {.gcsafe, raises: [Defect].} =
 
       if next == nil:
         if not(fut.finished()):
-          # Can't get strName anymore
-          const msg = "Async procedure yielded `nil`, " &
+          raiseAssert "Async procedure (" & ($fut.location[LocCreateIndex]) & ") yielded `nil`, " &
                       "are you await'ing a `nil` Future?"
-          raiseAssert msg
       else:
         GC_ref(fut)
         next.addCallback(internalContinue[T], cast[pointer](fut))

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -15,92 +15,6 @@ proc skipUntilStmtList(node: NimNode): NimNode {.compileTime.} =
   if node[0].kind == nnkStmtList:
     result = skipUntilStmtList(node[0])
 
-# proc skipStmtList(node: NimNode): NimNode {.compileTime.} =
-#   result = node
-#   if node[0].kind == nnkStmtList:
-#     result = node[0]
-when defined(chronosStrictException):
-  template createCb(retFutureSym, iteratorNameSym,
-                    strName, identName, futureVarCompletions: untyped) =
-    bind finished
-
-    var nameIterVar = iteratorNameSym
-    {.push stackTrace: off.}
-    var identName: proc(udata: pointer) {.gcsafe, raises: [Defect].}
-    identName = proc(udata: pointer) {.gcsafe, raises: [Defect].} =
-      try:
-        # If the compiler complains about unlisted exception here, it's usually
-        # because you're calling a callback or forward declaration in your code
-        # for which the compiler cannot deduce raises signatures - make sure
-        # to annotate both forward declarations and `proc` types with `raises`!
-        if not(nameIterVar.finished()):
-          var next = nameIterVar()
-          # Continue while the yielded future is already finished.
-          while (not next.isNil()) and next.finished():
-            next = nameIterVar()
-            if nameIterVar.finished():
-              break
-
-          if next == nil:
-            if not(retFutureSym.finished()):
-              const msg = "Async procedure (&" & strName & ") yielded `nil`, " &
-                          "are you await'ing a `nil` Future?"
-              raiseAssert msg
-          else:
-            next.addCallback(identName)
-      except CancelledError:
-        retFutureSym.cancelAndSchedule()
-      except CatchableError as exc:
-        futureVarCompletions
-        retFutureSym.fail(exc)
-
-    identName(nil)
-    {.pop.}
-else:
-  template createCb(retFutureSym, iteratorNameSym,
-                    strName, identName, futureVarCompletions: untyped) =
-    bind finished
-
-    var nameIterVar = iteratorNameSym
-    {.push stackTrace: off.}
-    var identName: proc(udata: pointer) {.gcsafe, raises: [Defect].}
-    identName = proc(udata: pointer) {.gcsafe, raises: [Defect].} =
-      try:
-        # If the compiler complains about unlisted exception here, it's usually
-        # because you're calling a callback or forward declaration in your code
-        # for which the compiler cannot deduce raises signatures - make sure
-        # to annotate both forward declarations and `proc` types with `raises`!
-        if not(nameIterVar.finished()):
-          var next = nameIterVar()
-          # Continue while the yielded future is already finished.
-          while (not next.isNil()) and next.finished():
-            next = nameIterVar()
-            if nameIterVar.finished():
-              break
-
-          if next == nil:
-            if not(retFutureSym.finished()):
-              const msg = "Async procedure (&" & strName & ") yielded `nil`, " &
-                          "are you await'ing a `nil` Future?"
-              raiseAssert msg
-          else:
-            next.addCallback(identName)
-      except CancelledError:
-        retFutureSym.cancelAndSchedule()
-      except CatchableError as exc:
-        futureVarCompletions
-        retFutureSym.fail(exc)
-      except Exception as exc:
-        # TODO remove Exception handler to turn on strict mode
-        if exc of Defect:
-          raise (ref Defect)(exc)
-
-        futureVarCompletions
-        retFutureSym.fail((ref ValueError)(msg: exc.msg, parent: exc))
-
-    identName(nil)
-    {.pop.}
-
 proc createFutureVarCompletions(futureVarIdents: seq[NimNode],
     fromNode: NimNode): NimNode {.compileTime.} =
   result = newNimNode(nnkStmtList, fromNode)
@@ -221,31 +135,16 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 
   var outerProcBody = newNimNode(nnkStmtList, prc.body)
 
-  # -> var retFuture = newFuture[T]()
-  var retFutureSym = ident "chronosInternalRetFuture"
-  var subRetType =
-    if returnType.kind == nnkEmpty:
-      newIdentNode("void")
-    else:
-      baseType
-  # Do not change this code to `quote do` version because `instantiationInfo`
-  # will be broken for `newFuture()` call.
-  outerProcBody.add(
-    newVarStmt(
-      retFutureSym,
-      newCall(newTree(nnkBracketExpr, ident "newFuture", subRetType),
-              newLit(prcName))
-    )
-  )
 
-  # -> iterator nameIter(): FutureBase {.closure.} =
+  # -> iterator nameIter(chronosInternalRetFuture: Future[T]): FutureBase {.closure.} =
   # ->   {.push warning[resultshadowed]: off.}
   # ->   var result: T
   # ->   {.pop.}
   # ->   <proc_body>
   # ->   complete(retFuture, result)
+  let internalFutureSym = ident "chronosInternalRetFuture"
   var iteratorNameSym = genSym(nskIterator, $prcName)
-  var procBody = prc.body.processBody(retFutureSym, subtypeIsVoid,
+  var procBody = prc.body.processBody(internalFutureSym, subtypeIsVoid,
                                       futureVarIdents)
   # don't do anything with forward bodies (empty)
   if procBody.kind != nnkEmpty:
@@ -275,12 +174,18 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 
       procBody.add(
         newCall(newIdentNode("complete"),
-          retFutureSym, newIdentNode("result"))) # -> complete(retFuture, result)
+          internalFutureSym, newIdentNode("result"))) # -> complete(retFuture, result)
     else:
       # -> complete(retFuture)
-      procBody.add(newCall(newIdentNode("complete"), retFutureSym))
+      procBody.add(newCall(newIdentNode("complete"), internalFutureSym))
 
-    var closureIterator = newProc(iteratorNameSym, [newIdentNode("FutureBase")],
+    let
+      internalFutureType =
+        if subtypeIsVoid:
+          newNimNode(nnkBracketExpr, prc).add(newIdentNode("Future")).add(newIdentNode("void"))
+        else: returnType
+      internalFutureParameter = nnkIdentDefs.newTree(internalFutureSym, internalFutureType, newEmptyNode())
+    var closureIterator = newProc(iteratorNameSym, [newIdentNode("FutureBase"), internalFutureParameter],
                                   procBody, nnkIteratorDef)
     closureIterator.pragma = newNimNode(nnkPragma, lineInfoFrom=prc.body)
     closureIterator.addPragma(newIdentNode("closure"))
@@ -323,17 +228,38 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
       closureIterator.addPragma(newIdentNode("gcsafe"))
     outerProcBody.add(closureIterator)
 
-    # -> createCb(retFuture)
-    # NOTE: The "_continue" suffix is checked for in asyncfutures.nim to produce
-    # friendlier stack traces:
-    var cbName = genSym(nskVar, prcName & "_continue")
-    var procCb = getAst createCb(retFutureSym, iteratorNameSym,
-                         newStrLitNode(prcName),
-                         cbName,
-                         createFutureVarCompletions(futureVarIdents, nil))
-    outerProcBody.add procCb
+    # -> var resultFuture = newFuture[T]()
+    # declared at the end to be sure that the closure
+    # doesn't reference it, avoid cyclic ref (#203)
+    var retFutureSym = ident "resultFuture"
+    var subRetType =
+      if returnType.kind == nnkEmpty:
+        newIdentNode("void")
+      else:
+        baseType
+    # Do not change this code to `quote do` version because `instantiationInfo`
+    # will be broken for `newFuture()` call.
+    outerProcBody.add(
+      newVarStmt(
+        retFutureSym,
+        newCall(newTree(nnkBracketExpr, ident "newFuture", subRetType),
+                newLit(prcName))
+      )
+    )
+ 
+    # -> resultFuture.closure = iterator
+    outerProcBody.add(
+       newAssignment(
+        newDotExpr(retFutureSym, newIdentNode("closure")),
+        iteratorNameSym)
+    )
 
-    # -> return retFuture
+    # -> futureContinue(resultFuture))
+    outerProcBody.add(
+        newCall(newIdentNode("futureContinue"), retFutureSym)
+    )
+
+    # -> return resultFuture
     outerProcBody.add newNimNode(nnkReturnStmt, prc.body[^1]).add(retFutureSym)
 
   if prc.kind != nnkLambda: # TODO: Nim bug?
@@ -361,8 +287,9 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 template await*[T](f: Future[T]): untyped =
   when declared(chronosInternalRetFuture):
     when not declaredInScope(chronosInternalTmpFuture):
-      var chronosInternalTmpFuture {.inject.}: FutureBase
-    chronosInternalTmpFuture = f
+      var chronosInternalTmpFuture {.inject.}: FutureBase = f
+    else:
+      chronosInternalTmpFuture = f
     chronosInternalRetFuture.child = chronosInternalTmpFuture
 
     # This "yield" is meant for a closure iterator in the caller.
@@ -389,8 +316,9 @@ template await*[T](f: Future[T]): untyped =
 template awaitne*[T](f: Future[T]): Future[T] =
   when declared(chronosInternalRetFuture):
     when not declaredInScope(chronosInternalTmpFuture):
-      var chronosInternalTmpFuture {.inject.}: FutureBase
-    chronosInternalTmpFuture = f
+      var chronosInternalTmpFuture {.inject.}: FutureBase = f
+    else:
+      chronosInternalTmpFuture = f
     chronosInternalRetFuture.child = chronosInternalTmpFuture
     yield chronosInternalTmpFuture
     chronosInternalRetFuture.child = nil

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -141,7 +141,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
   # ->   var result: T
   # ->   {.pop.}
   # ->   <proc_body>
-  # ->   complete(retFuture, result)
+  # ->   complete(chronosInternalRetFuture, result)
   let internalFutureSym = ident "chronosInternalRetFuture"
   var iteratorNameSym = genSym(nskIterator, $prcName)
   var procBody = prc.body.processBody(internalFutureSym, subtypeIsVoid,
@@ -174,9 +174,9 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 
       procBody.add(
         newCall(newIdentNode("complete"),
-          internalFutureSym, newIdentNode("result"))) # -> complete(retFuture, result)
+          internalFutureSym, newIdentNode("result"))) # -> complete(chronosInternalRetFuture, result)
     else:
-      # -> complete(retFuture)
+      # -> complete(chronosInternalRetFuture)
       procBody.add(newCall(newIdentNode("complete"), internalFutureSym))
 
     let

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -286,6 +286,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 
 template await*[T](f: Future[T]): untyped =
   when declared(chronosInternalRetFuture):
+    #work around https://github.com/nim-lang/Nim/issues/19193
     when not declaredInScope(chronosInternalTmpFuture):
       var chronosInternalTmpFuture {.inject.}: FutureBase = f
     else:
@@ -315,6 +316,7 @@ template await*[T](f: Future[T]): untyped =
 
 template awaitne*[T](f: Future[T]): Future[T] =
   when declared(chronosInternalRetFuture):
+    #work around https://github.com/nim-lang/Nim/issues/19193
     when not declaredInScope(chronosInternalTmpFuture):
       var chronosInternalTmpFuture {.inject.}: FutureBase = f
     else:


### PR DESCRIPTION
This PR modifies the async flow to improve RAM usage of async transformation.
Results, about half of ram consumption in nimbus:
![image](https://user-images.githubusercontent.com/13471753/143567724-741f92ee-e4ab-41c4-922f-c778501162c8.png)

(obviously, the RSS being sentient and having is own mind, it isn't divided by two, but actual consumption is)

## How
The main goal is to rely as little as possible on mark & sweep, and rely instead on reference counting.
Reference counting fails on cyclic references, and also in other cases: https://github.com/nim-lang/Nim/issues/19193

So first step, add a workaround in `await` to avoid 19193.

Second step, more tricky, avoid cyclic reference of the closure/iterator.

Before this PR:
```nim
proc testInner(): Future[seq[int]] {.stackTrace: off, gcsafe.} =
  var chronosInternalRetFuture = newFuture[seq[int]]("testInner")
  iterator testInner_436207618(): FutureBase {.closure, gcsafe,
      raises: [Defect, CatchableError, Exception].} =
    {.push, warning[resultshadowed]: off.}
    var result: seq[int]
    {.pop.}
    block:
      var innerVal = newSeq[int](1000000)
      complete(chronosInternalRetFuture, newSeq[int](1000000))
      return nil
    complete(chronosInternalRetFuture, result)

  bind finished
  var nameIterVar`gensym0 = testInner_436207618
  {.push, stackTrace: off.}
  var testInner_continue_436207619: proc (udata`gensym0: pointer) {.gcsafe,
      raises: [Defect].}
  testInner_continue_436207619 = proc (udata`gensym0: pointer) {.gcsafe,
      raises: [Defect].} =
    try:
      if not (nameIterVar`gensym0.finished()):
        var next`gensym0 = nameIterVar`gensym0()
        while (not next`gensym0.isNil()) and next`gensym0.finished():
          next`gensym0 = nameIterVar`gensym0()
          if nameIterVar`gensym0.finished():
            break
        if next`gensym0 == nil:
          if not (chronosInternalRetFuture.finished()):
            const
              msg`gensym0 = "Async procedure (&" & "testInner" &
                  ") yielded `nil`, " &
                  "are you await\'ing a `nil` Future?"
            raiseAssert msg`gensym0
        else:
          next`gensym0.addCallback(testInner_continue_436207619)
    except CancelledError:
      chronosInternalRetFuture.cancelAndSchedule()
    except CatchableError as exc`gensym0:
      chronosInternalRetFuture.fail(exc`gensym0)
    except Exception as exc`gensym0:
      if exc`gensym0 of Defect:
        raise (ref Defect)(exc`gensym0)
      chronosInternalRetFuture.fail((ref ValueError)(msg: exc`gensym0.msg,
          parent: exc`gensym0))
  testInner_continue_436207619(nil)
  {.pop.}
  return chronosInternalRetFuture
```

A closure iterator and a _continue proc is generated inside the main proc.
Everything has a reference to everything: the closure, the continue, and the Future, which is bad.

After this PR:
```nim
proc testInner(): Future[seq[int]] {.stackTrace: off, gcsafe.} =
  iterator testInner_436207618(chronosInternalRetFuture: Future[seq[int]]): FutureBase {.
      closure, gcsafe, raises: [Defect, CatchableError, Exception].} =
    {.push, warning[resultshadowed]: off.}
    var result: seq[int]
    {.pop.}
    block:
      var innerVal = newSeq[int](1000000)
      complete(chronosInternalRetFuture, newSeq[int](1000000))
      return nil
    complete(chronosInternalRetFuture, result)

  var resultFuture = newFuture[seq[int]]("testInner")
  resultFuture.closure = testInner_436207618
  futureContinue(resultFuture)
  return resultFuture
```

The future is generated at the last minute to be sure that no one has a reference to it.
The "continue" is extracted somewhere else, and doesn't rely on closure environement (@stefantalpalaru I guess it broke stacktraces, could use a hand here)

The future is in charge of holding a reference to the closure, no one else. It means the closure can be freed easily when no longer needed, and no weird cycle here.
So, the iterator needs to take the future as argument. And we need to be very careful not to store it in the closure environment, or we're back to a cyclic ref. Maybe we can block it in some way? Not sure


For reference, here is the `futureContinue`:
```nim
{.push stackTrace: off.}
proc futureContinue*[T](fut: Future[T]) {.gcsafe, raises: [Defect].} =
  # Used internally by async transformation
  try:
    if not(fut.closure.finished()):
      var next = fut.closure(fut)
      # Continue while the yielded future is already finished.
      while (not next.isNil()) and next.finished():
        next = fut.closure(fut)
        if fut.closure.finished():
          break

      if next == nil:
        if not(fut.finished()):
          # Can't get strName anymore
          const msg = "Async procedure yielded `nil`, " &
                      "are you await'ing a `nil` Future?"
          raiseAssert msg
      else:
        next.addCallback(proc (arg: pointer) {.gcsafe, raises: [Defect].} =
          futureContinue(fut))
  except CancelledError:
    fut.cancelAndSchedule()
  except CatchableError as exc:
    fut.fail(exc)
  except Exception as exc:
    if exc of Defect:
      raise (ref Defect)(exc)

    fut.fail((ref ValueError)(msg: exc.msg, parent: exc))
{.pop.}
```

The addCallback relies on a new closure, which is unfortunate, but passing the `fut` as `addCallback` argument doesn't work: `addCallback` except a pointer, so it's not counted for GC, and everything breaks.


My test for this is:
```nim
proc testInner(): Future[seq[int]] {.async.} =
  var innerVal = newSeq[int](1000000)
  return newSeq[int](1000000)

proc testOuter() {.async.} =
  for itera in 0..<10000:
    discard await testInner()

GC_disableMarkAndSweep() # disable cycle collection, leave non cycle collection on

waitFor(testOuter())
```
With master it crashes, with this branch, it takes a bit of memory but eventually works

It's is better than the test in the original issue, because it allocates memory both in the return value, and in the iterator.
But it's not very CI-able, so not sure how to test this automatically