### PR TITLE
chore: utilize newSeqUninitialized

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1027,7 +1027,7 @@ proc new*(t: typedesc[HttpClientRequestRef], session: HttpSessionRef,
     state: HttpReqRespState.Ready, session: session, meth: meth,
     version: version, flags: flags, headers: HttpTable.init(headers),
     address: ha, bodyFlag: HttpClientBodyFlag.Custom, buffer: @body,
-    headersBuffer: newSeq[byte](max(maxResponseHeadersSize, HttpMaxHeadersSize))
+    headersBuffer: newSeqUninitialized[byte](max(maxResponseHeadersSize, HttpMaxHeadersSize))
   )
   trackCounter(HttpClientRequestTrackerName)
   res
@@ -1044,7 +1044,7 @@ proc new*(t: typedesc[HttpClientRequestRef], session: HttpSessionRef,
     state: HttpReqRespState.Ready, session: session, meth: meth,
     version: version, flags: flags, headers: HttpTable.init(headers),
     address: address, bodyFlag: HttpClientBodyFlag.Custom, buffer: @body,
-    headersBuffer: newSeq[byte](max(maxResponseHeadersSize, HttpMaxHeadersSize))
+    headersBuffer: newSeqUninitialized[byte](max(maxResponseHeadersSize, HttpMaxHeadersSize))
   )
   trackCounter(HttpClientRequestTrackerName)
   ok(res)

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -349,7 +349,7 @@ func stringToBytes*(src: openArray[char]): seq[byte] =
   ## If this equation is not correct this procedures MUST not be used.
   var default: seq[byte]
   if len(src) > 0:
-    var dst = newSeq[byte](len(src))
+    var dst = newSeqUninitialized[byte](len(src))
     stringToBytes(src, dst)
     dst
   else:

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -890,7 +890,7 @@ proc init*(value: var HttpConnection, server: HttpServerRef,
     state: HttpState.Alive,
     server: server,
     transp: transp,
-    buffer: newSeq[byte](server.maxHeadersSize),
+    buffer: newSeqUninitialized[byte](server.maxHeadersSize),
     mainReader: newAsyncStreamReader(transp),
     mainWriter: newAsyncStreamWriter(transp)
   )

--- a/chronos/apps/http/multipart.nim
+++ b/chronos/apps/http/multipart.nim
@@ -130,14 +130,14 @@ proc init*[A: BChar, B: BChar](mpt: typedesc[MultiPartReader],
   doAssert(len(boundary) > 0)
   # Our internal boundary has format `<CR><LF><-><-><boundary>`, so we can
   # reuse different parts of this sequence for processing.
-  var fboundary = newSeq[byte](len(boundary) + 4)
+  var fboundary = newSeqUninitialized[byte](len(boundary) + 4)
   fboundary[0] = 0x0D'u8
   fboundary[1] = 0x0A'u8
   fboundary[2] = byte('-')
   fboundary[3] = byte('-')
   copyMem(addr fboundary[4], unsafeAddr boundary[0], len(boundary))
   # Make copy of buffer, because all the returned parts depending on it.
-  var buf = newSeq[byte](len(buffer))
+  var buf = newSeqUninitialized[byte](len(buffer))
   if len(buf) > 0:
     copyMem(addr buf[0], unsafeAddr buffer[0], len(buffer))
   MultiPartReader(kind: MultiPartSource.Buffer,
@@ -164,7 +164,7 @@ proc new*[B: BChar](
   doAssert(partHeadersMaxSize >= 256)
   # Our internal boundary has format `<CR><LF><-><-><boundary>`, so we can
   # reuse different parts of this sequence for processing.
-  var fboundary = newSeq[byte](len(boundary) + 4)
+  var fboundary = newSeqUninitialized[byte](len(boundary) + 4)
   fboundary[0] = 0x0D'u8
   fboundary[1] = 0x0A'u8
   fboundary[2] = byte('-')
@@ -172,7 +172,7 @@ proc new*[B: BChar](
   copyMem(addr fboundary[4], unsafeAddr boundary[0], len(boundary))
   MultiPartReaderRef(kind: MultiPartSource.Stream, firstTime: true,
                      stream: stream, offset: 0, boundary: fboundary,
-                     buffer: newSeq[byte](partHeadersMaxSize))
+                     buffer: newSeqUninitialized[byte](partHeadersMaxSize))
 
 template handleAsyncStreamReaderError(targ, excarg: untyped) =
   if targ.hasOverflow():

--- a/chronos/bipbuffer.nim
+++ b/chronos/bipbuffer.nim
@@ -36,7 +36,7 @@ type
 
 proc init*(t: typedesc[BipBuffer], size: int): BipBuffer =
   ## Creates new Bip Buffer with size `size`.
-  BipBuffer(data: newSeq[byte](size))
+  BipBuffer(data: newSeqUninitialized[byte](size))
 
 template len(pos: BipPos): Natural =
   pos.finish - pos.start

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -103,7 +103,7 @@ func endsWith(s, suffix: openArray[byte]): bool =
 proc boundedReadLoop(stream: AsyncStreamReader) {.async: (raises: []).} =
   var rstream = BoundedStreamReader(stream)
   rstream.state = AsyncStreamState.Running
-  var buffer = newSeq[byte](rstream.buffer.backend.availSpace())
+  var buffer = newSeqUninitialized[byte](rstream.buffer.backend.availSpace())
   while true:
     let toRead =
       if rstream.boundSize.isNone():

--- a/chronos/streams/chunkstream.nim
+++ b/chronos/streams/chunkstream.nim
@@ -100,7 +100,7 @@ proc setChunkSize(buffer: var openArray[byte], length: int64): int =
 
 proc chunkedReadLoop(stream: AsyncStreamReader) {.async: (raises: []).} =
   var rstream = ChunkedStreamReader(stream)
-  var buffer = newSeq[byte](MaxChunkHeaderSize)
+  var buffer = newSeqUninitialized[byte](MaxChunkHeaderSize)
   rstream.state = AsyncStreamState.Running
 
   while true:

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -526,7 +526,7 @@ proc newTLSClientAsyncStream*(
                         uint(len(trustAnchors)))
 
   let size = max(SSL_BUFSIZE_BIDI, bufferSize)
-  res.sbuffer = newSeq[byte](size)
+  res.sbuffer = newSeqUninitialized[byte](size)
   sslEngineSetBuffer(res.ccontext.eng, addr res.sbuffer[0],
                      uint(len(res.sbuffer)), 1)
   sslEngineSetVersions(res.ccontext.eng, uint16(minVersion),
@@ -606,7 +606,7 @@ proc newTLSServerAsyncStream*(rsource: AsyncStreamReader,
                          uint(len(certificate.certs)), addr privateKey.rsakey)
 
   let size = max(SSL_BUFSIZE_BIDI, bufferSize)
-  res.sbuffer = newSeq[byte](size)
+  res.sbuffer = newSeqUninitialized[byte](size)
   sslEngineSetBuffer(res.scontext.eng, addr res.sbuffer[0],
                      uint(len(res.sbuffer)), 1)
   sslEngineSetVersions(res.scontext.eng, uint16(minVersion),
@@ -637,7 +637,7 @@ proc copyKey(src: RsaPrivateKey): TLSPrivateKey =
   ## Creates copy of RsaPrivateKey ``src``.
   var offset = 0'u
   let keySize = src.plen + src.qlen + src.dplen + src.dqlen + src.iqlen
-  var res = TLSPrivateKey(kind: TLSKeyType.RSA, storage: newSeq[byte](keySize))
+  var res = TLSPrivateKey(kind: TLSKeyType.RSA, storage: newSeqUninitialized[byte](keySize))
   copyMem(addr res.storage[offset], src.p, src.plen)
   res.rsakey.p = addr res.storage[offset]
   res.rsakey.plen = src.plen
@@ -664,7 +664,7 @@ proc copyKey(src: EcPrivateKey): TLSPrivateKey =
   ## Creates copy of EcPrivateKey ``src``.
   var offset = 0
   let keySize = src.xlen
-  var res = TLSPrivateKey(kind: TLSKeyType.EC, storage: newSeq[byte](keySize))
+  var res = TLSPrivateKey(kind: TLSKeyType.EC, storage: newSeqUninitialized[byte](keySize))
   copyMem(addr res.storage[offset], src.x, src.xlen)
   res.eckey.x = addr res.storage[offset]
   res.eckey.xlen = src.xlen
@@ -789,7 +789,7 @@ proc init*(tt: typedesc[TLSSessionCache],
   ##
   ## One cached item is near 100 bytes size.
   let rsize = min(size, 4096)
-  var res = TLSSessionCache(storage: newSeq[byte](rsize))
+  var res = TLSSessionCache(storage: newSeqUninitialized[byte](rsize))
   sslSessionCacheLruInit(addr res.context, addr res.storage[0], rsize)
   res
 

--- a/chronos/transports/datagram.nim
+++ b/chronos/transports/datagram.nim
@@ -417,7 +417,7 @@ when defined(windows):
 
     res.fd = localSock
     res.function = cbproc
-    res.buffer = newSeq[byte](bufferSize)
+    res.buffer = newSeqUninitialized[byte](bufferSize)
     res.queue = initDeque[GramVector]()
     res.udata = udata
     res.state = {ReadPaused, WritePaused}
@@ -635,7 +635,7 @@ else:
 
     res.fd = localSock
     res.function = cbproc
-    res.buffer = newSeq[byte](bufferSize)
+    res.buffer = newSeqUninitialized[byte](bufferSize)
     res.queue = initDeque[GramVector]()
     res.udata = udata
     res.state = {ReadPaused, WritePaused}
@@ -1157,7 +1157,7 @@ proc getMessage*(transp: DatagramTransport): seq[byte] {.
     transp.state.excl(ReadError)
     raise transp.getError()
   if transp.buflen > 0:
-    var res = newSeq[byte](transp.buflen)
+    var res = newSeqUninitialized[byte](transp.buflen)
     copyMem(addr res[0], addr transp.buffer[0], transp.buflen)
     res
   else:

--- a/chronos/transports/osnet.nim
+++ b/chronos/transports/osnet.nim
@@ -668,7 +668,7 @@ when defined(linux):
     if not sendRouteMessage(netfd, pid, 1, RTM_GETROUTE,
                             NLM_F_REQUEST, address):
       return Route()
-    var data = newSeq[byte]()
+    var data = newSeqUninitialized[byte](0)
     var res = Route()
     while true:
       if not readNetlinkMessage(netfd, data):
@@ -694,7 +694,7 @@ when defined(linux):
     if not sendLinkMessage(netfd, pid, 1, RTM_GETLINK,
                            NLM_F_REQUEST or NLM_F_DUMP):
       return res
-    var data = newSeq[byte]()
+    var data = newSeqUninitialized[byte](0)
     res = newSeq[NetworkInterface]()
     while true:
       if not readNetlinkMessage(netfd, data):
@@ -724,7 +724,7 @@ when defined(linux):
     if not sendLinkMessage(netfd, pid, 2, RTM_GETADDR,
                            NLM_F_REQUEST or NLM_F_DUMP):
       return
-    var data = newSeq[byte]()
+    var data = newSeqUninitialized[byte](0)
     while true:
       if not readNetlinkMessage(netfd, data):
         break
@@ -1041,7 +1041,7 @@ elif defined(windows):
     var vista = isVista()
 
     while true:
-      buffer = newSeq[byte](size)
+      buffer = newSeqUninitialized[byte](size)
       var addresses = cast[ptr IpAdapterAddressesXp](addr buffer[0])
       gres = getAdaptersAddresses(osdefs.AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX,
                                   nil, addresses, addr size)


### PR DESCRIPTION
utilizing `newSeqUninitialized` instead of `newSeq` to gain bit more performance when initializing sequences.

in this pr, `newSeqUninitialized` is utilized only in places where it can directly replace `newSeq` without any change to other logic.