### PR TITLE
posix: fast path for write

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,5 +1,5 @@
 packageName   = "chronos"
-version       = "3.0.9"
+version       = "3.0.10"
 author        = "Status Research & Development GmbH"
 description   = "Chronos"
 license       = "Apache License 2.0 or MIT"

--- a/chronos/sendfile.nim
+++ b/chronos/sendfile.nim
@@ -29,7 +29,8 @@ when defined(nimdoc):
     ##
     ## ``count`` is the number of bytes to copy between the file descriptors.
     ## On exit ``count`` will hold number of bytes actually transferred between
-    ## file descriptors.
+    ## file descriptors. May be >0 even in the case of error return, if some
+    ## bytes were sent before the error occurred.
     ##
     ## If the transfer was successful, the number of bytes written to ``outfd``
     ## is stored in ``count``, and ``0`` returned. Note that a successful call
@@ -45,10 +46,13 @@ when defined(linux) or defined(android):
 
   proc sendfile*(outfd, infd: int, offset: int, count: var int): int =
     var o = offset
-    result = osSendFile(cint(outfd), cint(infd), addr o, count)
-    if result >= 0:
-      count = result
-      result = 0
+    let res = osSendFile(cint(outfd), cint(infd), addr o, count)
+    if res >= 0:
+      count = res
+      0
+    else:
+      count = 0
+      -1
 
 elif defined(freebsd) or defined(openbsd) or defined(netbsd) or
      defined(dragonflybsd):
@@ -69,18 +73,17 @@ elif defined(freebsd) or defined(openbsd) or defined(netbsd) or
 
   proc sendfile*(outfd, infd: int, offset: int, count: var int): int =
     var o = 0'u
-    result = osSendFile(cint(infd), cint(outfd), uint(offset), uint(count), nil,
+    let res = osSendFile(cint(infd), cint(outfd), uint(offset), uint(count), nil,
                         addr o, 0)
-    if result >= 0:
+    if res >= 0:
       count = int(o)
-      result = 0
+      0
     else:
       let err = osLastError()
-      if int(err) == EAGAIN:
-        count = int(o)
-        result = 0
-      else:
-        result = -1
+      count =
+        if int(err) == EAGAIN: int(o)
+        else: 0
+      -1
 
 elif defined(macosx):
   import posix, os
@@ -100,14 +103,13 @@ elif defined(macosx):
 
   proc sendfile*(outfd, infd: int, offset: int, count: var int): int =
     var o = count
-    result = osSendFile(cint(infd), cint(outfd), offset, addr o, nil, 0)
-    if result >= 0:
+    let res = osSendFile(cint(infd), cint(outfd), offset, addr o, nil, 0)
+    if res >= 0:
       count = int(o)
-      result = 0
+      0
     else:
       let err = osLastError()
-      if int(err) == EAGAIN:
-        count = int(o)
-        result = 0
-      else:
-        result = -1
+      count =
+        if int(err) == EAGAIN: int(o)
+        else: 0
+      -1

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -28,27 +28,6 @@ suite "Stream Transport test suite":
     FilesCount = 10
     TestsCount = 100
 
-    m1 = "readLine() multiple clients with messages (" & $ClientsCount &
-         " clients x " & $MessagesCount & " messages)"
-    m2 = "readExactly() multiple clients with messages (" & $ClientsCount &
-         " clients x " & $MessagesCount & " messages)"
-    m3 = "readUntil() multiple clients with messages (" & $ClientsCount &
-         " clients x " & $MessagesCount & " messages)"
-    m4 = "writeFile() multiple clients (" & $FilesCount & " files)"
-    m5 = "write(string)/read(int) multiple clients (" & $ClientsCount &
-         " clients x " & $MessagesCount & " messages)"
-    m6 = "write(seq[byte])/consume(int)/read(int) multiple clients (" &
-         $ClientsCount & " clients x " & $MessagesCount & " messages)"
-    m7 = "readLine() buffer overflow test"
-    m8 = "readUntil() buffer overflow test"
-    m11 = "readExactly() unexpected disconnect test"
-    m12 = "readUntil() unexpected disconnect test"
-    m13 = "readLine() unexpected disconnect empty string test"
-    m14 = "Closing socket while operation pending test (issue #8)"
-    m15 = "Connection refused test"
-    m16 = "readOnce() read until atEof() test"
-    m17 = "0.0.0.0/::0 (INADDR_ANY) test"
-
   when defined(windows):
     let addresses = [
       initTAddress("127.0.0.1:33335"),
@@ -1246,29 +1225,34 @@ suite "Stream Transport test suite":
   for i in 0..<len(addresses):
     test prefixes[i] & "close(transport) test":
       check waitFor(testCloseTransport(addresses[i])) == 1
-    test prefixes[i] & m8:
+    test prefixes[i] & "readUntil() buffer overflow test":
       check waitFor(test8(addresses[i])) == 1
-    test prefixes[i] & m7:
+    test prefixes[i] & "readLine() buffer overflow test":
       check waitFor(test7(addresses[i])) == 1
-    test prefixes[i] & m11:
+    test prefixes[i] & "readExactly() unexpected disconnect test":
       check waitFor(test11(addresses[i])) == 1
-    test prefixes[i] & m12:
+    test prefixes[i] & "readUntil() unexpected disconnect test":
       check waitFor(test12(addresses[i])) == 1
-    test prefixes[i] & m13:
+    test prefixes[i] & "readLine() unexpected disconnect empty string test":
       check waitFor(test13(addresses[i])) == 1
-    test prefixes[i] & m14:
+    test prefixes[i] & "Closing socket while operation pending test (issue #8)":
       check waitFor(test14(addresses[i])) == 1
-    test prefixes[i] & m1:
+    test prefixes[i] & "readLine() multiple clients with messages (" &
+        $ClientsCount & " clients x " & $MessagesCount & " messages)":
       check waitFor(test1(addresses[i])) == ClientsCount * MessagesCount
-    test prefixes[i] & m2:
+    test prefixes[i] & "readExactly() multiple clients with messages (" &
+        $ClientsCount & " clients x " & $MessagesCount & " messages)":
       check waitFor(test2(addresses[i])) == ClientsCount * MessagesCount
-    test prefixes[i] & m3:
+    test prefixes[i] & "readUntil() multiple clients with messages (" &
+        $ClientsCount & " clients x " & $MessagesCount & " messages)":
       check waitFor(test3(addresses[i])) == ClientsCount * MessagesCount
-    test prefixes[i] & m5:
+    test prefixes[i] & "write(string)/read(int) multiple clients (" &
+        $ClientsCount & " clients x " & $MessagesCount & " messages)":
       check waitFor(testWR(addresses[i])) == ClientsCount * MessagesCount
-    test prefixes[i] & m6:
+    test prefixes[i] & "write(seq[byte])/consume(int)/read(int) multiple clients (" &
+         $ClientsCount & " clients x " & $MessagesCount & " messages)":
       check waitFor(testWCR(addresses[i])) == ClientsCount * MessagesCount
-    test prefixes[i] & m4:
+    test prefixes[i] & "writeFile() multiple clients (" & $FilesCount & " files)":
       when defined(windows):
         if addresses[i].family == AddressFamily.IPv4:
           check waitFor(testSendFile(addresses[i])) == FilesCount
@@ -1276,21 +1260,21 @@ suite "Stream Transport test suite":
           skip()
       else:
         check waitFor(testSendFile(addresses[i])) == FilesCount
-    test prefixes[i] & m15:
+    test prefixes[i] & "Connection refused test":
       var address: TransportAddress
       if addresses[i].family == AddressFamily.Unix:
         address = initTAddress("/tmp/notexistingtestpipe")
       else:
         address = initTAddress("127.0.0.1:43335")
       check waitFor(testConnectionRefused(address)) == true
-    test prefixes[i] & m16:
+    test prefixes[i] & "readOnce() read until atEof() test":
       check waitFor(test16(addresses[i])) == 1
     test prefixes[i] & "Connection reset test on send() only":
       when defined(macosx):
         skip()
       else:
         check waitFor(testWriteConnReset(addresses[i])) == 1
-    test prefixes[i] & m17:
+    test prefixes[i] & "0.0.0.0/::0 (INADDR_ANY) test":
       if addresses[i].family == AddressFamily.IPv4:
         check waitFor(testAnyAddress()) == true
       else:

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -1168,7 +1168,9 @@ suite "Stream Transport test suite":
       await sleepAsync(100.milliseconds)
 
       for i in 0 ..< len(futs):
-        if futs[i].failed() and (futs[i].error of TransportUseClosedError):
+        # writes may complete via fast write
+        if futs[i].completed() or (
+            futs[i].failed() and (futs[i].error of TransportUseClosedError)):
           inc(res)
 
       await server.closeWait()


### PR DESCRIPTION
When `write` is called on a `StreamTransport`, the current sequence of
operations is:

* copy data to queue
* register for "write" event notification
* return unfinished future to `write` caller
* wait for "write" notification (in `poll`)
* perform one `send`
* wait for notification again if there's more data to write
* complete the future

In this PR, we introduce a fast path for writing:

* If the queue is empty, try to send as much data as possible
  * If all data is sent, return completed future without `poll` round
  * If there's more data to send than can be sent in one go, add the
rest to queue
* If the queue is not empty, enqueue as above
* When notified that write is possible, keep writing until OS buffer is
full before waiting for event again

With this flow, as long as there is space in the OS buffer, we will
avoid data copying and poll loops - this above all provides great
performance benefits when there are many small writes to many sockets.

Also fixes an issue where sockets would not be deregistered from the
writer notifications on close.