### PR TITLE
Enable TCP client to enable TCP_NODELAY

### DIFF
--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1532,6 +1532,7 @@ else:
           if sock == asyncInvalidSocket:
             sock.closeSocket()
           retFuture.fail(getTransportOsError(err))
+          return retFuture
 
     proc continuation(udata: pointer) =
       if not(retFuture.finished()):

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1529,8 +1529,7 @@ else:
         if not(setSockOpt(sock, handles.IPPROTO_TCP,
                           handles.TCP_NODELAY, 1)):
           let err = osLastError()
-          if sock == asyncInvalidSocket:
-            sock.closeSocket()
+          sock.closeSocket()
           retFuture.fail(getTransportOsError(err))
           return retFuture
 


### PR DESCRIPTION
That's probably not the proper way to do it, but currently, TCP_NODELAY can only be enabled on the server, not on the client