### PR TITLE
Fix nested waitFor (IndexError defect crash) bug.

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -352,9 +352,9 @@ when defined(windows):
 
     AsyncFD* = distinct int
 
-  proc getModuleHandle(lpModuleName: WideCString): HANDLE {.
+  proc getModuleHandle(lpModuleName: WideCString): Handle {.
        stdcall, dynlib: "kernel32", importc: "GetModuleHandleW", sideEffect.}
-  proc getProcAddress(hModule: HANDLE, lpProcName: cstring): pointer {.
+  proc getProcAddress(hModule: Handle, lpProcName: cstring): pointer {.
        stdcall, dynlib: "kernel32", importc: "GetProcAddress", sideEffect.}
   proc rtlNtStatusToDosError(code: uint64): ULONG {.
        stdcall, dynlib: "ntdll", importc: "RtlNtStatusToDosError", sideEffect.}

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -286,8 +286,7 @@ template processIdlers(loop: untyped) =
 
 template processCallbacks(loop: untyped) =
   while true:
-    doAssert loop.callbacks.len > 0  # Sentinel element is always added before
-    let callable = loop.callbacks.popFirst()
+    let callable = loop.callbacks.popFirst()  # len must be > 0 due to sentinel
     if isSentinel(callable):
       break
     if not(isNil(callable.function)):

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -126,6 +126,10 @@ suite "Asynchronous issues test suite":
         raiseAssert "Unexpected exception happened"
     let timer = setTimer(Moment.fromNow(0.seconds), waiterProc, nil)
     await sleepAsync(100.milliseconds)
+
+    await inpTransp.closeWait()
+    await outTransp.closeWait()
+    await server.closeWait()
     return true
 
   test "Issue #6":

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -21,7 +21,7 @@ suite "Asynchronous issues test suite":
       test: string
 
   proc udp4DataAvailable(transp: DatagramTransport,
-                       remote: TransportAddress): Future[void] {.async, gcsafe.} =
+                         remote: TransportAddress) {.async, gcsafe.} =
     var udata = getUserData[CustomData](transp)
     var expect = TEST_MSG
     var data: seq[byte]
@@ -98,6 +98,36 @@ suite "Asynchronous issues test suite":
 
     result = r1 and r2
 
+  proc createBigMessage(size: int): seq[byte] =
+    var message = "MESSAGE"
+    var res = newSeq[byte](size)
+    for i in 0 ..< len(result):
+      res[i] = byte(message[i mod len(message)])
+    res
+
+  proc testIndexError(): Future[bool] {.async.} =
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    flags = {ReuseAddr})
+    let messageSize = DefaultStreamBufferSize * 4
+    var buffer = newSeq[byte](messageSize)
+    let msg = createBigMessage(messageSize)
+    let address = server.localAddress()
+    let afut = server.accept()
+    let outTransp = await connect(address)
+    let inpTransp = await afut
+    let bytesSent = await outTransp.write(msg)
+    check bytesSent == messageSize
+    var rfut = inpTransp.readExactly(addr buffer[0], messageSize)
+
+    proc waiterProc(udata: pointer) {.raises: [Defect], gcsafe.} =
+      try:
+        waitFor(sleepAsync(0.milliseconds))
+      except CatchableError as exc:
+        raiseAssert "Unexpected exception happened"
+    let timer = setTimer(Moment.fromNow(0.seconds), waiterProc, nil)
+    await sleepAsync(100.milliseconds)
+    return true
+
   test "Issue #6":
     check waitFor(issue6()) == true
 
@@ -112,3 +142,6 @@ suite "Asynchronous issues test suite":
 
   test "Defer for asynchronous procedures test [Nim's issue #13899]":
     check waitFor(testDefer()) == true
+
+  test "IndexError crash test":
+    check waitFor(testIndexError()) == true


### PR DESCRIPTION
* Add GetQueuedCompletionStatusEx() support for Windows, which allows to capture more then one event in single `poll()` call.

This PR will fix
#308 
#242 

