### PR TITLE
allow reuse of port for UDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nimcache/
 nimble.develop
 nimble.paths
 /build/
+nimbledeps

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -314,6 +314,13 @@ when defined(windows):
           closeSocket(localSock)
         raiseTransportOsError(err)
 
+    if ServerFlags.ReusePort in flags:
+      if not setSockOpt(localSock, osdefs.SOL_SOCKET, osdefs.SO_REUSEPORT, 1):
+        let err = osLastError()
+        if sock == asyncInvalidSocket:
+          closeSocket(localSock)
+        raiseTransportOsError(err)
+
     if ServerFlags.Broadcast in flags:
       if not setSockOpt(localSock, osdefs.SOL_SOCKET, osdefs.SO_BROADCAST, 1):
         let err = osLastError()
@@ -513,6 +520,13 @@ else:
     ## Apply ServerFlags here
     if ServerFlags.ReuseAddr in flags:
       if not setSockOpt(localSock, osdefs.SOL_SOCKET, osdefs.SO_REUSEADDR, 1):
+        let err = osLastError()
+        if sock == asyncInvalidSocket:
+          closeSocket(localSock)
+        raiseTransportOsError(err)
+
+    if ServerFlags.ReusePort in flags:
+      if not setSockOpt(localSock, osdefs.SOL_SOCKET, osdefs.SO_REUSEPORT, 1):
         let err = osLastError()
         if sock == asyncInvalidSocket:
           closeSocket(localSock)


### PR DESCRIPTION
My use case was to have several process running on the same host listening for udp broadcast on a given port.  I needed to setup the same 0.0.0.0:xxxx in each process and it works only if SO_REUSEPORT is set