### PR TITLE
Fix TLS certificate allocation

### DIFF
--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -709,6 +709,7 @@ proc init*(tt: typedesc[TLSCertificate],
   ## This procedure initializes array of certificates from PEM encoded string.
   var items = pemDecode(data)
   var res = TLSCertificate()
+  res.storage = newSeqOfCap[byte](data.len)
   for item in items:
     if item.name == "CERTIFICATE" and len(item.data) > 0:
       let offset = len(res.storage)

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -708,8 +708,8 @@ proc init*(tt: typedesc[TLSCertificate],
   ##
   ## This procedure initializes array of certificates from PEM encoded string.
   var items = pemDecode(data)
-  var res = TLSCertificate()
-  res.storage = newSeqOfCap[byte](data.len)
+  # storage needs to be big enough for input data
+  var res = TLSCertificate(storage: newSeqOfCap[byte](data.len))
   for item in items:
     if item.name == "CERTIFICATE" and len(item.data) > 0:
       let offset = len(res.storage)


### PR DESCRIPTION
When using multiple certificates (which is most real ones), this part can fail randomly:
https://github.com/status-im/nim-chronos/blob/b47b2a96ce824fa331a76877df0b1764a0bcb6d9/chronos/streams/tlsstream.nim#L712-L719

since the `res.storage.add(item.data)` _can_ reallocate a new sequence, and thus the previous `addr res.storage[offset]` now points to invalid data.

This PR is a simple fix for that, by allocating enough space to be sure that no allocation is needed. It will allocate a tad more than necessary, but I don't think that's an issue