### PR TITLE
avoid double `GC_unref` when final `boundstream.transfer` is cancelled

### DIFF
--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -193,8 +193,9 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async: (raises: []).} =
       try:
         await rstream.buffer.transfer()
       except CancelledError:
-        rstream.state = AsyncStreamState.Error
-        rstream.error = newBoundedStreamIncompleteError()
+        if rstream.state == AsyncStreamState.Running:
+          rstream.state = AsyncStreamState.Error
+          rstream.error = newBoundedStreamIncompleteError()
       break
     of AsyncStreamState.Closing, AsyncStreamState.Closed:
       break

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -193,7 +193,7 @@ proc boundedReadLoop(stream: AsyncStreamReader) {.async: (raises: []).} =
       try:
         await rstream.buffer.transfer()
       except CancelledError:
-        if rstream.state == AsyncStreamState.Running:
+        if rstream.state == AsyncStreamState.Finished:
           rstream.state = AsyncStreamState.Error
           rstream.error = newBoundedStreamIncompleteError()
       break


### PR DESCRIPTION
When a `BoundedStreamReader` finishes, it performs one final `transfer` to signal EOF. If the other end subsequently closes the stream, state changes from `Finished` to `Closing` and enqueues a callback that will finish the close operation. If the `transfer` is then cancelled, the `state` changes from `Closing` to `Error`. The stream will eventually be closed, so changes again from `Error` to `Closing`, and the cleanup callback is scheduled a second time. Each of the cleanup callbacks then proceeds to `GC_unref` to `udata` before changing the state to `Closed`. The double `GC_unref` only happens if `udata` is used.

In practice, the buggy flow is triggered when `nimbus-eth2` interacts with Geth, and Geth provides a response with `Content-Length`. This is the case for example when a block without transactions is fetched; otherwise, it uses `Transfer-Encoding: chunked`. Luckily, that setup does not configure `udata`, so there is no double free in practice. But, other applications that use `udata` and use the cancellation flow that triggers the bug may be affected.