### PR TITLE
Rate limiter

### DIFF
--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -19,8 +19,6 @@ type
     budgetCap: int64
     lastUpdate: Moment
 
-  RateCounterRef* = ref RateCounter
-
   RateCost* = distinct int64
 
 proc update(rc: var RateCounter) =
@@ -93,8 +91,8 @@ proc init*(T: typedesc[RateCounter], cap: Duration): T =
     lastUpdate: Moment.now()
   )
 
-proc new*(T: typedesc[RateCounterRef], cap: Duration): T =
-  T(
+proc new*(T: typedesc[RateCounter], cap: Duration): ref RateCounter =
+  (ref T)(
     budget: cap.nanoseconds,
     budgetCap: cap.nanoseconds,
     lastUpdate: Moment.now()

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -36,6 +36,18 @@ proc operationsPerSecond*(ops: float): RateCost =
 
   RateCost(budgetPerSecond / ops)
 
+proc tokensPerSecond*(tokens, budget: SomeNumber): RateCost =
+  ## Create a RateCost from a token budget per second
+  runnableExamples:
+    let cost = tokensPerSecond(
+      1518, # packet of 1518 bytes
+      1000000 # budget of 1mb
+    )
+  let
+    budgetUsed = tokens / budget
+    allowedPerSeconds = 1.float / budgetUsed
+  operationsPerSecond(allowedPerSeconds)
+
 proc timeBudgetPerSecond*(time, budget: Duration): RateCost =
   ## Create a RateCost from a time budget per second.
   runnableExamples:
@@ -49,9 +61,7 @@ proc timeBudgetPerSecond*(time, budget: Duration): RateCost =
   let
     timeAsUs = time.nanoseconds.float
     budgetAsUs = budget.nanoseconds.float
-    budgetUsed = timeAsUs / budgetAsUs
-    allowedPerSeconds = 1.float / budgetUsed
-  operationsPerSecond(allowedPerSeconds)
+  tokensPerSecond(timeAsUs, budgetAsUs)
 
 proc tryConsume*(rc: var RateCounter, cost: RateCost): bool =
   ## If there is still budget left, remove cost from the budget

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -1,0 +1,83 @@
+#               Chronos Rate Limiter
+#            (c) Copyright 2022-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+{.push raises: [Defect].}
+
+import ../chronos
+
+export timer
+
+type
+  RateCounter* = object
+    budget: int64
+    budgetCap: int64
+    lastUpdate: Moment
+
+  RateCounterRef* = ref RateCounter
+
+  RateCost* = distinct int
+
+proc update(rc: var RateCounter) =
+  let
+    currentTime = Moment.now()
+    timeDelta = nanoseconds(currentTime - rc.lastUpdate)
+
+  rc.lastUpdate = currentTime
+  rc.budget = min(rc.budgetCap, rc.budget + timeDelta)
+
+proc operationsPerSecond*(ops: float): RateCost =
+  ## Create a RateCost from an allowed number of 
+  ## operations per second
+  const budgetPerSecond = 1.seconds.nanoseconds.float
+
+  RateCost(budgetPerSecond / ops)
+
+proc tryConsume*(rc: var RateCounter, cost: RateCost): bool =
+  ## If there is still budget left, remove cost from the budget
+  ## Otherwise, return false
+  rc.update()
+  if rc.budget >= 0:
+    rc.budget.dec(int(cost))
+    true
+  else:
+    false
+
+proc consume*(rc: var RateCounter, cost: RateCost): Future[void] =
+  ## Wait until some budget is available, then substract cost
+  ## from it
+
+  # Manual async because of var argument
+  rc.update()
+  rc.budget.dec(int(cost))
+
+  if rc.budget >= 0:
+    result = newFuture[void]("RateCounter.consume")
+    result.complete()
+    return result
+  else:
+    return sleepAsync(nanoseconds(-rc.budget))
+
+proc init*(T: typedesc[RateCounter], cap: Duration): T =
+  ## Create a RateCounter.
+  ## The RateCounter will be smoothed out over the
+  ## duration of `cap`.
+  ##
+  ## Example: RateCounter.init(10.seconds)
+  ## 10 seconds worth of budget could be used instantly
+  T(
+    budget: cap.nanoseconds,
+    budgetCap: cap.nanoseconds,
+    lastUpdate: Moment.now()
+  )
+
+proc new*(T: typedesc[RateCounterRef], cap: Duration): T =
+  T(
+    budget: cap.nanoseconds,
+    budgetCap: cap.nanoseconds,
+    lastUpdate: Moment.now()
+  )

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -9,6 +9,7 @@
 {.push raises: [Defect].}
 
 import ../chronos
+import timer
 
 export timer
 

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -8,4 +8,4 @@
 import testmacro, testsync, testsoon, testtime, testfut, testsignal,
        testaddress, testdatagram, teststream, testserver, testbugs, testnet,
        testasyncstream, testhttpserver, testshttpserver, testhttpclient
-import testutils
+import testutils, testratelimit

--- a/tests/testratelimit.nim
+++ b/tests/testratelimit.nim
@@ -49,7 +49,7 @@ suite "RateLimiter test suite":
       duration < 1600.milliseconds
 
   test "Ref version":
-    let counter = RateCounterRef.new(2.seconds)
+    let counter = RateCounter.new(2.seconds)
 
     check:
       # Use up the 2 seconds budget

--- a/tests/testratelimit.nim
+++ b/tests/testratelimit.nim
@@ -1,0 +1,62 @@
+#                Chronos Test Suite
+#            (c) Copyright 2022-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import unittest
+import ../chronos
+import ../chronos/ratelimit
+
+suite "RateLimiter test suite":
+  test "Sync test":
+    var counter = RateCounter.init(2.seconds)
+
+    check:
+      # Use up the 2 seconds budget
+      counter.tryConsume(operationsPerSecond(2)) == true
+      counter.tryConsume(operationsPerSecond(2)) == true
+      counter.tryConsume(operationsPerSecond(1)) == true
+      counter.tryConsume(operationsPerSecond(1)) == true
+
+      # Out of budget, should fail
+      counter.tryConsume(operationsPerSecond(2)) == false
+
+  test "Async test":
+    var
+      counter = RateCounter.init(1.seconds)
+      toWait: seq[Future[void]]
+
+    check counter.consume(operationsPerSecond(1000)).completed
+
+    # Exhaust budget
+    while counter.tryConsume(operationsPerSecond(1000)):
+      discard
+
+    for i in 0..<150:
+      toWait.add(counter.consume(operationsPerSecond(100)))
+
+    check counter.tryConsume(operationsPerSecond(1)) == false
+
+    let start = Moment.now()
+    waitFor(allFutures(toWait))
+    let duration = Moment.now() - start
+    # 150 with 100 op/seconds should take
+    # 1.5 seconds
+    check:
+      duration > 1400.milliseconds
+      duration < 1600.milliseconds
+
+  test "Ref version":
+    let counter = RateCounterRef.new(2.seconds)
+
+    check:
+      # Use up the 2 seconds budget
+      counter[].consume(operationsPerSecond(2)).completed
+      counter[].tryConsume(operationsPerSecond(2)) == true
+      counter[].tryConsume(operationsPerSecond(1)) == true
+      counter[].tryConsume(operationsPerSecond(1)) == true
+
+      # Out of budget, should fail
+      counter[].tryConsume(operationsPerSecond(2)) == false

--- a/tests/testratelimit.nim
+++ b/tests/testratelimit.nim
@@ -60,3 +60,15 @@ suite "RateLimiter test suite":
 
       # Out of budget, should fail
       counter[].tryConsume(operationsPerSecond(2)) == false
+
+  test "Time Budget Per Second":
+    var counter = RateCounter.init(1.seconds)
+
+    check:
+      # Use start budget
+      counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == true
+      counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == true
+      counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == true
+
+      counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == true
+      counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == false

--- a/tests/testratelimit.nim
+++ b/tests/testratelimit.nim
@@ -72,3 +72,15 @@ suite "RateLimiter test suite":
 
       counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == true
       counter.tryConsume(timeBudgetPerSecond(10.milliseconds, 30.milliseconds)) == false
+
+  test "TokensPerSecond":
+    var counter = RateCounter.init(1.seconds)
+
+    check:
+      # Use start budget
+      counter.tryConsume(tokensPerSecond(10, 30)) == true
+      counter.tryConsume(tokensPerSecond(10, 30)) == true
+      counter.tryConsume(tokensPerSecond(10, 30)) == true
+
+      counter.tryConsume(tokensPerSecond(10, 30)) == true
+      counter.tryConsume(tokensPerSecond(10, 30)) == false


### PR DESCRIPTION
Adds a generic rate limiter:
```nim
var counter = RateCounter.init(cap=1.seconds)
echo counter.tryConsume(10.operationsPerSecond) # succeeds
await counter.consume(operationsPerSecond(0.1)) # Will block for ~9 seconds
```