### PR TITLE
fix conversion error with `or` on futures with `{.async: (raises: []).}`

### DIFF
--- a/chronos/internal/raisesfutures.nim
+++ b/chronos/internal/raisesfutures.nim
@@ -142,7 +142,7 @@ macro union*(tup0: typedesc, tup1: typedesc): typedesc =
     if not found:
       result.add err
 
-  for err2 in getType(getTypeInst(tup1)[1])[1..^1]:
+  for err2 in tup1.members():
     result.add err2
   if result.len == 0:
     result = makeNoRaises()


### PR DESCRIPTION
```nim
import chronos

proc f(): Future[void] {.async: (raises: []).} =
  discard

discard f() or f() or f()
```

```
/Users/etan/Documents/Repos/nimbus-eth2/vendor/nim-chronos/chronos/internal/raisesfutures.nim(145, 44) union
/Users/etan/Documents/Repos/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/core/macros.nim(185, 28) []
/Users/etan/Documents/Repos/nimbus-eth2/test.nim(6, 13) template/generic instantiation of `or` from here
/Users/etan/Documents/Repos/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(1668, 39) template/generic instantiation of `union` from here
/Users/etan/Documents/Repos/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/core/macros.nim(185, 28) Error: illegal conversion from '-1' to '[0..9223372036854775807]'
```

Fix by checking for `void` before trying to access `raises`