### PR TITLE
Allow to close thread dispatcher

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -446,8 +446,8 @@ when defined(windows):
     return disp.ioPort
 
   proc closeIoHandler(disp: PDispatcher) {.raises: [Defect, OSError].} =
-    if not disp.ioPort.closeHandle():
-      raiseOSError(osLastError)
+    if disp.ioPort.closeHandle() == 0:
+      raiseOSError(osLastError())
 
   proc register*(fd: AsyncFD) {.raises: [Defect, CatchableError].} =
     ## Register file descriptor ``fd`` in thread's dispatcher.

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -850,8 +850,11 @@ proc getThreadDispatcher*(): PDispatcher =
 
 proc closeThreadDispatcher*() {.raises: [Defect, CatchableError].} =
   if gDisp.isNil: return
-  gDisp.closeIoHandler()
+  let prevDisp = gDisp
+  while gDisp.callbacks.len > 1:
+    poll()
   setThreadDispatcher(nil)
+  prevDisp.closeIoHandler()
 
 proc setGlobalDispatcher*(disp: PDispatcher) {.
       gcsafe, deprecated: "Use setThreadDispatcher() instead".} =

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -417,7 +417,7 @@ when defined(windows):
     ## (Unix) for the specified dispatcher.
     return disp.ioPort
 
-  proc closeIoHandler(disp: PDispatcher): Handle {.raises: [Defect, OSError].} =
+  proc closeIoHandler(disp: PDispatcher) {.raises: [Defect, OSError].} =
     disp.ioPort.closeHandle()
 
   proc newDispatcher*(): PDispatcher {.raises: [Defect, CatchableError].} =

--- a/chronos/ioselects/ioselectors_epoll.nim
+++ b/chronos/ioselects/ioselectors_epoll.nim
@@ -98,13 +98,13 @@ proc newSelector*[T](): Selector[T] {.raises: [Defect, OSError].} =
   for i in 0 ..< numFD:
     result.fds[i].ident = InvalidIdent
 
-proc close*[T](s: Selector[T]) =
+proc close*[T](s: Selector[T]) {.raises: [Defect, OSError].} =
   let res = posix.close(s.epollFD)
   when hasThreadSupport:
     deallocSharedArray(s.fds)
     deallocShared(cast[pointer](s))
   if res != 0:
-    raiseIOSelectorsError(osLastError())
+    raiseOSError(osLastError())
 
 proc newSelectEvent*(): SelectEvent {.raises: [Defect, OSError, IOSelectorsException].} =
   let fdci = eventfd(0, 0)

--- a/chronos/ioselects/ioselectors_kqueue.nim
+++ b/chronos/ioselects/ioselectors_kqueue.nim
@@ -129,7 +129,7 @@ proc close*[T](s: Selector[T]) =
     deallocSharedArray(s.fds)
     deallocShared(cast[pointer](s))
   if res1 != 0 or res2 != 0:
-    raiseIOSelectorsError(osLastError())
+    raiseOSError(osLastError())
 
 proc newSelectEvent*(): SelectEvent =
   var fds: array[2, cint]

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -7,5 +7,6 @@
 #              MIT license (LICENSE-MIT)
 import testmacro, testsync, testsoon, testtime, testfut, testsignal,
        testaddress, testdatagram, teststream, testserver, testbugs, testnet,
-       testasyncstream, testhttpserver, testshttpserver, testhttpclient
+       testasyncstream, testhttpserver, testshttpserver, testhttpclient,
+       testclosedispatcher
 import testutils

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -5,8 +5,7 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import testmacro, testsync, testsoon, testtime, testfut, testsignal,
+import testclosedispatcher, testmacro, testsync, testsoon, testtime, testfut, testsignal,
        testaddress, testdatagram, teststream, testserver, testbugs, testnet,
-       testasyncstream, testhttpserver, testshttpserver, testhttpclient,
-       testclosedispatcher
+       testasyncstream, testhttpserver, testshttpserver, testhttpclient
 import testutils

--- a/tests/testclosedispatcher.nim
+++ b/tests/testclosedispatcher.nim
@@ -1,0 +1,22 @@
+#                Chronos Test Suite
+#            (c) Copyright 2022-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import unittest2
+import ../chronos
+
+when defined(nimHasUsed): {.used.}
+
+suite "Dispatcher closing":
+  test "Can close the current dispatcher":
+    waitFor(sleepAsync(1.milliseconds))
+    check isNil(getThreadDispatcher()) == false
+    let beforeClose = getThreadDispatcher()
+    closeThreadDispatcher()
+    waitFor(sleepAsync(1.milliseconds))
+    check:
+      isNil(getThreadDispatcher()) == false
+      getThreadDispatcher() != beforeClose


### PR DESCRIPTION
When a thread finishes, there is currently no way to release the resources of the dispatcher. Which on linux, include a FD & relatively big buffer for `epoll`

We could use `onThreadDestruction` to call "close" automatically, but that raises questions in what to do with pending futures 