### PR TITLE
Callback duration metric

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -15,7 +15,7 @@ import std/[tables, strutils, heapqueue, deques]
 import stew/results
 import "."/[config, futures, osdefs, oserrno, osutils, timer]
 
-when defined(chronosEnableCallbackDurationMetric):
+when chronosEnableCallbackDurationMetric:
   import std/monotimes
   import pkg/metrics
 
@@ -266,14 +266,14 @@ template processCallbacks(loop: untyped) =
     if isSentinel(callable):
       break
     if not(isNil(callable.function)):
-      when defined(chronosEnableCallbackDurationMetric):
+      when chronosEnableCallbackDurationMetric:
         let startTime = getMonoTime().ticks
 
       callable.function(callable.udata)
 
-      when defined(chronosEnableCallbackDurationMetric):
+      when chronosEnableCallbackDurationMetric:
         let durationUs = (getMonoTime().ticks - startTime) div 1000
-        chronosCallbackDuration.set(durationNs)
+        chronosCallbackDuration.set(durationUs)
 
 proc raiseAsDefect*(exc: ref Exception, msg: string) {.noreturn, noinline.} =
   # Reraise an exception as a Defect, where it's unexpected and can't be handled

--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -70,7 +70,7 @@ when (NimMajor, NimMinor) >= (1, 4):
         ""
       ## OS polling engine type which is going to be used by chronos.
 
-    chronosEnableCallbackDurationMetric {.booldefine.} = false
+    chronosEnableCallbackDurationMetric* {.booldefine.} = defined(chronosEnableCallbackDurationMetric)
       ## At the cost of some performance, produce a 'chronosCallbackDuration' metric.
       ## Useful for detecting application stalling/blocking.
 

--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -70,6 +70,10 @@ when (NimMajor, NimMinor) >= (1, 4):
         ""
       ## OS polling engine type which is going to be used by chronos.
 
+    chronosEnableCallbackDurationMetric {.booldefine.} = false
+      ## At the cost of some performance, produce a 'chronosCallbackDuration' metric.
+      ## Useful for detecting application stalling/blocking.
+
 else:
   # 1.2 doesn't support `booldefine` in `when` properly
   const


### PR DESCRIPTION
All right... this doesn't currently work and I need some help.

Here's the goal:
As a chronos user, I want to be able to measure callbacks durations (when using debug builds), so that I can be informed about long callbacks that will cause my app to block/not respond.

I've added a compile-flag and some code to asyncloop.nim to try and get this going, only to realize that chronos doesn't use nim-metrics. (And can't because nim-metrics uses chronos?) So I'm writing this message to ask help from you, experienced chronos developers! Do you see a use for a feature of this sort? How can this best be accomplished?
