### PR TITLE
Fix type mismatch error in asyncstream join

### DIFF
--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -873,10 +873,10 @@ proc join*(rw: AsyncStreamRW): Future[void] =
   else:
     var retFuture = newFuture[void]("async.stream.writer.join")
 
-  proc continuation(udata: pointer) {.gcsafe.} =
+  proc continuation(udata: pointer) {.gcsafe, raises:[].} =
     retFuture.complete()
 
-  proc cancellation(udata: pointer) {.gcsafe.} =
+  proc cancellation(udata: pointer) {.gcsafe, raises:[].} =
     rw.future.removeCallback(continuation, cast[pointer](retFuture))
 
   if not(rw.future.finished()):


### PR DESCRIPTION
I get this error when compile using Nim 1.16.12 in nimbus-eth1

```text
F:\projects\nimbus-eth1\vendor\nim-chronos\chronos\streams\asyncstream.nim(930, 5) template/generic instantiation of `join` from here
F:\projects\nimbus-eth1\vendor\nim-chronos\chronos\streams\asyncstream.nim(880, 14) Error: type mismatch: got <Future[system.void], proc (udata: pointer){.closure, gcsafe, locks: <unknown>.}, pointer>
but expected one of:
proc removeCallback(future: FutureBase; cb: CallbackFunc)
  first type mismatch at position: 2
  required type for cb: CallbackFunc
  but expression 'continuation' is of type: proc (udata: pointer){.closure, gcsafe, locks: <unknown>.}
  The `.raises` requirements differ.
proc removeCallback(future: FutureBase; cb: CallbackFunc; udata: pointer)
  first type mismatch at position: 2
  required type for cb: CallbackFunc
  but expression 'continuation' is of type: proc (udata: pointer){.closure, gcsafe, locks: <unknown>.}
  The `.raises` requirements differ.

expression: removeCallback(rw.future, continuation, cast[pointer](retFuture))
```