### PR TITLE
Increase AsyncStream and Transport default buffer size from 4096 to 16384.

### DIFF
--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -91,6 +91,12 @@ const
   chronosHasRaises* = 0
     ## raises effect support via `async: (raises: [])`
 
+  chronosTransportDefaultBufferSize* {.intdefine.} = 16384
+    ## Default size of chronos transport internal buffer.
+
+  chronosStreamDefaultBufferSize* {.intdefine.} = 16384
+    ## Default size of chronos async stream internal buffer.
+
 when defined(chronosStrictException):
   {.warning: "-d:chronosStrictException has been deprecated in favor of handleException".}
   # In chronos v3, this setting was used as the opposite of
@@ -113,7 +119,10 @@ when defined(debug) or defined(chronosConfig):
     printOption("chronosEventEngine", chronosEventEngine)
     printOption("chronosEventsCount", chronosEventsCount)
     printOption("chronosInitialSize", chronosInitialSize)
-
+    printOption("chronosTransportDefaultBufferSize",
+      chronosTransportDefaultBufferSize)
+    printOption("chronosStreamDefaultBufferSize",
+      chronosStreamDefaultBufferSize)
 
 # In nim 1.6, `sink` + local variable + `move` generates the best code for
 # moving a proc parameter into a closure - this only works for closure

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -9,12 +9,12 @@
 
 {.push raises: [].}
 
-import ../asyncloop, ../asyncsync
-import ../transports/common, ../transports/stream
+import ../[config, asyncloop, asyncsync]
+import ../transports/[common, stream]
 export asyncloop, asyncsync, stream, common
 
 const
-  AsyncStreamDefaultBufferSize* = 4096
+  AsyncStreamDefaultBufferSize* = chronosStreamDefaultBufferSize
     ## Default reading stream internal buffer size.
   AsyncStreamDefaultQueueSize* = 0
     ## Default writing stream internal queue size.

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -11,7 +11,7 @@
 
 import std/[strutils]
 import stew/[base10, byteutils]
-import ".."/[asyncloop, osdefs, oserrno, handles]
+import ".."/[config, asyncloop, osdefs, oserrno, handles]
 
 from std/net import Domain, `==`, IpAddress, IpAddressFamily, parseIpAddress,
                     SockType, Protocol, Port, `$`
@@ -21,10 +21,10 @@ export Domain, `==`, IpAddress, IpAddressFamily, parseIpAddress, SockType,
        Protocol, Port, toInt, `$`
 
 const
-  DefaultStreamBufferSize* = 4096    ## Default buffer size for stream
-                                     ## transports
-  DefaultDatagramBufferSize* = 65536 ## Default buffer size for datagram
-                                     ## transports
+  DefaultStreamBufferSize* = chronosTransportDefaultBufferSize
+    ## Default buffer size for stream transports
+  DefaultDatagramBufferSize* = 65536
+    ## Default buffer size for datagram transports
 type
   ServerFlags* = enum
     ## Server's flags


### PR DESCRIPTION
* Make buffer sizes configurable at compile time.