### PR TITLE
AsyncEventQueue: add resetRegistration() to continue using the same r…

### DIFF
--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -722,6 +722,15 @@ proc unregister*(ab: AsyncEventQueue, key: EventQueueKey) {.
     ab.readers.delete(index)
     ab.compact()
 
+proc resetRegistration*(ab: AsyncEventQueue, key: EventQueueKey) {.raises: [Defect].} =
+  let index = ab.getReaderIndex(key)
+  if index >= 0:
+    ab.unregister(key)
+    let reader = EventQueueReader(key: key,
+                                  offset: ab.offset + len(ab.queue),
+                                  overflow: false)
+    ab.readers.add(reader)
+
 proc close*(ab: AsyncEventQueue) {.raises: [Defect].} =
   for reader in ab.readers.items():
     if not(isNil(reader.waiter)) and not(reader.waiter.finished()):


### PR DESCRIPTION
…egistration key after AsyncEventQueueFullError

With _EventBus_ being deprecated I am checking how to move exiting code to _AsyncEventQueue_ and was wondering if the addition of `resetRegistration()` (tentative proc name) would be acceptable. It could be used when tasks catch `AsyncEventQueueFullError` and handle/log the occurence but then continue receiving events using the same key instead of  getting a new one.
