### PR TITLE
TCP write cancellation support

### DIFF
--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -329,7 +329,6 @@ elif defined(windows):
     (t).rwsabuf.buf = cast[cstring](
       cast[uint](addr t.buffer[0]) + uint((t).roffset))
     (t).rwsabuf.len = int32(len((t).buffer) - (t).roffset)
-    v.usedInWsa = true
 
   template setWriterWSABuffer(t, v: untyped) =
     (t).wwsabuf.buf = cast[cstring](v.buf)
@@ -2139,7 +2138,7 @@ proc addToWriteQueue(transp: StreamTransport, vector: StreamVector) =
       if item.writer == vector.writer:
         var canCancel = item.buflen == item.size
         when defined(windows):
-          canCancel = canCancel and vector.usedInWsa == false
+          canCancel = canCancel and item.usedInWsa == false
         if canCancel:
           item.buflen = 0
           vector.writer.child = nil

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -727,14 +727,14 @@ suite "Stream Transport test suite":
     let size = 500000
     proc client(server: StreamServer, transp: StreamTransport) {.async.} =
       let bigMsg = createBigMessage(size)
-      var futs: seq[Future[int]]
+      var futs = newSeq[Future[int]]()
       for _ in 0..<10:
         futs.add(transp.write(bigMsg))
 
       for f in futs:
         f.cancel()
       syncFut.complete()
-      await allFutures(futs.mapIt(it.cancelAndWait()))
+      await allFutures(futs)
 
       let cancelledCount = futs.countIt(it.cancelled)
       doAssert cancelledCount > 0

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -728,7 +728,8 @@ suite "Stream Transport test suite":
     proc client(server: StreamServer, transp: StreamTransport) {.async.} =
       let bigMsg = createBigMessage(size)
       var futs = newSeq[Future[int]]()
-      for _ in 0..<10:
+      discard await transp.write(bigMsg)
+      for _ in 0..<9:
         futs.add(transp.write(bigMsg))
 
       for f in futs:
@@ -751,7 +752,7 @@ suite "Stream Transport test suite":
     var buffer = newSeq[byte](size)
     await ntransp.readExactly(unsafeAddr buffer[0], buffer.len)
 
-    let expectedMsgs = (await syncFut1) - 1
+    let expectedMsgs = await syncFut1
     buffer.setLen(size * expectedMsgs)
     result = true
     await ntransp.readExactly(unsafeAddr buffer[0], buffer.len)


### PR DESCRIPTION
This PR allows to cancel TCP write, if they are not already begun
Seems to work on every platform, surprisingly