### PR TITLE
Less flaky rate limit tests

### DIFF
--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -33,7 +33,9 @@ proc update(bucket: TokenBucket, currentTime: Moment) =
     bucket.budget = min(bucket.budgetCap, bucket.budget)
     return
 
-  assert currentTime >= bucket.lastUpdate
+  if currentTime < bucket.lastUpdate:
+    return
+
   let
     timeDelta = currentTime - bucket.lastUpdate
     fillPercent = timeDelta.milliseconds.float / bucket.fillDuration.milliseconds.float

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -28,13 +28,12 @@ type
     pendingRequests: seq[BucketWaiter]
     manuallyReplenished: AsyncEvent
 
-proc update(bucket: TokenBucket) =
+proc update(bucket: TokenBucket, currentTime: Moment) =
   if bucket.fillDuration == default(Duration):
     bucket.budget = min(bucket.budgetCap, bucket.budget)
     return
 
   let
-    currentTime = Moment.now()
     timeDelta = currentTime - bucket.lastUpdate
     fillPercent = timeDelta.milliseconds.float / bucket.fillDuration.milliseconds.float
     replenished =
@@ -46,7 +45,7 @@ proc update(bucket: TokenBucket) =
   bucket.lastUpdate += milliseconds(deltaFromReplenished)
   bucket.budget = min(bucket.budgetCap, bucket.budget + replenished)
 
-proc tryConsume*(bucket: TokenBucket, tokens: int): bool =
+proc tryConsume*(bucket: TokenBucket, tokens: int, now = Moment.now()): bool =
   ## If `tokens` are available, consume them,
   ## Otherwhise, return false.
 
@@ -54,7 +53,7 @@ proc tryConsume*(bucket: TokenBucket, tokens: int): bool =
     bucket.budget -= tokens
     return true
 
-  bucket.update()
+  bucket.update(now)
 
   if bucket.budget >= tokens:
     bucket.budget -= tokens
@@ -93,12 +92,12 @@ proc worker(bucket: TokenBucket) {.async.} =
 
   bucket.workFuture = nil
 
-proc consume*(bucket: TokenBucket, tokens: int): Future[void] =
+proc consume*(bucket: TokenBucket, tokens: int, now = Moment.now()): Future[void] =
   ## Wait for `tokens` to be available, and consume them.
 
   let retFuture = newFuture[void]("TokenBucket.consume")
   if isNil(bucket.workFuture) or bucket.workFuture.finished():
-    if bucket.tryConsume(tokens):
+    if bucket.tryConsume(tokens, now):
       retFuture.complete()
       return retFuture
 
@@ -119,10 +118,10 @@ proc consume*(bucket: TokenBucket, tokens: int): Future[void] =
 
   return retFuture
 
-proc replenish*(bucket: TokenBucket, tokens: int) =
+proc replenish*(bucket: TokenBucket, tokens: int, now = Moment.now()) =
   ## Add `tokens` to the budget (capped to the bucket capacity)
   bucket.budget += tokens
-  bucket.update()
+  bucket.update(now)
   bucket.manuallyReplenished.fire()
 
 proc new*(

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -33,6 +33,7 @@ proc update(bucket: TokenBucket, currentTime: Moment) =
     bucket.budget = min(bucket.budgetCap, bucket.budget)
     return
 
+  assert currentTime >= bucket.lastUpdate
   let
     timeDelta = currentTime - bucket.lastUpdate
     fillPercent = timeDelta.milliseconds.float / bucket.fillDuration.milliseconds.float

--- a/tests/testratelimit.nim
+++ b/tests/testratelimit.nim
@@ -31,7 +31,7 @@ suite "Token Bucket":
       bucket.tryConsume(100, fullTime) == false
 
   test "Async test":
-    var bucket = TokenBucket.new(1000, 500.milliseconds)
+    var bucket = TokenBucket.new(1000, 1000.milliseconds)
     check: bucket.tryConsume(1000) == true
 
     var toWait = newSeq[Future[void]]()
@@ -42,17 +42,14 @@ suite "Token Bucket":
     waitFor(allFutures(toWait))
     let duration = Moment.now() - start
 
-    check: duration in 700.milliseconds .. 1100.milliseconds
+    check: duration in 1400.milliseconds .. 2200.milliseconds
 
   test "Over budget async":
-    var bucket = TokenBucket.new(100, 10.milliseconds)
+    var bucket = TokenBucket.new(100, 100.milliseconds)
     # Consume 10* the budget cap
     let beforeStart = Moment.now()
-    waitFor(bucket.consume(1000).wait(1.seconds))
-    when not defined(macosx):
-      # CI's macos scheduler is so jittery that this tests sometimes takes >500ms
-      # the test will still fail if it's >1 seconds
-      check Moment.now() - beforeStart in 90.milliseconds .. 150.milliseconds
+    waitFor(bucket.consume(1000).wait(5.seconds))
+    check Moment.now() - beforeStart in 900.milliseconds .. 1500.milliseconds
 
   test "Sync manual replenish":
     var bucket = TokenBucket.new(1000, 0.seconds)


### PR DESCRIPTION
Let the caller specify the "now" (which outside of tests, can be useful to avoid querying the clock multiple times, if the caller already knows the `now`)

In sync test, modify the `now` parameter instead of sleeping to avoid flakyness
In async tests, this is unfortunately not possible since the `worker` will actually sleep to wait for the bucket to fill