### PR TITLE
`asyncraises` -> `async: (raises: ..., raw: ...)`

### DIFF
--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -131,4 +131,4 @@
 import ./internal/[asyncengine, asyncfutures, asyncmacro, errors]
 
 export asyncfutures, asyncengine, errors
-export asyncmacro.async, asyncmacro.await, asyncmacro.awaitne, asyncraises
+export asyncmacro.async, asyncmacro.await, asyncmacro.awaitne

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -21,7 +21,7 @@ export Port
 export deques, errors, futures, timer, results
 
 export
-  asyncmacro.async, asyncmacro.await, asyncmacro.awaitne, asyncmacro.asyncraises
+  asyncmacro.async, asyncmacro.await, asyncmacro.awaitne
 
 const
   MaxEventsCount* = 64


### PR DESCRIPTION
Per discussion in
https://github.com/status-im/nim-chronos/pull/251#issuecomment-1559233139, `async: (parameters..)` is introduced as a way to customize the async transformation instead of relying on separate keywords (like asyncraises).

Two parameters are available as of now:

`raises`: controls the exception effect tracking
`raw`: disables body transformation

Parameters are added to `async` as a tuple allowing more params to be added easily in the future:
```nim
proc f() {.async: (name: value, ...).}
```