### PR TITLE
Restore HTTP auth test

### DIFF
--- a/tests/testhttpclient.nim
+++ b/tests/testhttpclient.nim
@@ -764,9 +764,6 @@ suite "HTTP client testing suite":
     check waitFor(testRequestRedirectTest(address, true, 4)) == "redirect-true"
 
   test "HTTPS basic authorization test":
-    skip()
-    return
-    # started to fail out of the blue
     check waitFor(testBasicAuthorization()) == true
 
   test "Leaks test":


### PR DESCRIPTION
This test is failing, I've skipped it on master to avoid blocking the CI (here and Nim)

The server used for this test (https://guest:guest@jigsaw.w3.org/HTTP/Basic/) is returning a TLS error 40 when we try to connect to it from chronos (works fine with `curl`)

Wireshark doesn't seem to dislike the Client Hello we send, so it may be a bug on the other side

For reference, the curl hello on the left, and the bearssl one on the right:
![image](https://user-images.githubusercontent.com/13471753/160866656-9ee5ace0-dc5a-4d47-afdf-9ba7fb64ebb6.png)
