### PR TITLE
Ensure `transp.reader` is reset to `nil` on error

### DIFF
--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -2372,7 +2372,7 @@ template readLoop(name, body: untyped): untyped =
           # resumeRead() could not return any error.
           raiseOsDefect(errorCode, "readLoop(): Unable to resume reading")
         else:
-          transp.reader.complete()
+          transp.completeReader()
           if errorCode == oserrno.ESRCH:
             # ESRCH 3 "No such process"
             # This error could be happened on pipes only, when process which


### PR DESCRIPTION
In `stream.readLoop`, a finished `Future` was left in `transp.reader` if there was an error in `resumeRead`. Set it to `nil` as well.