### PR TITLE
Tentative fix for the HTTP client connection state assertion failures

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1066,6 +1066,12 @@ proc open*(request: HttpClientRequestRef): Future[HttpBodyWriter] {.
 
 proc finish*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
      async.} =
+  if request.connection.state in {HttpClientConnectionState.Closing,
+                                  HttpClientConnectionState.Closed}:
+    let e = newHttpInterruptError()
+    request.setError(e)
+    raise e
+ 
   ## Finish sending request and receive response.
   doAssert(not(isNil(request.connection)),
            "Request missing connection instance")

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1066,15 +1066,14 @@ proc open*(request: HttpClientRequestRef): Future[HttpBodyWriter] {.
 
 proc finish*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
      async.} =
-  if request.connection.state in {HttpClientConnectionState.Closing,
-                                  HttpClientConnectionState.Closed}:
-    let e = newHttpInterruptError()
-    request.setError(e)
-    raise e
- 
   ## Finish sending request and receive response.
   doAssert(not(isNil(request.connection)),
            "Request missing connection instance")
+  if request.connection.state in {HttpClientConnectionState.Closing,
+                                  HttpClientConnectionState.Closed}:
+    let e = newHttpUseClosedError()
+    request.setError(e)
+    raise e
   doAssert(request.state == HttpReqRespState.Open,
            "Request's state is " & $request.state)
   doAssert(request.connection.state ==

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -53,6 +53,7 @@ type
   HttpProtocolError* = object of HttpError
   HttpRedirectError* = object of HttpError
   HttpAddressError* = object of HttpError
+  HttpUseClosedError* = object of HttpError
 
   KeyValueTuple* = tuple
     key: string
@@ -110,6 +111,9 @@ template newHttpReadError*(message: string): ref HttpReadError =
 
 template newHttpWriteError*(message: string): ref HttpWriteError =
   newException(HttpWriteError, message)
+
+template newHttpUseClosedError*(): ref HttpUseClosedError =
+  newException(HttpUseClosedError, "Connection was already closed")
 
 iterator queryParams*(query: string,
                       flags: set[QueryParamsFlag] = {}): KeyValueTuple {.


### PR DESCRIPTION
I've traced the problem to a HTTP connection being closed while there
are outstanding requests that still go through the motions (the crash
occurs when a requests reaches its `finish` processing step, but it
was already put in a Closed state by the connection that owns it).