### PR TITLE
fix crash after reading from fd > 1024

### DIFF
--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1256,7 +1256,12 @@ else:
       raiseAsDefect exc, "removeWriter"
 
   proc writeStreamLoop(udata: pointer) =
-    doAssert not isNil(udata)
+    if isNil(udata):
+      # TODO this is an if rather than an assert for historical reasons:
+      # it should not happen unless there are race conditions - but if there
+      # are race conditions, `transp` might be invalid even if it's not nil:
+      # it could have been released
+      return
 
     let
       transp = cast[StreamTransport](udata)
@@ -1350,7 +1355,12 @@ else:
     transp.removeWriter()
 
   proc readStreamLoop(udata: pointer) =
-    doAssert not isNil(udata)
+    if isNil(udata):
+      # TODO this is an if rather than an assert for historical reasons:
+      # it should not happen unless there are race conditions - but if there
+      # are race conditions, `transp` might be invalid even if it's not nil:
+      # it could have been released
+      return
 
     let
       transp = cast[StreamTransport](udata)

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1580,7 +1580,12 @@ else:
     return retFuture
 
   proc acceptLoop(udata: pointer) =
-    doAssert not isNil(udata)
+    if isNil(udata):
+      # TODO this is an if rather than an assert for historical reasons:
+      # it should not happen unless there are race conditions - but if there
+      # are race conditions, `transp` might be invalid even if it's not nil:
+      # it could have been released
+      return
 
     var
       saddr: Sockaddr_storage

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1260,7 +1260,7 @@ else:
       transp = cast[StreamTransport](udata)
       fd = SocketHandle(transp.fd)
 
-    if int(fd) == 0:
+    if int(fd) <= 0:
       ## This situation can be happen, when there events present
       ## after transport was closed.
       return

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -407,7 +407,7 @@ elif defined(windows):
           ## Initiation
           transp.state.incl(WritePending)
           if transp.kind == TransportKind.Socket:
-            let sock = SocketHandle(transp.wovl.data.fd)
+            let sock = SocketHandle(transp.fd)
             var vector = transp.queue.popFirst()
             if vector.kind == VectorKind.DataBuffer:
               transp.wovl.zeroOvelappedOffset()
@@ -492,7 +492,7 @@ elif defined(windows):
               else:
                 transp.queue.addFirst(vector)
           elif transp.kind == TransportKind.Pipe:
-            let pipe = Handle(transp.wovl.data.fd)
+            let pipe = Handle(transp.fd)
             var vector = transp.queue.popFirst()
             if vector.kind == VectorKind.DataBuffer:
               transp.wovl.zeroOvelappedOffset()
@@ -587,7 +587,7 @@ elif defined(windows):
           transp.state.excl(ReadPaused)
           transp.state.incl(ReadPending)
           if transp.kind == TransportKind.Socket:
-            let sock = SocketHandle(transp.rovl.data.fd)
+            let sock = SocketHandle(transp.fd)
             transp.roffset = transp.offset
             transp.setReaderWSABuffer()
             let ret = WSARecv(sock, addr transp.rwsabuf, 1,
@@ -610,7 +610,7 @@ elif defined(windows):
                 transp.setReadError(err)
                 transp.completeReader()
           elif transp.kind == TransportKind.Pipe:
-            let pipe = Handle(transp.rovl.data.fd)
+            let pipe = Handle(transp.fd)
             transp.roffset = transp.offset
             transp.setReaderWSABuffer()
             let ret = readFile(pipe, cast[pointer](transp.rwsabuf.buf),
@@ -650,9 +650,9 @@ elif defined(windows):
     else:
       transp = StreamTransport(kind: TransportKind.Socket)
     transp.fd = sock
-    transp.rovl.data = CompletionData(fd: sock, cb: readStreamLoop,
+    transp.rovl.data = CompletionData(cb: readStreamLoop,
                                       udata: cast[pointer](transp))
-    transp.wovl.data = CompletionData(fd: sock, cb: writeStreamLoop,
+    transp.wovl.data = CompletionData(cb: writeStreamLoop,
                                       udata: cast[pointer](transp))
     transp.buffer = newSeq[byte](bufsize)
     transp.state = {ReadPaused, WritePaused}
@@ -670,9 +670,9 @@ elif defined(windows):
     else:
       transp = StreamTransport(kind: TransportKind.Pipe)
     transp.fd = fd
-    transp.rovl.data = CompletionData(fd: fd, cb: readStreamLoop,
+    transp.rovl.data = CompletionData(cb: readStreamLoop,
                                       udata: cast[pointer](transp))
-    transp.wovl.data = CompletionData(fd: fd, cb: writeStreamLoop,
+    transp.wovl.data = CompletionData(cb: writeStreamLoop,
                                       udata: cast[pointer](transp))
     transp.buffer = newSeq[byte](bufsize)
     transp.flags = flags
@@ -746,8 +746,7 @@ elif defined(windows):
               sock.closeSocket()
               retFuture.fail(getTransportOsError(err))
             else:
-              let transp = newStreamSocketTransport(povl.data.fd, bufferSize,
-                                                    child)
+              let transp = newStreamSocketTransport(sock, bufferSize, child)
               # Start tracking transport
               trackStream(transp)
               retFuture.complete(transp)
@@ -761,7 +760,7 @@ elif defined(windows):
 
       povl = RefCustomOverlapped()
       GC_ref(povl)
-      povl.data = CompletionData(fd: sock, cb: socketContinuation)
+      povl.data = CompletionData(cb: socketContinuation)
       let res = loop.connectEx(SocketHandle(sock),
                                cast[ptr SockAddr](addr saddr),
                                DWORD(slen), nil, 0, nil,
@@ -895,7 +894,6 @@ elif defined(windows):
           if pipeHandle == INVALID_HANDLE_VALUE:
             raiseAssert osErrorMsg(osLastError())
           server.sock = AsyncFD(pipeHandle)
-          server.aovl.data.fd = AsyncFD(pipeHandle)
           try: register(server.sock)
           except CatchableError as exc:
             raiseAsDefect exc, "register"
@@ -1177,8 +1175,7 @@ elif defined(windows):
       let dwLocalAddressLength = DWORD(sizeof(Sockaddr_in6) + 16)
       let dwRemoteAddressLength = DWORD(sizeof(Sockaddr_in6) + 16)
 
-      server.aovl.data = CompletionData(fd: server.sock,
-                                        cb: continuationSocket,
+      server.aovl.data = CompletionData(cb: continuationSocket,
                                         udata: cast[pointer](server))
       server.apending = true
       let res = loop.acceptEx(SocketHandle(server.sock),
@@ -1219,8 +1216,7 @@ elif defined(windows):
           retFuture.fail(getTransportOsError(err))
         return retFuture
 
-      server.aovl.data = CompletionData(fd: server.sock,
-                                        cb: continuationPipe,
+      server.aovl.data = CompletionData(cb: continuationPipe,
                                         udata: cast[pointer](server))
       server.apending = true
       let res = connectNamedPipe(Handle(server.sock),
@@ -1260,11 +1256,11 @@ else:
       raiseAsDefect exc, "removeWriter"
 
   proc writeStreamLoop(udata: pointer) =
-    var cdata = cast[ptr CompletionData](udata)
-    var transp = cast[StreamTransport](cdata.udata)
-    let fd = SocketHandle(cdata.fd)
+    let
+      transp = cast[StreamTransport](udata)
+      fd = SocketHandle(transp.fd)
 
-    if int(fd) == 0 or isNil(transp):
+    if int(fd) == 0:
       ## This situation can be happen, when there events present
       ## after transport was closed.
       return
@@ -1358,10 +1354,10 @@ else:
 
   proc readStreamLoop(udata: pointer) =
     # TODO fix Defect raises - they "shouldn't" happen
-    var cdata = cast[ptr CompletionData](udata)
-    var transp = cast[StreamTransport](cdata.udata)
-    let fd = SocketHandle(cdata.fd)
-    if int(fd) == 0 or isNil(transp):
+    let
+      transp = cast[StreamTransport](udata)
+      fd = SocketHandle(transp.fd)
+    if int(fd) <= 0:
       ## This situation can be happen, when there events present
       ## after transport was closed.
       return
@@ -1381,7 +1377,7 @@ else:
             elif int(err) in {ECONNRESET}:
               transp.state.incl({ReadEof, ReadPaused})
               try:
-                cdata.fd.removeReader()
+                transp.fd.removeReader()
               except IOSelectorsException as exc:
                 raiseAsDefect exc, "removeReader"
               except ValueError as exc:
@@ -1390,7 +1386,7 @@ else:
               transp.state.incl(ReadPaused)
               transp.setReadError(err)
               try:
-                cdata.fd.removeReader()
+                transp.fd.removeReader()
               except IOSelectorsException as exc:
                 raiseAsDefect exc, "removeReader"
               except ValueError as exc:
@@ -1398,7 +1394,7 @@ else:
           elif res == 0:
             transp.state.incl({ReadEof, ReadPaused})
             try:
-              cdata.fd.removeReader()
+              transp.fd.removeReader()
             except IOSelectorsException as exc:
               raiseAsDefect exc, "removeReader"
             except ValueError as exc:
@@ -1408,7 +1404,7 @@ else:
             if transp.offset == len(transp.buffer):
               transp.state.incl(ReadPaused)
               try:
-                cdata.fd.removeReader()
+                transp.fd.removeReader()
               except IOSelectorsException as exc:
                 raiseAsDefect exc, "removeReader"
               except ValueError as exc:
@@ -1427,7 +1423,7 @@ else:
               transp.state.incl(ReadPaused)
               transp.setReadError(err)
               try:
-                cdata.fd.removeReader()
+                transp.fd.removeReader()
               except IOSelectorsException as exc:
                 raiseAsDefect exc, "removeReader"
               except ValueError as exc:
@@ -1435,7 +1431,7 @@ else:
           elif res == 0:
             transp.state.incl({ReadEof, ReadPaused})
             try:
-              cdata.fd.removeReader()
+              transp.fd.removeReader()
             except IOSelectorsException as exc:
               raiseAsDefect exc, "removeReader"
             except ValueError as exc:
@@ -1445,7 +1441,7 @@ else:
             if transp.offset == len(transp.buffer):
               transp.state.incl(ReadPaused)
               try:
-                cdata.fd.removeReader()
+                transp.fd.removeReader()
               except IOSelectorsException as exc:
                 raiseAsDefect exc, "removeReader"
               except ValueError as exc:
@@ -1519,11 +1515,9 @@ else:
 
     proc continuation(udata: pointer) =
       if not(retFuture.finished()):
-        var data = cast[ptr CompletionData](udata)
         var err = 0
-        let fd = data.fd
         try:
-          fd.removeWriter()
+          sock.removeWriter()
         except IOSelectorsException as exc:
           retFuture.fail(exc)
           return
@@ -1531,15 +1525,15 @@ else:
           retFuture.fail(exc)
           return
 
-        if not(fd.getSocketError(err)):
-          closeSocket(fd)
+        if not(sock.getSocketError(err)):
+          closeSocket(sock)
           retFuture.fail(getTransportOsError(osLastError()))
           return
         if err != 0:
-          closeSocket(fd)
+          closeSocket(sock)
           retFuture.fail(getTransportOsError(OSErrorCode(err)))
           return
-        let transp = newStreamSocketTransport(fd, bufferSize, child)
+        let transp = newStreamSocketTransport(sock, bufferSize, child)
         # Start tracking transport
         trackStream(transp)
         retFuture.complete(transp)
@@ -1585,7 +1579,7 @@ else:
     var
       saddr: Sockaddr_storage
       slen: SockLen
-    var server = cast[StreamServer](cast[ptr CompletionData](udata).udata)
+    let server = cast[StreamServer](udata)
     while true:
       if server.status in {ServerStatus.Stopped, ServerStatus.Closed}:
         break
@@ -1990,7 +1984,7 @@ proc createStreamServer*(host: TransportAddress,
       cb = acceptPipeLoop
 
     if not(isNil(cbproc)):
-      result.aovl.data = CompletionData(fd: serverSocket, cb: cb,
+      result.aovl.data = CompletionData(cb: cb,
                                         udata: cast[pointer](result))
     else:
       if host.family == AddressFamily.Unix:

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1256,14 +1256,11 @@ else:
       raiseAsDefect exc, "removeWriter"
 
   proc writeStreamLoop(udata: pointer) =
+    doAssert not isNil(udata)
+
     let
       transp = cast[StreamTransport](udata)
       fd = SocketHandle(transp.fd)
-
-    if int(fd) <= 0:
-      ## This situation can be happen, when there events present
-      ## after transport was closed.
-      return
 
     if WriteClosed in transp.state:
       if transp.queue.len > 0:
@@ -1353,14 +1350,11 @@ else:
     transp.removeWriter()
 
   proc readStreamLoop(udata: pointer) =
-    # TODO fix Defect raises - they "shouldn't" happen
+    doAssert not isNil(udata)
+
     let
       transp = cast[StreamTransport](udata)
       fd = SocketHandle(transp.fd)
-    if int(fd) <= 0:
-      ## This situation can be happen, when there events present
-      ## after transport was closed.
-      return
 
     if ReadClosed in transp.state:
       transp.state.incl({ReadPaused})
@@ -1575,7 +1569,9 @@ else:
           break
     return retFuture
 
-  proc acceptLoop(udata: pointer) {.gcsafe.} =
+  proc acceptLoop(udata: pointer) =
+    doAssert not isNil(udata)
+
     var
       saddr: Sockaddr_storage
       slen: SockLen

--- a/tests/testsignal.nim
+++ b/tests/testsignal.nim
@@ -15,13 +15,14 @@ when not defined(windows):
 
 suite "Signal handling test suite":
   when not defined(windows):
-    var signalCounter = 0
+    var
+      signalCounter = 0
+      sigfd = -1
 
     proc signalProc(udata: pointer) =
-      var cdata = cast[ptr CompletionData](udata)
-      signalCounter = cast[int](cdata.udata)
+      signalCounter = cast[int](udata)
       try:
-        removeSignal(int(cdata.fd))
+        removeSignal(sigfd)
       except Exception as exc:
         raiseAssert exc.msg
 
@@ -30,7 +31,7 @@ suite "Signal handling test suite":
 
     proc test(signal, value: int): bool =
       try:
-        discard addSignal(signal, signalProc, cast[pointer](value))
+        sigfd = addSignal(signal, signalProc, cast[pointer](value))
       except Exception as exc:
         raiseAssert exc.msg
       var fut = asyncProc()


### PR DESCRIPTION
The socket selector holds a `seq` of per-descriptor data. When a reader
is registered, a pointer to a seq item is stored - when the `seq` grows,
this pointer becomes dangling and causes crashes like
https://github.com/status-im/nimbus-eth2/issues/3521.

It turns out that there already exist two mechanisms for passing user
data around - this PR simply removes one of them, saving on memory usage
and removing the need to store pointers to the `seq` data that become
dangling on resize.