### PR TITLE
HTTP client: Allow request connection management.

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -67,7 +67,8 @@ type
     Custom                    ## None of the above
 
   HttpClientRequestFlag* {.pure.} = enum
-    CloseConnection,          ## Send `Connection: close` in request
+    DedicatedConnection,      ## Create new HTTP connection for request
+    CloseConnection           ## Send `Connection: close` in request
 
   HttpClientConnectionFlag* {.pure.} = enum
     Request,                  ## Connection has pending request
@@ -110,6 +111,7 @@ type
     headersTimeout*: Duration
     connectionBufferSize*: int
     maxConnections*: int
+    connectionsCount*: int
     flags*: HttpClientFlags
 
   HttpAddress* = object
@@ -581,11 +583,14 @@ proc connect(session: HttpSessionRef,
   # If all attempts to connect to the remote host have failed.
   raiseHttpConnectionError("Could not connect to remote host")
 
-proc acquireConnection(session: HttpSessionRef,
-                       ha: HttpAddress): Future[HttpClientConnectionRef] {.
-     async.} =
+proc acquireConnection(
+       session: HttpSessionRef,
+       ha: HttpAddress,
+       flags: set[HttpClientRequestFlag]
+     ): Future[HttpClientConnectionRef] {.async.} =
   ## Obtain connection from ``session`` or establish a new one.
-  if HttpClientFlag.NewConnectionAlways in session.flags:
+  if (HttpClientFlag.NewConnectionAlways in session.flags) or
+     (HttpClientRequestFlag.DedicatedConnection in flags):
     var default: seq[HttpClientConnectionRef]
     let res =
       try:
@@ -594,6 +599,7 @@ proc acquireConnection(session: HttpSessionRef,
         raiseHttpConnectionError("Connection timed out")
     res[].state = HttpClientConnectionState.Acquired
     session.connections.mgetOrPut(ha.id, default).add(res)
+    inc(session.connectionsCount)
     return res
   else:
     let conn =
@@ -620,13 +626,23 @@ proc acquireConnection(session: HttpSessionRef,
           raiseHttpConnectionError("Connection timed out")
       res[].state = HttpClientConnectionState.Acquired
       session.connections.mgetOrPut(ha.id, default).add(res)
+      inc(session.connectionsCount)
       return res
 
 proc removeConnection(session: HttpSessionRef,
                       conn: HttpClientConnectionRef) {.async.} =
-  session.connections.withValue(conn.remoteHostname, connections):
-    connections[].keepItIf(it != conn)
+  let removeHost =
+    block:
+      var res = false
+      session.connections.withValue(conn.remoteHostname, connections):
+        connections[].keepItIf(it != conn)
+        if len(connections[]) == 0:
+          res = true
+      res
+  if removeHost:
+    session.connections.del(conn.remoteHostname)
   await conn.closeWait()
+  dec(session.connectionsCount)
 
 proc releaseConnection(session: HttpSessionRef,
                        connection: HttpClientConnectionRef) {.async.} =
@@ -807,7 +823,11 @@ proc prepareResponse(request: HttpClientRequestRef, data: openArray[byte]
   res.connection.state = HttpClientConnectionState.ResponseHeadersReceived
   if nobodyFlag:
     res.connection.flags.incl(HttpClientConnectionFlag.NoBody)
-  if connectionFlag:
+  let newConnectionAlways =
+    HttpClientFlag.NewConnectionAlways in request.session.flags
+  let closeConnection =
+    HttpClientRequestFlag.CloseConnection in request.flags
+  if connectionFlag and not(newConnectionAlways) and not(closeConnection):
     res.connection.flags.incl(HttpClientConnectionFlag.KeepAlive)
   res.connection.flags.incl(HttpClientConnectionFlag.Response)
   trackHttpClientResponse(res)
@@ -994,7 +1014,7 @@ proc send*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
            "Request's state is " & $request.state)
   let connection =
     try:
-      await request.session.acquireConnection(request.address)
+      await request.session.acquireConnection(request.address, request.flags)
     except CancelledError as exc:
       request.setError(newHttpInterruptError())
       raise exc
@@ -1045,7 +1065,7 @@ proc open*(request: HttpClientRequestRef): Future[HttpBodyWriter] {.
            "Request should not have static body content (len(buffer) == 0)")
   let connection =
     try:
-      await request.session.acquireConnection(request.address)
+      await request.session.acquireConnection(request.address, request.flags)
     except CancelledError as exc:
       request.setError(newHttpInterruptError())
       raise exc

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -641,8 +641,8 @@ proc removeConnection(session: HttpSessionRef,
       res
   if removeHost:
     session.connections.del(conn.remoteHostname)
-  await conn.closeWait()
   dec(session.connectionsCount)
+  await conn.closeWait()
 
 proc releaseConnection(session: HttpSessionRef,
                        connection: HttpClientConnectionRef) {.async.} =


### PR DESCRIPTION
This is proper fix for issue and replaces https://github.com/status-im/nim-chronos/pull/321.
With this fix
1. `NewConnectionAlways` global session flag which will create new connection for every HTTP request and close this connection after request's response received.
2. Added `HttpClientRequestFlag.DedicatedConnection` flag which will force to create new HTTP connection for this specific request. Note: Connection is not going to be closed.
3. `HttpClientRequestFlag.CloseConnection` flag will force HTTP client to send send `Connection: close` HTTP header with specific HTTP request and it also closes connection after response will be received.

So now, instead of using `NewConnectionAlways` you can specify both `DedicatedConnection` and `CloseConnection` to get equal behavior.
