### PR TITLE
Allow perform graceful shutdown

### DIFF
--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -13,7 +13,7 @@
 {.push raises: [].}
 
 import std/[sequtils, math, deques, tables, typetraits]
-import ./asyncloop
+import ./asyncloop, ./shutdown
 export asyncloop
 
 type
@@ -247,12 +247,14 @@ proc empty*[T](aq: AsyncQueue[T]): bool {.inline.} =
   (len(aq.queue) == 0)
 
 proc addFirstImpl[T](aq: AsyncQueue[T], item: T) =
-  aq.queue.addFirst(item)
-  aq.getters.wakeupNext()
+  if not isShutdownInProgress():
+    aq.queue.addFirst(item)
+    aq.getters.wakeupNext()
 
 proc addLastImpl[T](aq: AsyncQueue[T], item: T) =
-  aq.queue.addLast(item)
-  aq.getters.wakeupNext()
+  if not isShutdownInProgress():
+    aq.queue.addLast(item)
+    aq.getters.wakeupNext()
 
 proc popFirstImpl[T](aq: AsyncQueue[T]): T =
   let res = aq.queue.popFirst()

--- a/chronos/handles.nim
+++ b/chronos/handles.nim
@@ -130,8 +130,7 @@ proc createAsyncSocket2*(domain: Domain, sockType: SockType,
                          inherit = true): Result[AsyncFD, OSErrorCode] =
   ## Creates new asynchronous socket.
 
-  if isShutdownInProgress():
-    return err(ESHUTDOWN)
+  checkShutdownInProgress()
 
   when defined(windows):
     let flags =

--- a/chronos/handles.nim
+++ b/chronos/handles.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import "."/[asyncloop, osdefs, osutils]
+import "."/[asyncloop, osdefs, osutils, shutdown]
 import results
 from nativesockets import Domain, Protocol, SockType, toInt
 export Domain, Protocol, SockType, results
@@ -129,6 +129,10 @@ proc createAsyncSocket2*(domain: Domain, sockType: SockType,
                          protocol: Protocol,
                          inherit = true): Result[AsyncFD, OSErrorCode] =
   ## Creates new asynchronous socket.
+
+  if isShutdownInProgress():
+    return err(ESHUTDOWN)
+
   when defined(windows):
     let flags =
       if inherit:

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -714,8 +714,6 @@ elif defined(windows):
       loop.callbacks.addLast(AsyncCallback(function: aftercb, udata: param))
 
   proc safeCloseHandle(h: HANDLE): Result[void, string] =
-    if h.isNil():
-      return ok()
     let res = closeHandle(h)
     if res == 0:  # WINBOOL FALSE
       let errCode = osLastError()

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1129,8 +1129,13 @@ proc setTimer*(at: Moment, cb: CallbackFunc,
                udata: pointer = nil): TimerCallback =
   ## Arrange for the callback ``cb`` to be called at the given absolute
   ## timestamp ``at``. You can also pass ``udata`` to callback.
+  let finishAt = if isShutdownInProgress():
+                   ## Schedule timer to now so it will be executed ASAP.
+                   Moment.now()
+                 else:
+                   at
   let loop = getThreadDispatcher()
-  result = TimerCallback(finishAt: at,
+  result = TimerCallback(finishAt: finishAt,
                          function: AsyncCallback(function: cb, udata: udata))
   loop.timers.push(result)
 

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -713,8 +713,18 @@ elif defined(windows):
     if not(isNil(aftercb)):
       loop.callbacks.addLast(AsyncCallback(function: aftercb, udata: param))
 
+  proc safeCloseHandle(h: HANDLE): Result[void, string] =
+    if h.isNil():
+      return ok()
+    let res = closeHandle(h)
+    if res == 0:  # WINBOOL FALSE
+      let errCode = osLastError()
+      return err("Failed to close handle error code: " & $errCode)
+
+    ok()
+
   proc closeDispatcher*(loop: PDispatcher): Result[void, string] =
-    closeHandle(loop.ioPort)
+    ? safeCloseHandle(loop.ioPort)
     for i in loop.handles.items:
       closeHandle(i)
     loop.handles.clear()

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -716,9 +716,7 @@ elif defined(windows):
   proc safeCloseHandle(h: HANDLE): Result[void, string] =
     let res = closeHandle(h)
     if res == 0:  # WINBOOL FALSE
-      let errCode = osLastError()
-      return err("Failed to close handle error code: " & $errCode)
-
+      return err("Failed to close handle error code: " & osErrorMsg(osLastError()))
     ok()
 
   proc closeDispatcher*(loop: PDispatcher): Result[void, string] =

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -644,7 +644,7 @@ proc pollFor[F: Future | InternalRaisesFuture](fut: F): F {.raises: [].} =
 
   fut
 
-proc gracefulShutdown*() {.raises: [].} =
+proc gracefulShutdown*(): Result[void, string] {.raises: [].} =
   ## Continues polling the dispatcher until shutdown completion, then
   ## performs final cleanup of all dispatcher resources.
   ##
@@ -656,7 +656,7 @@ proc gracefulShutdown*() {.raises: [].} =
   while disp.networkEventsCount > 0:
     poll()
 
-  disp.closeDispatcher()
+  ? disp.closeDispatcher()
 
 proc waitFor*[T: not void](fut: Future[T]): lent T {.raises: [CatchableError].} =
   ## Blocks the current thread of execution until `fut` has finished, returning

--- a/chronos/ioselects/ioselectors_poll.nim
+++ b/chronos/ioselects/ioselectors_poll.nim
@@ -58,7 +58,7 @@ proc new*(t: typedesc[Selector], T: typedesc): SelectResult[Selector[T]] =
 
 proc close2*[T](s: Selector[T]): SelectResult[void] =
   s.fds.clear()
-  s.pollfds.clear()
+  s.pollfds.setLen(0)
 
 proc new*(t: typedesc[SelectEvent]): SelectResult[SelectEvent] =
   checkShutdownInProgress()

--- a/chronos/oserrno.nim
+++ b/chronos/oserrno.nim
@@ -1334,6 +1334,7 @@ elif defined(windows):
     WSAECONNABORTED* = OSErrorCode(10053)
     WSAECONNRESET* = OSErrorCode(10054)
     WSAENOBUFS* = OSErrorCode(10055)
+    WSAESHUTDOWN* = OSErrorCode(10058)
     WSAETIMEDOUT* = OSErrorCode(10060)
     WSAEADDRINUSE* = OSErrorCode(10048)
     WSAEDISCON* = OSErrorCode(10101)

--- a/chronos/shutdown.nim
+++ b/chronos/shutdown.nim
@@ -1,0 +1,31 @@
+## Manages nim-chronos graceful shutdown procedures.
+## 
+## Phases:
+##   1. Block new work requests.
+##   2. Signal all current work to start ending.
+##   3. Wait until all tasks are completed.
+##   4. Close resources.
+## 
+
+import ./oserrno
+
+## Flag aimed to control whether shutdown is in progress.
+## When set to true, new work requests should be rejected.
+var shutdownInProgress{.threadvar.}: bool
+
+proc initShutdownInProgressToFalse*() =
+  shutdownInProgress = false
+
+proc setShutdownInProgress*() =
+  shutdownInProgress = true
+
+proc isShutdownInProgress*(): bool =
+  return shutdownInProgress
+
+template checkShutdownInProgress*(): untyped =
+  if isShutdownInProgress():
+    when defined(windows):
+      return err(WSAESHUTDOWN)
+    else:
+      return err(ESHUTDOWN)
+


### PR DESCRIPTION
### Description

- This is meant to avoid leaking file descriptors when using Nim libraries.
- Currently, nim-chronos global dispatcher delegates the de-allocation of certain resources to the OS, when an app ends.
- Nim libraries leverage nim-chronos threads, i.e., a Nim library component starts a nim-chronos thread to operate with.
- Certain use cases, e.g. tests, require start/stop Nim library component, which implies start/stop nim-chronos threads.
- Then, certain file descriptors are leaked upon consecutive Nim-library-component creation/destruction (nim-chronos thread start/stop.) For example, on unix-like systems, fds handled by selector are leaked.

### Changes

- Attend and complete in-flight work requests to the chronos thread.
- nim-chronos thread blocks further tasks when shutdown is in progress.
- New `gracefulShutdown` proc is offered to the API.
- Free all resources, on each platform, when all tasks are completed.

### Context

The issue has been detected while testing [nim-sds](https://github.com/logos-messaging/nim-sds) in [status-go](https://github.com/status-im/status-go)

[This status-go PR](https://github.com/status-im/status-go/pull/7227) contains better issue detail.
[This](https://github.com/logos-messaging/nim-sds/pull/40) temporary workaround was implemented.

