### PR TITLE
Fix Future[void] async procedure in generic

### DIFF
--- a/chronos/asyncfutures2.nim
+++ b/chronos/asyncfutures2.nim
@@ -236,6 +236,10 @@ template complete*(future: Future[void]) =
   ## Completes a void ``future``.
   complete(future, getSrcLocation())
 
+template complete*(future: Future[void], val: untyped) =
+  ## Completes ``future``
+  complete(future, getSrcLocation())
+
 proc fail[T](future: Future[T], error: ref CatchableError, loc: ptr SrcLoc) =
   if not(future.cancelled()):
     checkFinished(FutureBase(future), loc)

--- a/chronos/asyncmacro2.nim
+++ b/chronos/asyncmacro2.nim
@@ -106,8 +106,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
   else:
     verifyReturnType(repr(returnType))
 
-  let subtypeIsVoid = returnType.kind == nnkEmpty or
-        (baseType.kind == nnkIdent and returnType[1].eqIdent("void"))
+  let subtypeIsVoid = returnType.kind == nnkEmpty or returnType[1].eqIdent("void")
 
   var outerProcBody = newNimNode(nnkStmtList, prc.body)
 

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -106,11 +106,10 @@ suite "Macro transformations test suite":
     check waitFor(testMacro2()).len == 0
 
   test "Future void in generic bug":
-    proc gen(T: typedesc[int]): T =
-      proc testproc(): Future[void] {.async.} = discard
-      T(5)
+    proc gen(T: typedesc): T =
+      proc testproc(): Future[T] {.async.} = discard
     let test = int.gen()
-
+    void.gen()
 
 suite "Closure iterator's exception transformation issues":
   test "Nested defer/finally not called on return":

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -105,6 +105,13 @@ suite "Macro transformations test suite":
     macroAsync2(testMacro2, seq, Opt, Result, OpenObject, cstring)
     check waitFor(testMacro2()).len == 0
 
+  test "Future void in generic bug":
+    proc gen(T: typedesc[int]): T =
+      proc testproc(): Future[void] {.async.} = discard
+      T(5)
+    let test = int.gen()
+
+
 suite "Closure iterator's exception transformation issues":
   test "Nested defer/finally not called on return":
     # issue #288


### PR DESCRIPTION
```nim
  test "Future void in generic bug":
    proc gen(T: typedesc[int]): T =
      proc testproc(): Future[void] {.async.} = discard
      T(5)
    let test = int.gen()
```
Currently fails

Upstream has a nicer fix: https://github.com/nim-lang/Nim/pull/17633 which also supports aliasing, but it's more invasive, so not sure if we should also integrate it