### PR TITLE
Fix missing connection flag.

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -978,6 +978,7 @@ proc send*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
       request.setError(exc)
       raise exc
 
+  connection.flags.incl(HttpClientConnectionFlag.Request)
   request.connection = connection
 
   try:
@@ -1028,6 +1029,7 @@ proc open*(request: HttpClientRequestRef): Future[HttpBodyWriter] {.
       request.setError(exc)
       raise exc
 
+  connection.flags.incl(HttpClientConnectionFlag.Request)
   request.connection = connection
 
   try:


### PR DESCRIPTION
Tracking of these flags is important for preventing pre-mature HTTP connection closing or inducing connection leaks.