### PR TITLE
make SomeFuture public

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -60,7 +60,7 @@ type
   FutureCompletedError* = object of FutureError
     ## Error raised when trying access the error of a completed Future
 
-  SomeFuture = Future|InternalRaisesFuture
+  SomeFuture* = Future|InternalRaisesFuture
 
 func raiseFuturePendingError(fut: FutureBase) {.
     noinline, noreturn, raises: FuturePendingError.} =


### PR DESCRIPTION
It makes it possible to not use `InternalRaisesFuture` in procs like https://github.com/vacp2p/nim-libp2p/pull/1175/files.