### PR TITLE
Fixes compilation issues in v3 compatibility mode (`-d:chronosHandleException`)

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -60,6 +60,14 @@ task test, "Run all tests":
       run args & " --mm:refc", "tests/testall"
     run args, "tests/testall"
 
+task test_v3_compat, "Run all tests in v3 compatibility mode":
+  for args in testArguments:
+    if (NimMajor, NimMinor) > (1, 6):
+      # First run tests with `refc` memory manager.
+      run args & " --mm:refc -d:chronosHandleException", "tests/testall"
+
+    run args & " -d:chronosHandleException", "tests/testall"
+
 task test_libbacktrace, "test with libbacktrace":
   if platform != "x86":
     let allArgs = @[

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -720,7 +720,7 @@ proc newDatagramTransportCommon(cbproc: UnsafeDatagramCallback,
   proc wrap(transp: DatagramTransport,
             remote: TransportAddress) {.async: (raises: []).} =
     try:
-      cbproc(transp, remote)
+      await cbproc(transp, remote)
     except CatchableError as exc:
       raiseAssert "Unexpected exception from stream server cbproc: " & exc.msg
 

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -2197,7 +2197,7 @@ proc createStreamServer*(host: TransportAddress,
   proc wrap(server: StreamServer,
             client: StreamTransport) {.async: (raises: []).} =
     try:
-      cbproc(server, client)
+      await cbproc(server, client)
     except CatchableError as exc:
       raiseAssert "Unexpected exception from stream server cbproc: " & exc.msg
 


### PR DESCRIPTION
fixes #544 

This PR adds the missing `await` calls which fixes the issue I was experiencing without visible ill effects. I've also added (somewhat naively) the ability to run the test suite in compat mode, though not sure this is a desirable change.