### PR TITLE
Fix missing imports in posix environment

### DIFF
--- a/chronos/selectors2.nim
+++ b/chronos/selectors2.nim
@@ -35,6 +35,9 @@ import stew/results
 import osdefs, osutils, oserrno
 export results, oserrno
 
+when defined(posix):
+  import std/posix
+
 const
   asyncEventsCount* {.intdefine.} = 64
     ## Number of epoll events retrieved by syscall.


### PR DESCRIPTION
Fix a problem that can't compile with the following error.

```
$ nim -v

Nim Compiler Version 1.6.12 [Linux: amd64]
Compiled at 2023-03-10
Copyright (c) 2006-2023 by Andreas Rumpf

git hash: 1aa9273640c0c51486cf3a7b67282fe58f360e91
active boot switches: -d:release
```

```
$ cd my-app
$ nimble build
.
.
.
/home/fox/.nimble/pkgs/chronos-3.1.0/chronos/selectors2.nim(298, 12) Error: undeclared identifier: 'sigprocmask'
candidates (edit distance, scope distance); see '--spellSuggest':
 (6, 6): 'EINPROGRESS' [const declared in /home/fox/.nimble/pkgs/chronos-3.1.0/chronos/oserrno.nim(1274, 5)]
 (6, 6): 'EINPROGRESS' [const declared in /home/fox/.nimble/pkgs/chronos-3.1.0/chronos/oserrno.nim(1274, 5)]
 (6, 6): 'EINPROGRESS' [const declared in /home/fox/.nimble/pkgs/chronos-3.1.0/chronos/oserrno.nim(1274, 5)]
 (6, 6): 'SIG_BLOCK' [const declared in /home/fox/.choosenim/toolchains/nim-1.6.12/lib/posix/posix_linux_amd64_consts.nim(403, 7)]
 (6, 6): 'SIG_BLOCK' [const declared in /home/fox/.choosenim/toolchains/nim-1.6.12/lib/posix/posix_linux_amd64_consts.nim(403, 7)]
 (6, 6): 'procCall' [proc declared in /home/fox/.choosenim/toolchains/nim-1.6.12/lib/system.nim(2965, 6)]
       Tip: 750 messages have been suppressed, use --verbose to show them.
.
.
.
```