### PR TITLE
futures: sinkify

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -202,14 +202,14 @@ proc finish(fut: FutureBase, state: FutureState) =
   when chronosFutureTracking:
     scheduleDestructor(fut)
 
-proc complete[T](future: Future[T], val: T, loc: ptr SrcLoc) =
+proc complete[T](future: Future[T], val: sink T, loc: ptr SrcLoc) =
   if not(future.cancelled()):
     checkFinished(future, loc)
     doAssert(isNil(future.internalError))
-    future.internalValue = val
+    future.internalValue = chronosMoveSink(val)
     future.finish(FutureState.Completed)
 
-template complete*[T](future: Future[T], val: T) =
+template complete*[T](future: Future[T], val: sink T) =
   ## Completes ``future`` with value ``val``.
   complete(future, val, getSrcLocation())
 

--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -157,7 +157,7 @@ proc wrapInTryFinally(
               newCall(ident "complete", fut)
             ),
             nnkElseExpr.newTree(
-              newCall(ident "complete", fut, ident "result")
+              newCall(ident "complete", fut, newCall(ident "move", ident "result"))
             )
           )
         )

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -15,7 +15,7 @@
 import
   bearssl/[brssl, ec, errors, pem, rsa, ssl, x509],
   bearssl/certs/cacert
-import ../asyncloop, ../timer, ../asyncsync
+import ".."/[asyncloop, asyncsync, config, timer]
 import asyncstream, ../transports/stream, ../transports/common
 export asyncloop, asyncsync, timer, asyncstream
 
@@ -62,7 +62,7 @@ type
 
   PEMContext = ref object
     data: seq[byte]
-  
+
   TrustAnchorStore* = ref object
     anchors: seq[X509TrustAnchor]
 
@@ -158,7 +158,7 @@ proc tlsWriteRec(engine: ptr SslEngineContext,
     var length = 0'u
     var buf = sslEngineSendrecBuf(engine[], length)
     doAssert(length != 0 and not isNil(buf))
-    await writer.wsource.write(buf, int(length))
+    await writer.wsource.write(chronosMoveSink(buf), int(length))
     sslEngineSendrecAck(engine[], length)
     TLSResult.Success
   except AsyncStreamError as exc:
@@ -481,7 +481,7 @@ proc newTLSClientAsyncStream*(
   ## ``minVersion`` of bigger then ``maxVersion`` you will get an error.
   ##
   ## ``flags`` - custom TLS connection flags.
-  ## 
+  ##
   ## ``trustAnchors`` - use this if you want to use certificate trust
   ## anchors other than the default Mozilla trust anchors. If you pass
   ## a ``TrustAnchorStore`` you should reuse the same instance for

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -596,22 +596,6 @@ proc raiseTransportOsError*(err: OSErrorCode) {.
   ## Raises transport specific OS error.
   raise getTransportOsError(err)
 
-type
-  SeqHeader = object
-    length, reserved: int
-
-proc isLiteral*(s: string): bool {.inline.} =
-  when defined(gcOrc) or defined(gcArc):
-    false
-  else:
-    (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
-proc isLiteral*[T](s: seq[T]): bool {.inline.} =
-  when defined(gcOrc) or defined(gcArc):
-    false
-  else:
-    (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
 template getTransportTooManyError*(
            code = OSErrorCode(0)
          ): ref TransportTooManyError =

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -11,7 +11,7 @@
 
 import std/deques
 when not(defined(windows)): import ".."/selectors2
-import ".."/[asyncloop, osdefs, oserrno, osutils, handles]
+import ".."/[asyncloop, config, osdefs, oserrno, osutils, handles]
 import "."/common
 
 type
@@ -894,7 +894,7 @@ proc send*(transp: DatagramTransport, msg: sink string,
   transp.checkClosed(retFuture)
 
   let length = if msglen <= 0: len(msg) else: msglen
-  var localCopy = msg
+  var localCopy = chronosMoveSink(msg)
   retFuture.addCallback(proc(_: pointer) = reset(localCopy))
 
   let vector = GramVector(kind: WithoutAddress, buf: addr localCopy[0],
@@ -917,7 +917,7 @@ proc send*[T](transp: DatagramTransport, msg: sink seq[T],
   transp.checkClosed(retFuture)
 
   let length = if msglen <= 0: (len(msg) * sizeof(T)) else: (msglen * sizeof(T))
-  var localCopy = msg
+  var localCopy = chronosMoveSink(msg)
   retFuture.addCallback(proc(_: pointer) = reset(localCopy))
 
   let vector = GramVector(kind: WithoutAddress, buf: addr localCopy[0],
@@ -955,7 +955,7 @@ proc sendTo*(transp: DatagramTransport, remote: TransportAddress,
   transp.checkClosed(retFuture)
 
   let length = if msglen <= 0: len(msg) else: msglen
-  var localCopy = msg
+  var localCopy = chronosMoveSink(msg)
   retFuture.addCallback(proc(_: pointer) = reset(localCopy))
 
   let vector = GramVector(kind: WithAddress, buf: addr localCopy[0],
@@ -977,7 +977,7 @@ proc sendTo*[T](transp: DatagramTransport, remote: TransportAddress,
   var retFuture = newFuture[void]("datagram.transport.sendTo(seq)")
   transp.checkClosed(retFuture)
   let length = if msglen <= 0: (len(msg) * sizeof(T)) else: (msglen * sizeof(T))
-  var localCopy = msg
+  var localCopy = chronosMoveSink(msg)
   retFuture.addCallback(proc(_: pointer) = reset(localCopy))
 
   let vector = GramVector(kind: WithAddress, buf: addr localCopy[0],

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -1997,3 +1997,9 @@ suite "Future[T] behavior test suite":
       check:
         future1.cancelled() == true
         future2.cancelled() == true
+  test "Sink with literals":
+    # https://github.com/nim-lang/Nim/issues/22175
+    let fut = newFuture[string]()
+    fut.complete("test")
+    check:
+      fut.value() == "test"


### PR DESCRIPTION
This avoids copies here and there throughout the pipeline - ie `copyString` and friends can often be avoided when moving things into and out of futures

Annoyingly, one has to sprinkle the codebase liberally with `sink` and `move` for the pipeline to work well - sink stuff _generally_ works better in orc/arc

Looking at nim 1.6/refc, sink + local variable + move generates the best code:

msg directly:
```nim
	T1_ = (*colonenv_).msg1; (*colonenv_).msg1 = copyStringRC1(msg);
```

local copy without move:
```nim
	T60_ = (*colonenv_).localCopy1; (*colonenv_).localCopy1 =
copyStringRC1(msg);
```

local copy with move:
```nim
	asgnRef((void**) (&(*colonenv_).localCopy1), msg);
```

Annoyingly, sink is also broken for refc+literals as it tries to changes the refcount of the literal as part of the move (which shouldn't be happening, but here we are), so we have to use a hack to find literals and avoid moving them.