### PR TITLE
`results.?` compatibity

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -8,7 +8,7 @@ license       = "MIT or Apache License 2.0"
 skipDirs      = @["tests"]
 
 requires "nim >= 1.2.0",
-         "stew",
+         "stew#assign-result",
          "bearssl",
          "httputils",
          "unittest2"


### PR DESCRIPTION
This PR uses the facilities provided in
https://github.com/status-im/nim-stew/pull/134 to support `?` in `async`
proc's.