### PR TITLE
Fix documentation build

### DIFF
--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -516,7 +516,7 @@ proc resolveTAddress*(address: string, port: Port,
     resolveTAddress(address, port, AddressFamily.IPv6)
 
 proc windowsAnyAddressFix*(a: TransportAddress): TransportAddress =
-  ## BSD Sockets on *nix systems are able to perform connections to
+  ## BSD Sockets on \*nix systems are able to perform connections to
   ## `0.0.0.0` or `::0` which are equal to `127.0.0.1` or `::1`.
   when defined(windows):
     if (a.family == AddressFamily.IPv4 and


### PR DESCRIPTION
`nim doc --project --index:on chronos.nim` was failing with the following error:

    /path/to/nim-chronos/chronos/transports/common.nim(519, 21) Error: '*' expected

...which in turned caused errors in all files that import this one.

Now the entire docs can be built successfully, with only a few warnings.

Fixes #186.