### PR TITLE
Fix nimdoc comment for async procs

### DIFF
--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -102,6 +102,10 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
 
   var outerProcBody = newNimNode(nnkStmtList, prc.body)
 
+  # Copy comment for nimdoc
+  if prc.body.len > 0 and prc.body[0].kind == nnkCommentStmt:
+    outerProcBody.add(prc.body[0])
+
 
   # -> iterator nameIter(chronosInternalRetFuture: Future[T]): FutureBase {.closure.} =
   # ->   {.push warning[resultshadowed]: off.}


### PR DESCRIPTION
Currently, nim doc doesn't work on async procedures, because the comment will be move in the iterator, and thus won't be in the top procedure, eg:

```nim
proc test*() {.async.} =
  ## Awesome comment
  echo 5
```
Transformed into
```nim
proc test*(): Future[void] {.stackTrace: off, gcsafe.} =
  iterator test_436207618(chronosInternalRetFuture: Future[void]): FutureBase {.
      closure, gcsafe, raises: [Defect, CatchableError, Exception].} =
    block:
      ## Awesome comment
      echo 5
    complete(chronosInternalRetFuture)

  etc
```

This PR copies the first comment (which, AFAIK is the only used by nimdoc) to the outer procedure, which fixes this issue

Ideally we would also extract the runnableExamples