### PR TITLE
feat: add WaitGroup

### DIFF
--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -11,7 +11,7 @@ when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):
   import testmacro, testsync, testsoon, testtime, testfut, testsignal,
          testaddress, testdatagram, teststream, testserver, testbugs, testnet,
          testasyncstream, testhttpserver, testshttpserver, testhttpclient,
-         testproc, testratelimit, testfutures, testthreadsync
+         testproc, testratelimit, testfutures, testthreadsync, testwaitgroup
 
   # Must be imported last to check for Pending futures
   import testutils
@@ -20,7 +20,7 @@ elif chronosEventEngine == "poll":
   import testmacro, testsync, testsoon, testtime, testfut, testaddress,
          testdatagram, teststream, testserver, testbugs, testnet,
          testasyncstream, testhttpserver, testshttpserver, testhttpclient,
-         testratelimit, testfutures, testthreadsync
+         testratelimit, testfutures, testthreadsync, testwaitgroup
 
   # Must be imported last to check for Pending futures
   import testutils

--- a/tests/testwaitgroup.nim
+++ b/tests/testwaitgroup.nim
@@ -1,0 +1,53 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+import unittest2
+import ../chronos, ../chronos/unittest2/asynctests
+
+{.used.}
+
+suite "WaitGroup":
+  teardown:
+    checkLeaks()
+
+  asyncTest "negative count":
+    expect AssertionDefect:
+        discard newWaitGroup(-1)
+
+  asyncTest "zero count":
+    let wg = newWaitGroup(0)
+    check wg.wait().finished
+
+  asyncTest "zero count - done no effect":
+    let wg = newWaitGroup(0)
+    check wg.wait().finished
+    
+    wg.done()
+    check wg.wait().finished
+
+  asyncTest "count down to finish":
+    let wg = newWaitGroup(3)
+    
+    wg.done()
+    check not wg.wait().finished
+    wg.done()
+    check not wg.wait().finished
+    wg.done()
+    check wg.wait().finished
+
+  asyncTest "async count down to finish":
+    const count = 30
+    let wg = newWaitGroup(count)
+    
+    proc countDown() {.async.} =
+      await sleepAsync(5.millis)
+      wg.done()
+    for i in 0 ..< count:
+      asyncSpawn countDown()
+
+    check not wg.wait().finished
+    check await wg.wait().withTimeout(15.millis)


### PR DESCRIPTION
a synchronization primitive similar to `WaitGroup` in go or `CountDownLatch` in java.

useful [here](https://github.com/vacp2p/nim-quic/blob/319577a771192202a3975331876a87e796496b50/tests/quic/testIntegrationUsecase.nim#L46)