### PR TITLE
export selector and handles fields from PDispatcher to support third-party extensions

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -302,7 +302,7 @@ when defined(windows) or defined(nimdoc):
 
     PDispatcher* = ref object of PDispatcherBase
       ioPort: Handle
-      handles: HashSet[AsyncFD]
+      handles*: HashSet[AsyncFD]
       connectEx*: WSAPROC_CONNECTEX
       acceptEx*: WSAPROC_ACCEPTEX
       getAcceptExSockAddrs*: WSAPROC_GETACCEPTEXSOCKADDRS
@@ -504,7 +504,7 @@ elif unixPlatform:
       wdata*: CompletionData
 
     PDispatcher* = ref object of PDispatcherBase
-      selector: Selector[SelectorData]
+      selector*: Selector[SelectorData]
       keys: seq[ReadyKey]
 
   proc `==`*(x, y: AsyncFD): bool {.borrow.}


### PR DESCRIPTION
https://github.com/status-im/nim-chronos/pull/154, but pushed to the version used in the nim-task-runner used by status desktop