### PR TITLE
Feature flag for raises support

### DIFF
--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -11,6 +11,15 @@
 ## `chronosDebug` can be defined to enable several debugging helpers that come
 ## with a runtime cost - it is recommeneded to not enable these in production
 ## code.
+##
+## In this file we also declare feature flags starting with `chronosHas...` -
+## these constants are declared when a feature exists in a particular release -
+## each flag is declared as an integer starting at 0 during experimental
+## development, 1 when feature complete and higher numbers when significant
+## functionality has been added. If a feature ends up being removed (or changed
+## in a backwards-incompatible way), the feature flag will be removed or renamed
+## also - you can use `when declared(chronosHasXxx): when chronosHasXxx >= N:`
+## to require a particular version.
 const
   chronosHandleException* {.booldefine.}: bool = false
     ## Remap `Exception` to `AsyncExceptionError` for all `async` functions.
@@ -78,6 +87,9 @@ const
     else:
       ""
     ## OS polling engine type which is going to be used by chronos.
+
+  chronosHasRaises* = 0
+    ## raises effect support via `async: (raises: [])`
 
 when defined(chronosStrictException):
   {.warning: "-d:chronosStrictException has been deprecated in favor of handleException".}


### PR DESCRIPTION
Feature flags allow consumers of chronos to target versions with and without certain features via compile-time selection. The first feature flag added is for raise tracking support.