### PR TITLE
prevent http `closeWait` future from being cancelled

### DIFF
--- a/chronos/apps/http/httpbodyrw.nim
+++ b/chronos/apps/http/httpbodyrw.nim
@@ -43,7 +43,7 @@ proc closeWait*(bstream: HttpBodyReader) {.async: (raises: []).} =
   ## Close and free resource allocated by body reader.
   if bstream.bstate == HttpState.Alive:
     bstream.bstate = HttpState.Closing
-    var res = newSeq[Future[void]]()
+    var res = newSeq[Future[void].Raising([])]()
     # We closing streams in reversed order because stream at position [0], uses
     # data from stream at position [1].
     for index in countdown((len(bstream.streams) - 1), 0):
@@ -68,7 +68,7 @@ proc closeWait*(bstream: HttpBodyWriter) {.async: (raises: []).} =
   ## Close and free all the resources allocated by body writer.
   if bstream.bstate == HttpState.Alive:
     bstream.bstate = HttpState.Closing
-    var res = newSeq[Future[void]]()
+    var res = newSeq[Future[void].Raising([])]()
     for index in countdown(len(bstream.streams) - 1, 0):
       res.add(bstream.streams[index].closeWait())
     await noCancel(allFutures(res))

--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -524,6 +524,9 @@ proc closeWait*(ab: AsyncEventQueue): Future[void] {.
   proc continuation(udata: pointer) {.gcsafe.} =
     retFuture.complete()
 
+  # Ignore cancellation requests - we'll complete the future soon enough
+  retFuture.cancelCallback = nil
+
   ab.close()
   # Schedule `continuation` to be called only after all the `reader`
   # notifications will be scheduled and processed.

--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -523,15 +523,10 @@ proc closeWait*(ab: AsyncEventQueue): Future[void] {.
                                   {FutureFlag.OwnCancelSchedule})
   proc continuation(udata: pointer) {.gcsafe.} =
     retFuture.complete()
-  proc cancellation(udata: pointer) {.gcsafe.} =
-    # We are not going to change the state of `retFuture` to cancelled, so we
-    # will prevent the entire sequence of Futures from being cancelled.
-    discard
 
   ab.close()
   # Schedule `continuation` to be called only after all the `reader`
   # notifications will be scheduled and processed.
-  retFuture.cancelCallback = cancellation
   callSoon(continuation)
   retFuture
 

--- a/chronos/futures.nim
+++ b/chronos/futures.nim
@@ -34,13 +34,19 @@ type
 
   FutureFlag* {.pure.} = enum
     OwnCancelSchedule
-      ## This future does not participate in the automatic cancellation chain -
-      ## the owner of the future must set a `cancelCallback` - if cancellation
-      ## requests should be ignored, `cancelCallback` can be set to `nil`.
+      ## When OwnCancelSchedule is set, the owner of the future is responsible
+      ## for implementing cancellation in one of 3 ways:
       ##
-      ## Failure to set `cancellCallback` will result in a `Defect` if `cancel`
-      ## is called on the future - such futures must thus never participate
-      ## in `await` without `noCancel` or an equivalent mechanism.
+      ## * ensure that cancellation requests never reach the future by means of
+      ##   not exposing it to user code, `await` and `tryCancel`
+      ## * set `cancelCallback` to `nil` to stop cancellation propagation - this
+      ##   is appropriate when it is expected that the future will be completed
+      ##   in a regular way "soon"
+      ## * set `cancelCallback` to a handler that implements cancellation in an
+      ##   operation-specific way
+      ##
+      ## If `cancelCallback` is not set and the future gets cancelled, a
+      ## `Defect` will be raised.
 
   FutureFlags* = set[FutureFlag]
 

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -1013,6 +1013,7 @@ proc cancelAndWait*(future: FutureBase, loc: ptr SrcLoc): Future[void] {.
   if future.finished():
     retFuture.complete()
   else:
+    retFuture.cancelCallback = nil
     cancelSoon(future, continuation, cast[pointer](retFuture), loc)
 
   retFuture
@@ -1057,6 +1058,7 @@ proc noCancel*[F: SomeFuture](future: F): auto = # async: (raw: true, raises: as
   if future.finished():
     completeFuture()
   else:
+    retFuture.cancelCallback = nil
     future.addCallback(continuation)
   retFuture
 

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -901,9 +901,7 @@ proc closeWait*(rw: AsyncStreamRW): Future[void] {.async: (raises: []).} =
   ## Close and frees resources of stream ``rw``.
   if not rw.closed():
     rw.close()
-    # noCancel needed here to prevent cancellation from reaching rw.future -
-    # see assert on init
-    await noCancel rw.future
+    await noCancel(rw.join())
 
 proc startReader(rstream: AsyncStreamReader) =
   rstream.state = Running

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -912,8 +912,6 @@ proc startReader(rstream: AsyncStreamReader) =
   else:
     rstream.future = Future[void].Raising([]).init(
       "async.stream.empty.reader", {FutureFlag.OwnCancelSchedule})
-    rstream.future.cancelCallback = proc(_: pointer) =
-      raiseAssert "this future should not be cancelled"
 
 proc startWriter(wstream: AsyncStreamWriter) =
   wstream.state = Running
@@ -922,8 +920,6 @@ proc startWriter(wstream: AsyncStreamWriter) =
   else:
     wstream.future = Future[void].Raising([]).init(
       "async.stream.empty.writer", {FutureFlag.OwnCancelSchedule})
-    wstream.future.cancelCallback = proc(_: pointer) =
-      raiseAssert "this future should not be cancelled"
 
 proc init*(child, wsource: AsyncStreamWriter, loop: StreamWriterLoop,
            queueSize = AsyncStreamDefaultQueueSize) =

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -73,7 +73,7 @@ when defined(windows) or defined(nimdoc):
       udata*: pointer               # User-defined pointer
       flags*: set[ServerFlags]      # Flags
       bufferSize*: int              # Size of internal transports' buffer
-      loopFuture*: Future[void].Raising([CancelledError])     # Server's main Future
+      loopFuture*: Future[void].Raising([])     # Server's main Future
       domain*: Domain               # Current server domain (IPv4 or IPv6)
       apending*: bool
       asock*: AsyncFD               # Current AcceptEx() socket
@@ -92,7 +92,7 @@ else:
       udata*: pointer               # User-defined pointer
       flags*: set[ServerFlags]      # Flags
       bufferSize*: int              # Size of internal transports' buffer
-      loopFuture*: Future[void].Raising([CancelledError]) # Server's main Future
+      loopFuture*: Future[void].Raising([]) # Server's main Future
       errorCode*: OSErrorCode       # Current error code
       dualstack*: DualStackType     # IPv4/IPv6 dualstack parameters
 

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -73,7 +73,7 @@ when defined(windows) or defined(nimdoc):
       udata*: pointer               # User-defined pointer
       flags*: set[ServerFlags]      # Flags
       bufferSize*: int              # Size of internal transports' buffer
-      loopFuture*: Future[void]     # Server's main Future
+      loopFuture*: Future[void].Raising([CancelledError])     # Server's main Future
       domain*: Domain               # Current server domain (IPv4 or IPv6)
       apending*: bool
       asock*: AsyncFD               # Current AcceptEx() socket
@@ -92,7 +92,7 @@ else:
       udata*: pointer               # User-defined pointer
       flags*: set[ServerFlags]      # Flags
       bufferSize*: int              # Size of internal transports' buffer
-      loopFuture*: Future[void]     # Server's main Future
+      loopFuture*: Future[void].Raising([CancelledError]) # Server's main Future
       errorCode*: OSErrorCode       # Current error code
       dualstack*: DualStackType     # IPv4/IPv6 dualstack parameters
 

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -359,7 +359,8 @@ when defined(windows):
     res.queue = initDeque[GramVector]()
     res.udata = udata
     res.state = {ReadPaused, WritePaused}
-    res.future = newFuture[void]("datagram.transport")
+    res.future = Future[void].Raising([CancelledError]).init(
+      "datagram.transport")
     res.rovl.data = CompletionData(cb: readDatagramLoop,
                                       udata: cast[pointer](res))
     res.wovl.data = CompletionData(cb: writeDatagramLoop,

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -44,7 +44,7 @@ type
     remote: TransportAddress        # Remote address
     udata*: pointer                 # User-driven pointer
     function: DatagramCallback      # Receive data callback
-    future: Future[void]            # Transport's life future
+    future: Future[void].Raising([CancelledError]) # Transport's life future
     raddr: Sockaddr_storage         # Reader address storage
     ralen: SockLen                  # Reader address length
     waddr: Sockaddr_storage         # Writer address storage
@@ -568,7 +568,8 @@ else:
     res.queue = initDeque[GramVector]()
     res.udata = udata
     res.state = {ReadPaused, WritePaused}
-    res.future = newFuture[void]("datagram.transport")
+    res.future = Future[void].Raising([CancelledError]).init(
+      "datagram.transport")
     GC_ref(res)
     # Start tracking transport
     trackCounter(DgramTransportTrackerName)
@@ -840,31 +841,16 @@ proc join*(transp: DatagramTransport): Future[void] {.
 
   return retFuture
 
+proc closed*(transp: DatagramTransport): bool {.inline.} =
+  ## Returns ``true`` if transport in closed state.
+  {ReadClosed, WriteClosed} * transp.state != {}
+
 proc closeWait*(transp: DatagramTransport): Future[void] {.
-    async: (raw: true, raises: []).} =
+    async: (raises: []).} =
   ## Close transport ``transp`` and release all resources.
-  let retFuture = newFuture[void](
-    "datagram.transport.closeWait", {FutureFlag.OwnCancelSchedule})
-
-  if {ReadClosed, WriteClosed} * transp.state != {}:
-    retFuture.complete()
-    return retFuture
-
-  proc continuation(udata: pointer) {.gcsafe.} =
-    retFuture.complete()
-
-  proc cancellation(udata: pointer) {.gcsafe.} =
-    # We are not going to change the state of `retFuture` to cancelled, so we
-    # will prevent the entire sequence of Futures from being cancelled.
-    discard
-
-  transp.close()
-  if transp.future.finished():
-    retFuture.complete()
-  else:
-    transp.future.addCallback(continuation, cast[pointer](retFuture))
-    retFuture.cancelCallback = cancellation
-  retFuture
+  if not transp.closed():
+    transp.close()
+    await noCancel(transp.future)
 
 proc send*(transp: DatagramTransport, pbytes: pointer,
            nbytes: int): Future[void] {.
@@ -1020,7 +1006,3 @@ proc getMessage*(transp: DatagramTransport): seq[byte] {.
 proc getUserData*[T](transp: DatagramTransport): T {.inline.} =
   ## Obtain user data stored in ``transp`` object.
   cast[T](transp.udata)
-
-proc closed*(transp: DatagramTransport): bool {.inline.} =
-  ## Returns ``true`` if transport in closed state.
-  {ReadClosed, WriteClosed} * transp.state != {}

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -598,7 +598,8 @@ when defined(windows):
     transp.buffer = newSeq[byte](bufsize)
     transp.state = {ReadPaused, WritePaused}
     transp.queue = initDeque[StreamVector]()
-    transp.future = Future[void].Raising([]).init("stream.socket.transport")
+    transp.future = Future[void].Raising([CancelledError]).init(
+      "stream.socket.transport")
     GC_ref(transp)
     transp
 
@@ -619,7 +620,8 @@ when defined(windows):
     transp.flags = flags
     transp.state = {ReadPaused, WritePaused}
     transp.queue = initDeque[StreamVector]()
-    transp.future = Future[void].Raising([]).init("stream.pipe.transport")
+    transp.future = Future[void].Raising([CancelledError]).init(
+      "stream.pipe.transport")
     GC_ref(transp)
     transp
 

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -76,7 +76,7 @@ when defined(windows):
       offset: int                     # Reading buffer offset
       error: ref TransportError       # Current error
       queue: Deque[StreamVector]      # Writer queue
-      future: Future[void]            # Stream life future
+      future: Future[void].Raising([CancelledError]) # Stream life future
       # Windows specific part
       rwsabuf: WSABUF                 # Reader WSABUF
       wwsabuf: WSABUF                 # Writer WSABUF
@@ -598,7 +598,7 @@ when defined(windows):
     transp.buffer = newSeq[byte](bufsize)
     transp.state = {ReadPaused, WritePaused}
     transp.queue = initDeque[StreamVector]()
-    transp.future = newFuture[void]("stream.socket.transport")
+    transp.future = Future[void].Raising([]).init("stream.socket.transport")
     GC_ref(transp)
     transp
 
@@ -619,7 +619,7 @@ when defined(windows):
     transp.flags = flags
     transp.state = {ReadPaused, WritePaused}
     transp.queue = initDeque[StreamVector]()
-    transp.future = newFuture[void]("stream.pipe.transport")
+    transp.future = Future[void].Raising([]).init("stream.pipe.transport")
     GC_ref(transp)
     transp
 


### PR DESCRIPTION
* simplify `closeWait` implementations
  * remove redundant cancellation callbacks
  * use `noCancel` to avoid forgetting the right future flags
* add a few missing raises trackers