### PR TITLE
Several changes mostly on windows platform

### DIFF
--- a/chronos/osdefs.nim
+++ b/chronos/osdefs.nim
@@ -166,6 +166,8 @@ when defined(windows):
     SO_RCVTIMEO* = 0x1006
     SO_ERROR* = 0x1007
     SO_TYPE* = 0x1008
+    IPV6_V6ONLY* = 0x1b
+
     TCP_NODELAY* = 1
 
     STD_INPUT_HANDLE* = 0xFFFF_FFF6'u32

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -270,7 +270,13 @@ when defined(windows):
       if bres.isErr():
         raiseTransportOsError(bres.error())
 
+
     ## Apply ServerFlags here
+
+    # allowing dual-stack socket 
+    if local.family in {AddressFamily.IPv6}:
+      discard setSockOpt(localSock,osdefs.IPPROTO_IPV6,IPV6_V6ONLY,0)
+
     if ServerFlags.ReuseAddr in flags:
       if not setSockOpt(localSock, osdefs.SOL_SOCKET, osdefs.SO_REUSEADDR, 1):
         let err = osLastError()

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1894,7 +1894,7 @@ proc createStreamServer*(host: TransportAddress,
 
       # allowing dual-stack socket 
       if host.family in {AddressFamily.IPv6}:
-        discard setSockOpt(serverSocket,osdefs.IPPROTO_IPV6,IPV6_V6ONLY,0):  
+        discard setSockOpt(serverSocket,osdefs.IPPROTO_IPV6,IPV6_V6ONLY,0)
 
       # SO_REUSEADDR is not useful for Unix domain sockets.
       if ServerFlags.ReuseAddr in flags:

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1891,6 +1891,11 @@ proc createStreamServer*(host: TransportAddress,
         if wres.isErr():
           raiseTransportOsError(wres.error())
         serverSocket = sock
+
+      # allowing dual-stack socket 
+      if host.family in {AddressFamily.IPv6}:
+        discard setSockOpt(serverSocket,osdefs.IPPROTO_IPV6,IPV6_V6ONLY,0):  
+
       # SO_REUSEADDR is not useful for Unix domain sockets.
       if ServerFlags.ReuseAddr in flags:
         if not(setSockOpt(serverSocket, SOL_SOCKET, SO_REUSEADDR, 1)):

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1090,6 +1090,8 @@ when defined(windows):
           server.asock.closeSocket()
           retFuture.fail(getServerUseClosedError())
           server.clean()
+        of ERROR_NETNAME_DELETED: 
+            discard # retry
         of WSAENETDOWN, WSAENETRESET, WSAECONNABORTED, WSAECONNRESET,
            WSAETIMEDOUT:
           server.asock.closeSocket()


### PR DESCRIPTION
Hi, thanks for this awesome and useful lib, which I have used to build my own project [ReverseTlsTunnel](https://github.com/radkesvat/ReverseTlsTunnel)

In this pull request I have done some small changes as I describe below:

First on Windows, ill allow the server sockets (both TCP/UDP) to be Dual-Stack Socket meaning that it can accept 
connections from ipv4 as well as ipv6, on a single ipv6 socket

This was the default on most Unix-like platforms, but not for windows, so I only made this change for windows by calling:

> setSockOpt(serverSocket,osdefs.IPPROTO_IPV6,IPV6_V6ONLY,0)

Also note that I have added "IPPROTO_IPV6" definition to osdefs.nim (windows only) since it was required, with the value of 0x1b

***
The second change is to ignore the returned error code ERROR_NETNAME_DELETED in accept loop
this is also a change only for the windows platform code.

In my project, I had a problem that the server was crashing with the error code 

> [64] The specified network name is no longer available.

The server could only work for maximum 3 to 5 minutes, and then it would crash with that error.

So I have done some research and the solution was to ignore that error and try to accept a new connection.
More details are described here, in a [cpython issue](https://github.com/python/cpython/issues/93821).

They had this problem as well and fixed it by ignoring it.

After adding this change, my program is working perfectly fine on Windows without crashing.




