### PR TITLE
Add `join()` operation to wait for future completion.

### DIFF
--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -1187,23 +1187,7 @@ proc closeWait*(server: HttpServerRef) {.async: (raises: []).} =
 proc join*(server: HttpServerRef): Future[void] {.
      async: (raw: true, raises: [CancelledError]).} =
   ## Wait until HTTP server will not be closed.
-  var retFuture = newFuture[void]("http.server.join")
-
-  proc continuation(udata: pointer) {.gcsafe.} =
-    if not(retFuture.finished()):
-      retFuture.complete()
-
-  proc cancellation(udata: pointer) {.gcsafe.} =
-    if not(retFuture.finished()):
-      server.lifetime.removeCallback(continuation, cast[pointer](retFuture))
-
-  if server.state == ServerClosed:
-    retFuture.complete()
-  else:
-    server.lifetime.addCallback(continuation, cast[pointer](retFuture))
-    retFuture.cancelCallback = cancellation
-
-  retFuture
+  server.lifetime.join()
 
 proc getMultipartReader*(req: HttpRequestRef): HttpResult[MultiPartReaderRef] =
   ## Create new MultiPartReader interface for specific request.

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -836,24 +836,7 @@ proc join*(rw: AsyncStreamRW): Future[void] {.
      async: (raw: true, raises: [CancelledError]).} =
   ## Get Future[void] which will be completed when stream become finished or
   ## closed.
-  when rw is AsyncStreamReader:
-    var retFuture = newFuture[void]("async.stream.reader.join")
-  else:
-    var retFuture = newFuture[void]("async.stream.writer.join")
-
-  proc continuation(udata: pointer) {.gcsafe, raises:[].} =
-    retFuture.complete()
-
-  proc cancellation(udata: pointer) {.gcsafe, raises:[].} =
-    rw.future.removeCallback(continuation, cast[pointer](retFuture))
-
-  if not(rw.future.finished()):
-    rw.future.addCallback(continuation, cast[pointer](retFuture))
-    retFuture.cancelCallback = cancellation
-  else:
-    retFuture.complete()
-
-  return retFuture
+  rw.future.join()
 
 proc close*(rw: AsyncStreamRW) =
   ## Close and frees resources of stream ``rw``.

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -827,21 +827,7 @@ proc newDatagramTransport6*[T](cbproc: UnsafeDatagramCallback,
 proc join*(transp: DatagramTransport): Future[void] {.
     async: (raw: true, raises: [CancelledError]).} =
   ## Wait until the transport ``transp`` will be closed.
-  let retFuture = newFuture[void]("datagram.transport.join")
-
-  proc continuation(udata: pointer) {.gcsafe.} =
-    retFuture.complete()
-
-  proc cancel(udata: pointer) {.gcsafe.} =
-    transp.future.removeCallback(continuation, cast[pointer](retFuture))
-
-  if not(transp.future.finished()):
-    transp.future.addCallback(continuation, cast[pointer](retFuture))
-    retFuture.cancelCallback = cancel
-  else:
-    retFuture.complete()
-
-  return retFuture
+  transp.future.join()
 
 proc closed*(transp: DatagramTransport): bool {.inline.} =
   ## Returns ``true`` if transport in closed state.

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1780,20 +1780,7 @@ proc stop*(server: StreamServer) {.raises: [TransportOsError].} =
 proc join*(server: StreamServer): Future[void] {.
     async: (raw: true, raises: [CancelledError]).} =
   ## Waits until ``server`` is not closed.
-  var retFuture = newFuture[void]("stream.transport.server.join")
-
-  proc continuation(udata: pointer) =
-    retFuture.complete()
-
-  proc cancel(udata: pointer) =
-    server.loopFuture.removeCallback(continuation, cast[pointer](retFuture))
-
-  if not(server.loopFuture.finished()):
-    server.loopFuture.addCallback(continuation, cast[pointer](retFuture))
-    retFuture.cancelCallback = cancel
-  else:
-    retFuture.complete()
-  return retFuture
+  server.loopFuture.join()
 
 proc connect*(address: TransportAddress,
               bufferSize = DefaultStreamBufferSize,


### PR DESCRIPTION
This operation allows to monitor specific future and do not cancel it when `join()` was cancelled.