### PR TITLE
Add peak to AsyncQueue

### DIFF
--- a/tests/testsync.nim
+++ b/tests/testsync.nim
@@ -353,6 +353,19 @@ suite "Asynchronous sync primitives test suite":
   test "AsyncQueue() contains test":
     check test9() == true
 
+  test "AsyncQueue() peak test":
+    let q = newAsyncQueue[int]()
+    q.putNoWait(1)
+    q.putNoWait(2)
+
+    check:
+      q.peakNoWait() == 1
+      q.peakFirstNoWait() == 1
+      q.peakLastNoWait() == 2
+      (waitFor q.peak()) == 1
+      (waitFor q.peakFirst()) == 1
+      (waitFor q.peakLast()) == 2
+
   test "AsyncEventQueue() behavior test":
     let eventQueue = newAsyncEventQueue[int]()
     let key = eventQueue.register()


### PR DESCRIPTION
In some of my code I found the need to do something like this:
```
# wait for the first block data to be put on the queue
# so that we can access the first block once available
while blockDataQueue.empty():
  await sleepAsync(100.milliseconds)
# peek but don't remove it so that it can be processed later
let firstBlock = blockDataQueue[0]
```

Having a async peak proc that waits for the first item to be added to the queue would be good. The std/deques supports peakFirst and peakLast as well so this PR adds these to the AsyncQueue.