### PR TITLE
make it more Nim 1.4+ compatible

### DIFF
--- a/chronos/apps/http/httptable.nim
+++ b/chronos/apps/http/httptable.nim
@@ -10,7 +10,10 @@
 import std/[tables, strutils]
 import stew/base10
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 type
   HttpTable* = object

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -8,7 +8,10 @@
 #    Apache License, version 2.0, (LICENSE-APACHEv2)
 #                MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[os, tables, strutils, heapqueue, lists, options, nativesockets, net,
             deques]

--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -10,7 +10,10 @@
 
 ## This module implements some core synchronization primitives.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils, math, deques, tables, typetraits]
 import ./asyncloop

--- a/chronos/debugutils.nim
+++ b/chronos/debugutils.nim
@@ -7,7 +7,10 @@
 #    Apache License, version 2.0, (LICENSE-APACHEv2)
 #                MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import ./asyncloop
 export asyncloop

--- a/chronos/handles.nim
+++ b/chronos/handles.nim
@@ -7,7 +7,10 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[net, nativesockets]
 import stew/base10

--- a/chronos/ioselects/ioselectors_epoll.nim
+++ b/chronos/ioselects/ioselectors_epoll.nim
@@ -9,7 +9,10 @@
 
 # This module implements Linux epoll().
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import posix, times, epoll
 

--- a/chronos/sendfile.nim
+++ b/chronos/sendfile.nim
@@ -9,7 +9,10 @@
 
 ## This module provides cross-platform wrapper for ``sendfile()`` syscall.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 when defined(nimdoc):
   proc sendfile*(outfd, infd: int, offset: int, count: var int): int =

--- a/chronos/srcloc.nim
+++ b/chronos/srcloc.nim
@@ -6,7 +6,10 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 import stew/base10
 
 type

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -7,7 +7,10 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import ../asyncloop, ../asyncsync
 import ../transports/common, ../transports/stream

--- a/chronos/timer.nim
+++ b/chronos/timer.nim
@@ -24,7 +24,10 @@
 ## You can specify which timer you want to use ``-d:asyncTimer=<system/mono>``.
 const asyncTimer* {.strdefine.} = "mono"
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 when defined(windows):
   when asyncTimer == "system":

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -7,7 +7,10 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[os, strutils, nativesockets, net]
 import stew/base10

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -7,7 +7,10 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[net, nativesockets, os, deques]
 import ".."/[selectors2, asyncloop, handles]

--- a/chronos/transports/ipnet.nim
+++ b/chronos/transports/ipnet.nim
@@ -9,7 +9,10 @@
 
 ## This module implements various IP network utility procedures.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/strutils
 import stew/endians2

--- a/chronos/transports/osnet.nim
+++ b/chronos/transports/osnet.nim
@@ -10,7 +10,10 @@
 ## This module implements cross-platform network interfaces list.
 ## Currently supported OSes are Windows, Linux, MacOS, BSD(not tested).
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/algorithm
 from std/strutils import toHex

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -7,7 +7,10 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[net, nativesockets, os, deques]
 import ".."/[asyncloop, handles, selectors2]


### PR DESCRIPTION
A continuation of https://github.com/status-im/nimbus-eth2/pull/3888

Rationale (from that link):

> Currently (the latest commit in unstable branch), the CI log for the 1.6 branch has **107.000 lines**.
Removing every hint about cannot raise 'Defect' (including the ones in the vendor directory) leaves **16.000 lines**. 85% off.