### PR TITLE
Cleanup return type open syms

### DIFF
--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -103,10 +103,6 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
     let fut = repr(returnType[0])
     verifyReturnType(fut)
     baseType = returnType[1]
-  elif returnType.kind in nnkCallKinds and returnType[0].eqIdent("[]"):
-    let fut = repr(returnType[1])
-    verifyReturnType(fut)
-    baseType = returnType[2]
   elif returnType.kind == nnkEmpty:
     baseType = returnType
   else:

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -78,14 +78,13 @@ proc cleanupOpenSymChoice(node: NimNode): NimNode {.compileTime.} =
   if node.kind in nnkCallKinds and
     node[0].kind == nnkOpenSymChoice and node[0].eqIdent("[]"):
     result = newNimNode(nnkBracketExpr).add(
-      node[1],
-      node[2]
+      cleanupOpenSymChoice(node[1]),
+      cleanupOpenSymChoice(node[2])
     )
   else:
-    result = node
-
-  for index, child in result:
-    result[index] = cleanupOpenSymChoice(child)
+    result = node.copyNimNode()
+    for child in node:
+      result.add(cleanupOpenSymChoice(child))
 
 proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
   ## This macro transforms a single procedure into a closure iterator.

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -96,4 +96,4 @@ suite "Macro transformations test suite":
 
     type OpenObject = object
     macroAsync(testMacro, seq, OpenObject)
-    check waitFor(testmacro()).len == 0
+    check waitFor(testMacro()).len == 0

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -6,6 +6,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 import unittest2
+import macros
 import ../chronos
 
 when defined(nimHasUsed): {.used.}
@@ -80,3 +81,19 @@ suite "Macro transformations test suite":
     check waitFor(testAwait()) == true
   test "`awaitne` command test":
     check waitFor(testAwaitne()) == true
+
+
+  test "template async macro transformation":
+    template templatedAsync(name, restype: untyped): untyped =
+      proc name(): Future[restype] {.async.} = return @[4]
+
+    templatedAsync(testTemplate, seq[int])
+    check waitFor(testTemplate()) == @[4]
+
+    macro macroAsync(name, restype, innerrestype: untyped): untyped =
+      quote do:
+        proc `name`(): Future[`restype`[`innerrestype`]] {.async.} = return
+
+    type OpenObject = object
+    macroAsync(testMacro, seq, OpenObject)
+    check waitFor(testmacro()).len == 0


### PR DESCRIPTION
Fixes https://github.com/status-im/nimbus-eth1/issues/963
For some reason, the code was generating this kind of AST for the return type:
```
    Call
      OpenSymChoice
        Sym "[]"
        Sym "[]"
        ...
      Sym "Future"
      Call
        OpenSymChoice
          Sym "[]"
          Sym "[]"
          ..
        Ident "seq"
        Ident "OpenObject"
```
And this "recursive" OpenSymChoice wasn't handled properly by the macro