### PR TITLE
Add slot for single callback

### DIFF
--- a/chronos/futures.nim
+++ b/chronos/futures.nim
@@ -2,7 +2,7 @@
 #                     Chronos
 #
 #  (c) Copyright 2015 Dominik Picheta
-#  (c) Copyright 2018-2023 Status Research & Development GmbH
+#  (c) Copyright 2018-2025 Status Research & Development GmbH
 #
 #                Licensed under either of
 #    Apache License, version 2.0, (LICENSE-APACHEv2)
@@ -10,7 +10,7 @@
 
 {.push raises: [].}
 
-import "."/[config, srcloc]
+import ./[config, srcloc]
 
 export srcloc
 
@@ -56,6 +56,12 @@ type
     # structure may change in the future (haha)
 
     internalLocation*: array[LocationKind, ptr SrcLoc]
+    internalCallback*: InternalAsyncCallback
+      ## The vast majority of futures track a single callback only (the one
+      ## installed by `await`) - to avoid allocating a seq (which involves
+      ## making a separate allocation with space several callbacks), we keep a
+      ## spot in each future for that first one - the seq below will stay empty
+      ## until a second callback is added
     internalCallbacks*: seq[InternalAsyncCallback]
     internalCancelcb*: CallbackFunc
     internalChild*: FutureBase


### PR DESCRIPTION
While it's possible to add multiple callbacks to a future, most of them in fact only use one - ie in the typical pattern of `await f()`, `await` will install a single callback and after `await` is done, no more callbacks can be added.

When one callback is added to the callback list, we will currently allocate a seq - apart from being a separate allocation (that leads to a corresponding garbage collection event), we also overallocate memory since newseq will create space for several futures.

Keeping a single non-seq slot covers this common case at the expnse of a small increase in Future size.

In nimbus for example, the majority of all seq allocations (by count, using heaptrack) in a synced node come from the callback allocation as each `async` chain of calls results in several futures being allocated and consequently, several seq's being allocated for each await.