### PR TITLE
deprecate `callback=`, UDP fixes (fixes #491)

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -347,7 +347,9 @@ proc `callback=`*(future: FutureBase, cb: CallbackFunc) {.
   ## Sets the callback proc to be called when the future completes.
   ##
   ## If future has already completed then ``cb`` will be called immediately.
+  {.push warning[Deprecated]: off.}
   `callback=`(future, cb, cast[pointer](future))
+  {.pop.}
 
 proc `cancelCallback=`*(future: FutureBase, cb: CallbackFunc) =
   ## Sets the callback procedure to be called when the future is cancelled.

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -330,7 +330,8 @@ proc removeCallback*(future: FutureBase, cb: CallbackFunc,
 proc removeCallback*(future: FutureBase, cb: CallbackFunc) =
   future.removeCallback(cb, cast[pointer](future))
 
-proc `callback=`*(future: FutureBase, cb: CallbackFunc, udata: pointer) =
+proc `callback=`*(future: FutureBase, cb: CallbackFunc, udata: pointer) {.
+    deprecated: "use addCallback/removeCallback/clearCallbacks to manage the callback list".} =
   ## Clears the list of callbacks and sets the callback proc to be called when
   ## the future completes.
   ##
@@ -341,7 +342,8 @@ proc `callback=`*(future: FutureBase, cb: CallbackFunc, udata: pointer) =
   future.clearCallbacks
   future.addCallback(cb, udata)
 
-proc `callback=`*(future: FutureBase, cb: CallbackFunc) =
+proc `callback=`*(future: FutureBase, cb: CallbackFunc) {.
+    deprecated: "use addCallback/removeCallback/clearCallbacks instead to manage the callback list".} =
   ## Sets the callback proc to be called when the future completes.
   ##
   ## If future has already completed then ``cb`` will be called immediately.

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -1002,7 +1002,7 @@ proc getMessage*(transp: DatagramTransport): seq[byte] {.
     copyMem(addr res[0], addr transp.buffer[0], transp.buflen)
     res
   else:
-    @[]
+    default(seq[byte])
 
 proc getUserData*[T](transp: DatagramTransport): T {.inline.} =
   ## Obtain user data stored in ``transp`` object.


### PR DESCRIPTION
Using the callback setter may lead to callbacks owned by others being reset, which is unexpected.

* don't crash on zero-length UDP writes