### PR TITLE
contextvars: continuation-local storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 nimcache/
 *.exe
+# compiled test binaries (extensionless on Linux/macOS)
+tests/testcontextvars*
+!tests/*.nim
 nimble.develop
 nimble.paths
 /build/

--- a/benchmarks/bench_contextvars.nim
+++ b/benchmarks/bench_contextvars.nim
@@ -1,0 +1,412 @@
+#                Chronos Benchmark Suite
+#            (c) Copyright 2021-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Continuation-local storage (contextvars) cost benchmark.
+##
+## Each metric runs twice in the same binary: once unused (no binder
+## ever pushed, nil ambient context) and once with a contextVar bound
+## around the hot loop. Both numbers and their delta are printed
+## together.
+##
+## Bias controls: median-of-`Trials` per phase; `GC_fullCollect()`
+## before and after every phase; unused/bound run order alternates per
+## metric (`runBothWorlds`/`runBothWorldsInt`).
+##
+## Chain-depth ladder: `chainVars[0]` .. `chainVars[15]` are a runtime
+## `array[16, ContextVar[int]]`, raw-constructed at module init and
+## bound via `bindDepth`, a `when`-recursive static-unrolled template
+## (no runtime-parametrized "chain of depth N" exists -- unrolling per
+## depth is what keeps per-node overhead honest, not loop-amortized).
+## `bindDepth(D)` binds `chainVars[0]` outermost through `chainVars[D-1]`
+## innermost, so reading `chainVars[0]` at depth D walks all D nodes --
+## the worst-case lookup for that depth.
+##
+## Timing uses `getMonoTime().ticks` differences directly as
+## nanoseconds (valid on POSIX, backed by `clock_gettime`).
+##
+## To compare against a base commit: build and run this file
+## identically in both checkouts, once per memory manager, and diff the
+## logs by hand.
+##
+## Run via `nimble benchmarks` (release, both benchmarks/bench_*.nim) or
+## directly:
+##   nim c -d:release --mm:orc  -r benchmarks/bench_contextvars
+##   nim c -d:release --mm:refc -r benchmarks/bench_contextvars
+
+import std/[algorithm, monotimes, strformat]
+
+import chronos
+import chronos/contextvars
+
+{.used.}
+
+# --- trial configuration ----------------------------------------------------
+
+const
+  Trials = 5
+    ## Odd, so the median is a genuine sample rather than an average of
+    ## two middle elements.
+  CallSoonN = 300_000
+  SleepChainN = 30_000
+  FutureChurnN = 300_000
+  MemPendingFutureN = 150_000
+  MemQueuedCallbackN = 150_000
+  ChainReadN = 300_000
+  MixedBatchN = 300_000
+
+# --- contextVar declarations -------------------------------------------------
+# `benchVar`/`mixedVar` back the single-var metrics, raw-constructed --
+# private by the constructor's own default (this file is an executable,
+# not a library). `chainVars` backs the depth ladder: a per-declaration
+# sugar macro cannot mint an indexable family, so the ladder is a
+# raw-constructed `array[16, ContextVar[int]]` instead, filled at module
+# init (before any thread is created). Named `chainVars`, not `chain`, to
+# stay distinct from the local `chain()` procs metric 2 declares below
+# (an unrelated await chain).
+
+let benchVar = newContextVar("benchVar", 0)
+let mixedVar = newContextVar("mixedVar", 0)
+
+var chainVars: array[16, ContextVar[int]]
+for i in 0 ..< chainVars.len:
+  chainVars[i] = newContextVar[int]("chain" & $(i + 1), 0)
+
+template bindDepthFrom(i, depth: static int, body: untyped): untyped =
+  when i >= depth:
+    body
+  else:
+    chainVars[i].withValue(1):
+      bindDepthFrom(i + 1, depth, body)
+
+template bindDepth(depth: static int, body: untyped): untyped =
+  ## Nests `withValue` for `chainVars[0] .. chainVars[depth-1]`,
+  ## outermost to innermost -- `chainVars[0]` is bound first (oldest, at
+  ## the bottom of the stack) and `chainVars[depth-1]` last (newest, at
+  ## the top), so reading `chainVars[0]` inside `body` always walks the
+  ## full `depth` nodes regardless of how deep the ladder goes. Replaces
+  ## the old macro-expansion `withChainDepth` with the same nesting
+  ## order, runtime-parametrized over the array but still unrolled per
+  ## depth at compile time via `static`.
+  static:
+    doAssert depth in 1 .. chainVars.len, "bindDepth: depth out of the hand-declared ladder"
+  bindDepthFrom(0, depth, body)
+
+# --- median-of-N trial infrastructure ----------------------------------------
+
+proc median(samples: var seq[float]): float =
+  samples.sort()
+  samples[samples.len div 2]
+
+proc medianInt(samples: var seq[int]): int =
+  samples.sort()
+  samples[samples.len div 2]
+
+proc benchMedian(trials: int, fn: proc(): float {.closure.}): float =
+  ## Run `fn` `trials` times, `GC_fullCollect`ing before and after every
+  ## trial (not only around the memory metrics), and return the median.
+  ## `fn` is expected to return its own ns/op figure already normalized
+  ## by iteration count.
+  var samples = newSeq[float](trials)
+  for i in 0 ..< trials:
+    GC_fullCollect()
+    samples[i] = fn()
+    GC_fullCollect()
+  median(samples)
+
+proc benchMedianInt(trials: int, fn: proc(): int {.closure.}): int =
+  var samples = newSeq[int](trials)
+  for i in 0 ..< trials:
+    GC_fullCollect()
+    samples[i] = fn()
+    GC_fullCollect()
+  medianInt(samples)
+
+var worldOrderBoundFirst = false
+  ## Toggled by every `runBothWorlds`/`runBothWorldsInt` call so a fixed
+  ## unused-then-bound order cannot make warm-allocator/branch-predictor
+  ## carryover systematic across metrics.
+
+proc reportFloat(name: string, unused, bound: float) =
+  let delta = if unused == 0.0: 0.0 else: (bound - unused) / unused * 100.0
+  echo &"{name:<34} unused={unused:10.2f} ns/op   bound={bound:10.2f} ns/op   delta={delta:+7.1f}%"
+
+proc reportInt(name: string, unused, bound: int) =
+  let delta = if unused == 0: 0.0 else: (bound - unused).float / unused.float * 100.0
+  echo &"{name:<34} unused={unused:8} B/op     bound={bound:8} B/op     delta={delta:+7.1f}%"
+
+proc runBothWorlds(name: string, unusedFn, boundFn: proc(): float {.closure.}) =
+  var unused, bound: float
+  if worldOrderBoundFirst:
+    bound = benchMedian(Trials, boundFn)
+    unused = benchMedian(Trials, unusedFn)
+  else:
+    unused = benchMedian(Trials, unusedFn)
+    bound = benchMedian(Trials, boundFn)
+  worldOrderBoundFirst = not worldOrderBoundFirst
+  reportFloat(name, unused, bound)
+
+proc runBothWorldsInt(name: string, unusedFn, boundFn: proc(): int {.closure.}) =
+  var unused, bound: int
+  if worldOrderBoundFirst:
+    bound = benchMedianInt(Trials, boundFn)
+    unused = benchMedianInt(Trials, unusedFn)
+  else:
+    unused = benchMedianInt(Trials, unusedFn)
+    bound = benchMedianInt(Trials, boundFn)
+  worldOrderBoundFirst = not worldOrderBoundFirst
+  reportInt(name, unused, bound)
+
+# --- metric 1: callSoon schedule+fire ----------------------------------------
+
+proc benchCallSoonUnused(n: int): float =
+  var count = 0
+  proc cb(u: pointer) {.gcsafe, raises: [].} =
+    inc count
+  let start = getMonoTime().ticks
+  var scheduled = 0
+  while scheduled < n:
+    let batch = min(10_000, n - scheduled)
+    for i in 0 ..< batch:
+      callSoon(cb, nil)
+    inc scheduled, batch
+    poll()
+  while count < n:
+    poll()
+  (getMonoTime().ticks - start).float / n.float
+
+proc benchCallSoonBound(n: int): float =
+  var count = 0
+  proc cb(u: pointer) {.gcsafe, raises: [].} =
+    inc count
+  benchVar.withValue(1):
+    let start = getMonoTime().ticks
+    var scheduled = 0
+    while scheduled < n:
+      let batch = min(10_000, n - scheduled)
+      for i in 0 ..< batch:
+        callSoon(cb, nil)
+      inc scheduled, batch
+      poll()
+    while count < n:
+      poll()
+    result = (getMonoTime().ticks - start).float / n.float
+
+# --- metric 2: sleepAsync(0) await chain --------------------------------------
+
+proc benchSleepChainUnused(n: int): float =
+  proc chain(): Future[void] {.async.} =
+    for i in 0 ..< n:
+      await sleepAsync(0.milliseconds)
+  let start = getMonoTime().ticks
+  waitFor chain()
+  (getMonoTime().ticks - start).float / n.float
+
+proc benchSleepChainBound(n: int): float =
+  proc chain(): Future[void] {.async.} =
+    benchVar.withValue(1):
+      for i in 0 ..< n:
+        await sleepAsync(0.milliseconds)
+  let start = getMonoTime().ticks
+  waitFor chain()
+  (getMonoTime().ticks - start).float / n.float
+
+# --- metric 3: future create/await -------------------------------------------
+
+proc benchFutureChurnUnused(n: int): float =
+  proc mk(): Future[int] {.async.} =
+    return 1
+  proc run(): Future[int] {.async.} =
+    var acc = 0
+    for i in 0 ..< n:
+      acc += await mk()
+    return acc
+  let start = getMonoTime().ticks
+  discard waitFor run()
+  (getMonoTime().ticks - start).float / n.float
+
+proc benchFutureChurnBound(n: int): float =
+  proc mk(): Future[int] {.async.} =
+    return 1
+  proc run(): Future[int] {.async.} =
+    var acc = 0
+    benchVar.withValue(1):
+      for i in 0 ..< n:
+        acc += await mk()
+    return acc
+  let start = getMonoTime().ticks
+  discard waitFor run()
+  (getMonoTime().ticks - start).float / n.float
+
+# --- metric 4: mem / pending future -------------------------------------------
+
+proc benchMemPendingFutureUnused(n: int): int =
+  var futs = newSeqOfCap[Future[void]](n)
+  GC_fullCollect()
+  let before = getOccupiedMem()
+  for i in 0 ..< n:
+    futs.add newFuture[void]("bench")
+  result = (getOccupiedMem() - before) div n
+  GC_fullCollect()
+  for f in futs:
+    f.complete()
+
+proc benchMemPendingFutureBound(n: int): int =
+  var futs = newSeqOfCap[Future[void]](n)
+  GC_fullCollect()
+  benchVar.withValue(1):
+    let before = getOccupiedMem()
+    for i in 0 ..< n:
+      futs.add newFuture[void]("bench")
+    result = (getOccupiedMem() - before) div n
+  GC_fullCollect()
+  for f in futs:
+    f.complete()
+
+# --- metric 5: mem / queued callback ------------------------------------------
+#
+# callSoon always queues onto the one per-thread dispatcher's Deque,
+# whose backing buffer capacity only grows -- so median-of-N or
+# back-to-back measurement on the same thread would collapse to ~0
+# bytes/op after the first run warms the capacity. Each world instead
+# gets a fresh OS thread with its own pristine-capacity dispatcher.
+
+var queuedCallbackMemResult: int
+  ## Set by `queuedCallbackMemThread` on its own thread, read on the
+  ## main thread after `joinThread` establishes the happens-before edge.
+
+proc queuedCallbackMemThread(bound: bool) {.thread, nimcall.} =
+  var count = 0
+  proc cb(u: pointer) {.gcsafe, raises: [].} =
+    inc count
+  GC_fullCollect()
+  template measure() =
+    let before = getOccupiedMem()
+    for i in 0 ..< MemQueuedCallbackN:
+      callSoon(cb, nil)
+    queuedCallbackMemResult = (getOccupiedMem() - before) div MemQueuedCallbackN
+  if bound:
+    benchVar.withValue(1):
+      measure()
+  else:
+    measure()
+  GC_fullCollect()
+  while count < MemQueuedCallbackN:
+    poll()
+
+proc benchMemQueuedCallbackFresh(bound: bool): int =
+  var t: Thread[bool]
+  createThread(t, queuedCallbackMemThread, bound)
+  joinThread(t)
+  queuedCallbackMemResult
+
+# --- bound single-var steady state / chain-depth ladder ----------------------
+
+proc benchChainReadUnused(n: int): float =
+  var acc = 0
+  let start = getMonoTime().ticks
+  for i in 0 ..< n:
+    acc += chainVars[0].value
+  result = (getMonoTime().ticks - start).float / n.float
+  doAssert acc == 0, "unbound chainVars[0].value must read the declared default"
+
+proc benchChainReadBound(n: int, depth: static int): float =
+  var acc = 0
+  bindDepth(depth):
+    let start = getMonoTime().ticks
+    for i in 0 ..< n:
+      acc += chainVars[0].value
+    result = (getMonoTime().ticks - start).float / n.float
+  doAssert acc == n, "chainVars[0].value must read its bound value (1) at every depth"
+
+# --- mixed bound/unbound batch (branch-predictor-hostile interleaving) -------
+
+proc benchMixedBatch(n: int): float =
+  var count = 0
+  proc cb(u: pointer) {.gcsafe, raises: [].} =
+    inc count
+  let start = getMonoTime().ticks
+  var scheduled = 0
+  while scheduled < n:
+    let batch = min(10_000, n - scheduled)
+    for i in 0 ..< batch:
+      if (scheduled + i) mod 2 == 0:
+        callSoon(cb, nil)
+      else:
+        mixedVar.withValue(1):
+          callSoon(cb, nil)
+    inc scheduled, batch
+    poll()
+  while count < n:
+    poll()
+  (getMonoTime().ticks - start).float / n.float
+
+# --- report -------------------------------------------------------------------
+
+proc runReport() =
+  const mmName =
+    when defined(gcOrc): "orc"
+    elif defined(gcArc): "arc"
+    elif defined(gcRefc): "refc"
+    elif defined(gcMarkAndSweep): "markAndSweep"
+    else: "unknown"
+  echo &"chronos contextvars benchmark -- mm={mmName} release={defined(release)}"
+  echo ""
+
+  echo "-- struct sizes --"
+  echo &"sizeof(AsyncCallback):        {sizeof(AsyncCallback)} bytes"
+  block:
+    let sizeofProbe = newFuture[void]("sizeof-probe")
+    echo &"sizeof(Future[void] object): {sizeof(sizeofProbe[])} bytes"
+    sizeofProbe.complete()
+  echo ""
+
+  echo "-- five metrics, both worlds (unused vs. one contextVar bound around the hot loop) --"
+  runBothWorlds("callSoon schedule+fire",
+    proc(): float = benchCallSoonUnused(CallSoonN),
+    proc(): float = benchCallSoonBound(CallSoonN))
+  runBothWorlds("sleepAsync(0) await chain",
+    proc(): float = benchSleepChainUnused(SleepChainN),
+    proc(): float = benchSleepChainBound(SleepChainN))
+  runBothWorlds("future create/await",
+    proc(): float = benchFutureChurnUnused(FutureChurnN),
+    proc(): float = benchFutureChurnBound(FutureChurnN))
+  runBothWorldsInt("mem / pending future",
+    proc(): int = benchMemPendingFutureUnused(MemPendingFutureN),
+    proc(): int = benchMemPendingFutureBound(MemPendingFutureN))
+  block:
+    # Single-shot, fresh-dispatcher-per-world -- see the comment above
+    # `queuedCallbackMemThread` for why this metric cannot use the
+    # shared median-of-N machinery.
+    var unused, bound: int
+    if worldOrderBoundFirst:
+      bound = benchMemQueuedCallbackFresh(true)
+      unused = benchMemQueuedCallbackFresh(false)
+    else:
+      unused = benchMemQueuedCallbackFresh(false)
+      bound = benchMemQueuedCallbackFresh(true)
+    worldOrderBoundFirst = not worldOrderBoundFirst
+    reportInt("mem / queued callback", unused, bound)
+  echo ""
+
+  echo "-- bound single-var steady state + chain-depth ladder (contextLookup O(depth) walk) --"
+  let unboundRead = benchMedian(Trials, proc(): float = benchChainReadUnused(ChainReadN))
+  echo &"chain[0].value read, unbound (epsilon baseline) {unboundRead:10.2f} ns/op"
+  let depth1 = benchMedian(Trials, proc(): float = benchChainReadBound(ChainReadN, 1))
+  echo &"chain[0].value read, bound, depth=1 (steady state){depth1:10.2f} ns/op"
+  let depth4 = benchMedian(Trials, proc(): float = benchChainReadBound(ChainReadN, 4))
+  echo &"chain[0].value read, bound, depth=4               {depth4:10.2f} ns/op"
+  let depth16 = benchMedian(Trials, proc(): float = benchChainReadBound(ChainReadN, 16))
+  echo &"chain[0].value read, bound, depth=16              {depth16:10.2f} ns/op"
+  echo ""
+
+  echo "-- mixed bound/unbound batch (branch-predictor-hostile interleaving) --"
+  let mixed = benchMedian(Trials, proc(): float = benchMixedBatch(MixedBatchN))
+  echo &"callSoon schedule+fire, alternating bound/unbound  {mixed:10.2f} ns/op"
+
+when isMainModule:
+  runReport()

--- a/benchmarks/bench_http_fetch.nim
+++ b/benchmarks/bench_http_fetch.nim
@@ -42,7 +42,10 @@ const
   mediumMessage = createMessage(MediumRequestSize)
 
 proc inSecondsFloat(d: times.Duration): float =
-  d.inNanoseconds() / 1000000000
+  # Explicit `float()`: dividing the `int64` result of `inNanoseconds()`
+  # directly against an untyped-int literal resolves to system's
+  # `/(int, int): float`, whose `int` is 32-bit on i386.
+  float(d.inNanoseconds()) / 1_000_000_000.0
 
 # Create a simple HTTP server for benchmarking
 proc createBenchmarkServer(address: TransportAddress): HttpServerRef =
@@ -143,8 +146,9 @@ proc print(results: BenchmarkResult) =
     totalTime: results.totalTime.inSecondsFloat,
     numRequests: results.numRequests,
     reqsps: ((results.numRequests.float / results.totalTime.inSecondsFloat)),
-    sent: results.totalBytesSent / (1024 * 1024),
-    received: results.totalBytesReceived / (1024 * 1024),
+    # `.float` explicitly, same i386 reasoning as `inSecondsFloat` above.
+    sent: results.totalBytesSent.float / (1024 * 1024),
+    received: results.totalBytesReceived.float / (1024 * 1024),
     sendSpeed:
       (results.totalBytesSent.float / results.totalTime.inSecondsFloat / (1024 * 1024)),
     recvSpeed: (

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -32,7 +32,12 @@ let testArguments =
     [
       "-d:debug -d:chronosDebug -d:useSysAssert -d:useGcAssert",
       "-d:debug -d:chronosDebug -d:chronosEventEngine=poll -d:useSysAssert -d:useGcAssert",
+      "-d:debug -d:chronosDebug -d:chronosPreviewV5 -d:useSysAssert -d:useGcAssert",
       "-d:release -d:chronosPreviewV5",
+      # Pins the vacated-slot canary's no-sink branch (chronosUseSink
+      # gates `chronosMoveSink`'s identity-passthrough fallback) on
+      # every toolchain, not just whichever default chronosUseSink picks.
+      "-d:debug -d:chronosDebug -d:chronosUseSink=false -d:useSysAssert -d:useGcAssert",
     ]
 
 let cfg =
@@ -74,7 +79,7 @@ task benchmarks, "Run benchmarks":
   # Make sure benchmarks compile
   for f in walkDirRec("benchmarks"):
 
-    if f.contains("bench_") and f.endsWith(".nim"):
+    if f.extractFilename.startsWith("bench_") and f.endsWith(".nim"):
       run "-d:release", f[0..^5]
 
 task test, "Run all tests":
@@ -84,10 +89,12 @@ task test, "Run all tests":
     if (NimMajor, NimMinor) >= (2, 2): # ORC on 2.0 is too broken to investigate
       run args & " --mm:orc", "tests/testall"
 
-  # Make sure benchmarks compile
+  # Make sure benchmarks compile. `--threads:on` explicitly: Nim 1.6
+  # does not default it on, and bench_bulk_tcp.nim imports
+  # chronos/threadsync, which hard-fails to compile without it.
   for f in walkDirRec("benchmarks"):
-    if f.startsWith("bench_") and f.endsWith(".nim"):
-      build "", f[0..^5]
+    if f.extractFilename.startsWith("bench_") and f.endsWith(".nim"):
+      build "--threads:on", f[0..^5]
 
 task test_v3_compat, "Run all tests in v3 compatibility mode":
   for args in testArguments:

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -86,8 +86,19 @@ task test, "Run all tests":
   for args in testArguments:
     # First run tests with `refc` memory manager.
     run args & " --mm:refc", "tests/testall"
+    # testcontextvarsstandalone is its own step, not part of testall: it
+    # covers the contextvars suites that cannot share testall's binary
+    # (testcontextvarsleakguard deliberately lets an AssertionDefect
+    # escape poll() under chronosDebug; testcontextvarslock's chronosDebug
+    # construction lock is one-way for the process's lifetime). The
+    # `orchestrate` argument runs each suite in its own subprocess, so
+    # isolation holds by construction rather than by import order.
+    build args & " --mm:refc", "tests/testcontextvarsstandalone"
+    exec "build/testcontextvarsstandalone orchestrate"
     if (NimMajor, NimMinor) >= (2, 2): # ORC on 2.0 is too broken to investigate
       run args & " --mm:orc", "tests/testall"
+      build args & " --mm:orc", "tests/testcontextvarsstandalone"
+      exec "build/testcontextvarsstandalone orchestrate"
 
   # Make sure benchmarks compile. `--threads:on` explicitly: Nim 1.6
   # does not default it on, and bench_bulk_tcp.nim imports

--- a/chronos/asyncloop.nim
+++ b/chronos/asyncloop.nim
@@ -12,5 +12,14 @@
 
 import ./internal/[asyncengine, asyncfutures, asyncmacro, errors]
 
-export asyncfutures, asyncengine, errors
+when defined(windows):
+  # `asyncengine.nim`'s `captureContextInto(var CompletionData)`
+  # overload is exported for `stream.nim`'s accept-loop registration
+  # sites to use, but must not flow past this module — same
+  # unnameability discipline as `CompletionData.context` itself, whose
+  # privacy this overload exists to preserve.
+  export asyncfutures, errors
+  export asyncengine except captureContextInto
+else:
+  export asyncfutures, asyncengine, errors
 export asyncmacro.async, asyncmacro.await, asyncmacro.awaitne

--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -152,4 +152,7 @@ when chronosUseSink:
   template chronosMoveSink*(v: sink auto): untyped = move(v)
 else:
   template chronosSink*(T: type): type = T
-  template chronosMoveSink*(v: sink auto): untyped = v
+  # Plain `auto`, no `sink`: this branch returns `v` unchanged (no move
+  # happens), and on Nim < 2.0.6 `sink auto` fails to match an lvalue
+  # seq-element argument for some instantiations.
+  template chronosMoveSink*(v: auto): untyped = v

--- a/chronos/contextvars.nim
+++ b/chronos/contextvars.nim
@@ -1,0 +1,626 @@
+#
+#                     Chronos
+#
+#  (c) Copyright 2026-Present Status Research & Development GmbH
+#
+#                Licensed under either of
+#    Apache License, version 2.0, (LICENSE-APACHEv2)
+#                MIT license (LICENSE-MIT)
+
+## Continuation-local storage for chronos: dynamically-scoped values that
+## follow a logical task through `await` suspensions, callback
+## registrations, and combinators, while concurrent tasks stay isolated
+## from each other. See `docs/src/contextvars.md` for the full design,
+## usage examples, and the "Test plan" section describing this feature's
+## test coverage.
+##
+## A context variable is a value — a `ContextVar[T]` key returned by
+## `newContextVar[T]` or declared with the `{.contextVar.}` pragma — not a
+## family of macro-minted identifiers. Every operation on a key is an
+## ordinary call:
+##
+## - `cv.value` — the innermost binding for the current logical task, or
+##   the key's default when nothing is bound; raises
+##   `UnboundContextVarDefect` for a must-bind key read while unbound.
+## - `ctx[cv]` — the same read, against a captured `AsyncContext` snapshot
+##   instead of the ambient chain.
+## - `cv.withValue(v): body` — bind `cv` to `v` for the dynamic extent of
+##   `body`, restoring the previous binding on every exit path (normal,
+##   exception, `CancelledError`).
+##
+## ## Public API
+##
+## - `ContextVar[T]` / `newContextVar[T](name, default, private = true)`
+##   / `newRequiredContextVar[T](name, private = true)` (must-bind) —
+##   the key type and its raw constructors.
+## - `{.contextVar.}` — declaration pragma: `let name* {.contextVar.} =
+##   default` derives the key's name and `dumpContext` privacy from the
+##   declaration site itself. See docs/src/contextvars.md, "The
+##   `{.contextVar.}` pragma".
+## - `value`, `` `[]` ``, `withValue`, `name`, `hasDefault`, `private` —
+##   the operation vocabulary above, plus read-only accessors.
+## - `` `contains` ``/`cv in ctx`, `isBound` — non-raising boundness
+##   probes, identity-correct (unlike inferring boundness from
+##   `dumpContext`'s name-grouped output). See docs/src/contextvars.md,
+##   "Required variables".
+## - `AsyncContext`, `currentContext()`, `withContext(ctx, body)`,
+##   `` `==` ``/`hash` — snapshot/restore for callback-style code that
+##   runs under a context captured earlier. See docs/src/contextvars.md,
+##   "Bridging independent callbacks".
+## - `dumpContext(ctx): seq[ContextVarEntry]` / `` `$`(ctx): string `` —
+##   introspect every registered (non-private) key's state within a
+##   snapshot. See docs/src/contextvars.md, "Inspecting contexts".
+## - `UnboundContextVarDefect` — raised by a must-bind key's read
+##   (`.value` or `ctx[cv]`) when read while unbound; carries the key's
+##   name in `varName`.
+
+import std/[algorithm, atomics, hashes, strutils]
+when (NimMajor, NimMinor) >= (2, 0):
+  # `{.contextVar.}` (see the gate below) is the only consumer.
+  import std/macros
+import ./config
+import ./futures
+import ./internal/contextnode
+# Neither `ContextNodeBase` nor the ambient `currentAsyncContext`
+# threadvar (declared in `chronos/futures.nim`, used internally below via
+# the plain `import ./futures`) is re-exported: `AsyncContext` below
+# wraps the chain head in a field private to this module, so no external
+# code — including code that imports `chronos/internal/contextnode`
+# directly — has any route to construct one outside `currentContext()`'s
+# own capture. See docs/src/contextvars.md, "Implementation".
+
+# --- Key types and the registry --------------------------------------------
+
+type
+  ContextVarBase* {.acyclic.} = ref object of RootRef
+    ## Non-generic base of a `ContextVar[T]` key. Ref identity IS key
+    ## identity: no custom `==` is ever defined for this hierarchy — see
+    ## `hash*` below for the pointer-identity hash that is defined.
+    ## Fields stay unexported — `name`/`hasDefault`/`private` below are
+    ## read-only accessors, and `render`/`nextRegistered` are
+    ## registry/render internals reachable only from this module.
+    ##
+    ## `{.acyclic.}`: `nextRegistered` only ever links into
+    ## `registryHead` (append-only, see `registerVar`), so this chain is
+    ## cycle-free by construction; and every registered key is
+    ## already immortal for the process's life (see `registryHead`
+    ## below), so cycle-collector bookkeeping for it can never lead to
+    ## a collection either way. Also decouples a key from the
+    ## constructing thread's per-thread cycle-collector bookkeeping
+    ## under `--mm:orc` — load-bearing, not cosmetic: without it, a key
+    ## constructed on a thread that then exits leaves a dangling
+    ## bookkeeping entry that SIGSEGVs the next decref to touch it, even
+    ## at ordinary process teardown. `ContextVar[T]` below repeats the
+    ## pragma — it isn't inherited by generic subtypes.
+    name: string
+    hasDefault: bool
+    private: bool
+    render: proc(cv: ContextVarBase, node: ContextNodeBase): string
+      {.nimcall, gcsafe, raises: [].}
+      ## `node == nil` renders the key's stored default instead of a
+      ## bound node's value — the one instantiation `dumpContext`
+      ## needs for both the bound and the unbound-but-defaulted case.
+    nextRegistered: ContextVarBase
+
+  ContextVar*[T] {.acyclic.} = ref object of ContextVarBase
+    default: T
+
+  ContextNodeKeyed = ref object of ContextNodeBase
+    ## Carries `key` where every chain node can read it without
+    ## knowing `T` — `contextnode.nim`'s `ContextNodeBase` declares
+    ## only `next`, so this layer inserts the field the lookup walk
+    ## needs, one level below it. `ContextNode[T]` is the only type
+    ## ever built on this layer, so `key`'s presence at this offset
+    ## is sound by construction, not by runtime tag.
+    ##
+    ## Stored as a raw `pointer`, not `ContextVarBase`: a key is a
+    ## module-level `let` constructed before any `createThread` (see
+    ## "Registry and key lifetime" below) and kept alive for the
+    ## process's life by the registry's intrusive list — every key
+    ## registers, private or not, precisely so this field can stay an
+    ## untraced pointer — never by a chain node, so the pointee outlives
+    ## every node that could reference it. This is
+    ## load-bearing, not cosmetic: `withValue` can run on any thread
+    ## once a key is constructed, and under `--mm:refc` the GC heap is
+    ## per-thread (`gch` is `{.rtlThreadVar.}`), so a traced
+    ## `ContextVarBase` field here would incref a foreign-thread-
+    ## allocated key through the wrong thread's heap bookkeeping on
+    ## every bind — reproduced as a `[GCASSERT] incRef: interiorPtr`
+    ## crash under `-d:useGcAssert` (two threads, each `withValue`-
+    ## binding the same key). `{.cursor.}` was tried first and does NOT
+    ## fix this: this codebase's own precedent (`asyncfutures.nim`'s
+    ## `cbc2 {.cursor.}` sites) documents it as an orc/arc
+    ## cycle-avoidance device, and empirically refc still emits the
+    ## write barrier for a cursor field here. A raw `pointer` sidesteps
+    ## ref-counting entirely, on every MM, matching the old registry's
+    ## own `ptr ContextVarRegistration` precedent for the same class of
+    ## hazard.
+    key: pointer
+
+  ContextNode[T] = ref object of ContextNodeKeyed
+    ## One chain node: the key it was bound under, plus the owned
+    ## value. Unexported like `ContextNodeKeyed` — nothing outside this
+    ## module ever names either type; `withValue`/`` `[]` `` build and
+    ## walk nodes from inside their own template/proc bodies, which
+    ## resolve against this module's scope regardless of the caller's.
+    value: T
+
+func name*(cv: ContextVarBase): string {.inline.} =
+  ## Read-only: the string is stored anyway, so log/tracing code
+  ## shouldn't need a registry walk to name a key. No matching `name=`
+  ## is ever defined.
+  cv.name
+
+func hasDefault*(cv: ContextVarBase): bool {.inline.} =
+  cv.hasDefault
+
+func private*(cv: ContextVarBase): bool {.inline.} =
+  cv.private
+
+func hash*(cv: ContextVarBase): Hash {.inline, raises: [].} =
+  ## Pointer-identity hash, consistent with ref identity being key
+  ## identity (no custom `` `==` `` is ever defined for this hierarchy —
+  ## see the guardrail in tests/testcontextvarsguardrails.nim) — mirrors
+  ## `hash*(ctx: AsyncContext)` below. Safe to use `ContextVar[T]` as a
+  ## `Table`/`HashSet` key.
+  hash(cast[pointer](cv))
+
+var registryHead: ContextVarBase
+  ## Head of the intrusive registry list — process-lifetime, allocation
+  ## free. Registration keeps a key alive for the life of the process,
+  ## matching what a purely static, module-level-global design would
+  ## have gotten for free.
+
+func renderValue[T](v: T): string {.raises: [].} =
+  when T is ref:
+    if v == nil:
+      return "nil"
+  when compiles($(v)):
+    try:
+      $(v)
+    except CatchableError:
+      "<render-error>"
+  else:
+    "<no-$>"
+
+func renderGeneric[T](cv: ContextVarBase, node: ContextNodeBase): string
+    {.nimcall, gcsafe, raises: [].} =
+  if node != nil:
+    renderValue(cast[ContextNode[T]](node).value)
+  else:
+    renderValue(ContextVar[T](cv).default)
+
+# --- Construction guards and the raw constructors ---------------------------
+
+when defined(chronosDebug):
+  var contextVarConstructionLocked = false
+    ## Guard flag for the write-once-then-read-only registry discipline
+    ## documented in docs/src/contextvars.md, "Registry and key
+    ## lifetime": keys are constructed only before any `createThread`.
+    ## Flipped by `lockContextVarConstruction()`; chronos does not wrap
+    ## user thread creation, so nothing calls this automatically — it
+    ## is an opt-in debug hook, exercised by the test suite. Debug-only:
+    ## no lock is paid on any path in a release build.
+
+  proc lockContextVarConstruction*() {.inline.} =
+    ## Engage the construction guard. Any `newContextVar`/
+    ## `newRequiredContextVar` call after this point asserts. One-way
+    ## for the process's lifetime — there is no matching unlock,
+    ## mirroring the real thread-creation event it stands in for.
+    contextVarConstructionLocked = true
+
+  proc checkContextVarConstructionAllowed() {.inline.} =
+    doAssert not contextVarConstructionLocked,
+      "newContextVar/newRequiredContextVar called after " &
+      "lockContextVarConstruction() — keys must be constructed before " &
+      "any thread creation"
+
+var contextVarThreadGenCounter: Atomic[uint]
+  ## Source of the never-recycled per-thread identity the guard below
+  ## checks against, in place of `getThreadId()`: an OS thread id is
+  ## reused once its thread exits, which would let a later, unrelated
+  ## thread pass as the one that constructed the first key. Generation
+  ## `0` is reserved for "unstamped" (see `contextVarThreadGen` below),
+  ## so the first generation handed out is `1`.
+
+var contextVarThreadGen {.threadvar.}: uint
+  ## This thread's identity, lazily assigned by `contextVarThreadGeneration`
+  ## on first use. `0` means not yet stamped.
+
+proc contextVarThreadGeneration(): uint {.inline.} =
+  if contextVarThreadGen == 0'u:
+    contextVarThreadGen = contextVarThreadGenCounter.fetchAdd(1'u) + 1'u
+  contextVarThreadGen
+
+var contextVarConstructionThreadGen: Atomic[uint]
+  ## Recording slot for the automatic same-thread construction guard: `0`
+  ## means no key has been constructed yet; any other value is the
+  ## generation (see above) of the thread that constructed the first one.
+  ## Set exactly once, via the compare-exchange in
+  ## `checkContextVarConstructionThread` below, so the guard needs no
+  ## lock to stay race-free.
+
+proc checkContextVarConstructionThread() {.inline.} =
+  ## Unconditional in every build, not just `-d:chronosDebug`: the
+  ## hazard this guards is `--mm:refc` GC-heap corruption from a chain
+  ## node's untraced raw `key` pointer (see docs/src/contextvars.md,
+  ## "Registry and key lifetime"), and the construction path it runs on
+  ## is cold, so there is no release-build case for skipping it.
+  let gen = contextVarThreadGeneration()
+  var recorded = 0'u
+  if not contextVarConstructionThreadGen.compareExchange(recorded, gen):
+    doAssert recorded == gen,
+      "newContextVar/newRequiredContextVar called from a different " &
+      "thread than the one that constructed the first context " &
+      "variable key — under --mm:refc this corrupts the GC heap (see " &
+      "docs/src/contextvars.md, \"Registry and key lifetime\"); " &
+      "construct every context variable key on a single thread, " &
+      "before any createThread call"
+
+proc checkContextVarConstruction() {.inline.} =
+  ## Called unconditionally from both constructors below, so callers
+  ## don't need their own `when defined(chronosDebug):` wrapper: the
+  ## lock check (`checkContextVarConstructionAllowed`) is allowed only
+  ## under `-d:chronosDebug`, opt-in as above; the thread check
+  ## (`checkContextVarConstructionThread`) always runs.
+  when defined(chronosDebug):
+    checkContextVarConstructionAllowed()
+  checkContextVarConstructionThread()
+
+proc registerVar(base: ContextVarBase) =
+  base.nextRegistered = registryHead
+  registryHead = base
+
+proc newContextVar*[T](name: chronosSink string, default: T,
+                        private = true): ContextVar[T] {.raises: [].} =
+  ## Defaulted-arm constructor. Registers unconditionally, regardless of
+  ## `private` — see "Registry and key lifetime" in
+  ## docs/src/contextvars.md for why registration is now the key's only
+  ## lifetime guarantee. `private` governs `dumpContext` visibility only,
+  ## and defaults to `true` — see "Privacy and the raw constructors".
+  ##
+  ## `default` stays a plain `T`, not `chronosSink T`: `T` must be
+  ## inferred from this very argument at ordinary call sites (there is
+  ## no other `T`-typed parameter to pin it, unlike this codebase's
+  ## other `chronosSink T` sites — `asyncfutures.nim`'s `complete`,
+  ## `callbackqueue.nim`'s `addLast`/`prependNoGrow` — where a
+  ## `Future[T]`/`CallbackQueue[T]` parameter already fixes `T` before
+  ## the sink parameter is even considered). Under `--mm:refc`'s
+  ## chronosUseSink branch (Nim >= 2.0.6), `chronosSink` lowers to
+  ## `sink`, and routing generic-parameter inference through the
+  ## template that produces it — rather than a bare `sink T` — defeats
+  ## Nim's sigmatch: `newContextVar("x", 0)` stops compiling with a type
+  ## mismatch, reproduced in isolation down to a two-line template.
+  ## `name`, which carries no inference burden, keeps `chronosSink`.
+  checkContextVarConstruction()
+  result = ContextVar[T](name: name, hasDefault: true, private: private,
+                          default: default)
+  result.render = renderGeneric[T]
+  registerVar(result)
+
+proc newRequiredContextVar*[T](name: chronosSink string,
+                                private = true): ContextVar[T] {.raises: [].} =
+  ## Must-bind constructor — no default supplied. See
+  ## docs/src/contextvars.md, "Required variables". Same unconditional
+  ## registration and `private` default as `newContextVar` above; a
+  ## distinct name rather than a second overload of `newContextVar` —
+  ## see docs/src/contextvars.md, "The raw constructors".
+  checkContextVarConstruction()
+  result = ContextVar[T](name: name, hasDefault: false, private: private)
+  result.render = renderGeneric[T]
+  registerVar(result)
+
+iterator registeredVars(): ContextVarBase =
+  ## Unexported — the registry-walking primitive is internal to this
+  ## module, invoked by `dumpContext` only. Analogous to the old
+  ## design's `contextVarRegistry` iterator, which was pinned off the
+  ## public surface for the same reason: a caller has no legitimate use
+  ## for raw registry entries that `dumpContext`/`ContextVarEntry`
+  ## doesn't already serve.
+  var node = registryHead
+  while node != nil:
+    yield node
+    node = node.nextRegistered
+
+# --- Snapshot type and the one chain-walk lookup -----------------------------
+# `.value` re-expresses as `currentContext()[cv]` below, on top of this
+# same `` `[]` `` — the sole walk, so the re-expression is a thin wrapper,
+# not a second implementation.
+
+type
+  AsyncContext* = object
+    ## Opaque snapshot of a binding chain, captured by `currentContext()`.
+    node: ContextNodeBase
+      ## Private: the only route to a populated `AsyncContext` is
+      ## `currentContext()`'s capture below — construction from an
+      ## arbitrary `ContextNodeBase` must not compile, even for code
+      ## that imports `chronos/internal/contextnode` directly. See
+      ## docs/src/contextvars.md, "Implementation".
+
+func `==`*(a, b: AsyncContext): bool {.gcsafe, raises: [].} =
+  ## Identity equality: `true` iff `a` and `b` reference the same
+  ## underlying chain head — i.e. both were captured with no
+  ## intervening binding change.
+  a.node == b.node
+
+func hash*(ctx: AsyncContext): Hash {.gcsafe, raises: [].} =
+  ## Pointer-identity hash, consistent with `==`'s identity semantics —
+  ## safe to use `AsyncContext` as a `Table`/`HashSet` key.
+  hash(cast[pointer](ctx.node))
+
+proc currentContext*(): AsyncContext {.gcsafe, raises: [].} =
+  ## Capture the current task's binding chain as an opaque snapshot.
+  # `proc`, not `func`: reading the `{.threadvar.}` trips effect analysis.
+  {.cast(gcsafe).}:
+    AsyncContext(node: currentAsyncContext)
+
+template withContext*(ctx: AsyncContext, body: untyped) =
+  ## Run `body` with `ctx` as the current async context; restore the
+  ## prior context on every exit path (normal, exception, including
+  ## `CancelledError`).
+  let chronosCtxPrev = currentAsyncContext
+  currentAsyncContext = ctx.node
+  try:
+    body
+  finally:
+    currentAsyncContext = chronosCtxPrev
+
+type
+  UnboundContextVarDefect* = object of Defect
+    ## Raised by a must-bind key's read (`.value` or `ctx[cv]`) when no
+    ## binding is in scope.
+    varName*: string
+
+func findNode(chain: ContextNodeBase, cv: ContextVarBase): ContextNodeBase =
+  var node = chain
+  while node != nil:
+    if cast[ContextNodeKeyed](node).key == cast[pointer](cv):
+      return node
+    node = node.nextNode
+
+func `[]`*[T](ctx: AsyncContext, cv: ContextVar[T]): T {.raises: [].} =
+  let node = findNode(ctx.node, cv)
+  if node != nil:
+    when defined(chronosDebug):
+      doAssert node of ContextNode[T],
+        "contextvars internal error: a chain node whose key matched " &
+        "cv is not a ContextNode[T] — see the construction invariant " &
+        "in docs/src/contextvars.md, \"Implementation\""
+    return cast[ContextNode[T]](node).value
+  if cv.hasDefault:
+    cv.default
+  else:
+    var e = newException(UnboundContextVarDefect,
+      "context variable '" & cv.name & "' has no default and is not " &
+      "bound in this context")
+    e.varName = cv.name
+    raise e
+
+template value*[T](cv: ContextVar[T]): T =
+  ## `{.cast(gcsafe).}`: `cv` is typically a module-level `let` key (a
+  ## `ref`), and this template inlines directly into its caller — so
+  ## without the cast, the caller (often a `{.gcsafe.}`-required async
+  ## proc) would be flagged for "accessing a global using GC'ed
+  ## memory". Sound: keys are write-once at construction (see
+  ## docs/src/contextvars.md, "Registry and key lifetime") and never
+  ## mutated after.
+  {.cast(gcsafe).}:
+    currentContext()[cv]
+
+when defined(chronosDebug):
+  var chainBalance* {.threadvar.}: int
+    ## Debug-only bind/unbind balance counter for `withValue`:
+    ## increments at push, decrements at pop. A nonzero value at
+    ## test-suite end signals a binder leak. Deterministic + MM-
+    ## portable — doesn't depend on GC sweep timing.
+
+  proc chainLen*(): int {.inline, raises: [].} =
+    ## Debug-only chain-depth probe. Walks `currentAsyncContext` and
+    ## returns the number of nodes. Used by binder-contract tests to
+    ## verify push/pop balance without relying on finalizer timing.
+    # `proc`, not `func`: reading the `{.threadvar.}` trips effect analysis.
+    var n = currentAsyncContext
+    while n != nil:
+      inc result
+      n = n.nextNode
+
+template withValue*[T](cv: ContextVar[T], v: T, body: untyped): untyped =
+  ## Push a `ContextNode[T]` bound to `cv` onto the ambient chain for
+  ## the dynamic extent of `body`; restore the prior head on every exit
+  ## path. Allocates before mutating `currentAsyncContext`, so a failed
+  ## allocation can't leave a half-pushed chain.
+  ##
+  ## `{.cast(gcsafe).}`: same global-access rationale as `value` above —
+  ## `cv` inlines straight into the caller here too.
+  let chronosCtxPrev = currentAsyncContext
+  var chronosCtxNode: ContextNode[T]
+  {.cast(gcsafe).}:
+    chronosCtxNode = ContextNode[T](key: cast[pointer](cv), value: v)
+  linkNode(chronosCtxNode, chronosCtxPrev)
+  currentAsyncContext = chronosCtxNode
+  when defined(chronosDebug):
+    inc chainBalance
+  try:
+    body
+  finally:
+    currentAsyncContext = chronosCtxPrev
+    when defined(chronosDebug):
+      dec chainBalance
+
+# --- Introspection ------------------------------------------------------------
+# `ContextVarEntry`/`dumpContext`/`` `$` ``: same bound-flag semantics
+# (an unbound defaulted key still shows its rendered default; an unbound
+# must-bind key shows the `<unbound>` placeholder), same sorted-by-name
+# order, same `{name: value, ...}` `$` format documented in
+# docs/src/contextvars.md, "Inspecting contexts". Every key registers
+# now (see `newContextVar`), so `dumpContext` is the filtering point:
+# it skips `cv.private` entries itself rather than relying on their
+# absence from the registry.
+
+type
+  ContextVarEntry* = object
+    name*: string
+    bound*: bool
+    value*: string
+
+func contains*[T](ctx: AsyncContext, cv: ContextVar[T]): bool {.raises: [].} =
+  ## `cv in ctx` — identity-correct boundness probe (PEP 567 precedent:
+  ## Python contexts support `in`). True iff `cv` has an active binding
+  ## in `ctx`, false otherwise — including for a must-bind key, which
+  ## `.value`/`` `[]` `` would raise `UnboundContextVarDefect` for
+  ## instead. Answers what a `dumpContext` name-match cannot: which of
+  ## two same-name keys is the one actually bound (see "Registry and key
+  ## lifetime" — same-name keys never alias).
+  findNode(ctx.node, cv) != nil
+
+template isBound*[T](cv: ContextVar[T]): bool =
+  ## Ambient form of `contains` — mirrors `value`'s relationship to
+  ## `` `[]` ``. `{.cast(gcsafe).}`: same global-access rationale as
+  ## `value` above — `cv` inlines straight into the caller here too.
+  {.cast(gcsafe).}:
+    currentContext().contains(cv)
+
+proc dumpContext*(ctx: AsyncContext): seq[ContextVarEntry] {.raises: [].} =
+  ## Introspect every registered, non-private key as of `ctx`, sorted
+  ## by name. Never raises — render failures are caught inside each
+  ## key's render hook.
+  {.cast(gcsafe).}:
+    let chain = ctx.node
+    for cv in registeredVars():
+      if cv.private: continue
+      let node = findNode(chain, cv)
+      if node != nil:
+        result.add ContextVarEntry(name: cv.name, bound: true,
+                                    value: cv.render(cv, node))
+      elif cv.hasDefault:
+        result.add ContextVarEntry(name: cv.name, bound: false,
+                                    value: cv.render(cv, nil))
+      else:
+        result.add ContextVarEntry(name: cv.name, bound: false,
+                                    value: "<unbound>")
+  result.sort(proc(a, b: ContextVarEntry): int = cmp(a.name, b.name))
+
+proc `$`*(ctx: AsyncContext): string {.raises: [].} =
+  ## Render `ctx` as `{name: value, ...}`, via the same registry walk
+  ## as `dumpContext`. Debugging/logging only — not a stable format.
+  var parts: seq[string]
+  for entry in dumpContext(ctx):
+    parts.add entry.name & ": " & entry.value
+  "{" & parts.join(", ") & "}"
+
+# --- `{.contextVar.}` declaration sugar --------------------------------------
+# A pragma macro, not a statement macro: `contextVar name*: T = default`
+# doesn't parse (export postfix and identdef are `let`/`var`-only parser
+# productions). Attached as `{.contextVar.}` between the star and the
+# colon-type, it lets the parser's own identdef grammar do the
+# star/type/default parsing; the macro only rewrites the RHS into a
+# `newContextVar` call and re-emits the one `let`/`var` symbol.
+
+# Macro pragmas on `let`/`var` sections (the mechanism `{.contextVar.}`
+# relies on) are a 2.x-only language capability — `semVarMacroPragma`,
+# which rewrites `var p {.m.}` into a call to `m`, does not exist in the
+# 1.6 compiler, so the pragma silently never invokes on 1.6. Declare keys
+# with `newContextVar`/`newRequiredContextVar` directly on 1.6; see
+# docs/src/contextvars.md, "The `{.contextVar.}` pragma".
+when (NimMajor, NimMinor) >= (2, 0):
+  proc splitContextVarNameAndPrivate(identNode: NimNode):
+      tuple[nameNode: NimNode, nameStr: string, private: bool] =
+    ## Star present -> exported -> private = false; absent -> private =
+    ## true. `nnkIdent`/`nnkSym` both resolve via `strVal` (a wrapper
+    ## template forwarding its own parameter arrives as `nnkSym`); only
+    ## `nnkPostfix` needs unwrapping to reach the name.
+    # 1.6: explicit `result =` per branch, not a case-expression — 1.6 sems
+    # case-branches as statements even when the last one is a noreturn
+    # `error()` call, and rejects the tuple as unused. (Moot under the
+    # 2.x gate above, kept for hygiene since the shape is trivial to keep
+    # portable.)
+    case identNode.kind
+    of nnkPostfix:
+      if identNode.len != 2 or identNode[0].strVal != "*":
+        error("contextVar: unexpected postfix form: " & identNode.repr, identNode)
+      result = (identNode, identNode[1].strVal, false)
+    of nnkIdent, nnkSym:
+      result = (identNode, identNode.strVal, true)
+    else:
+      error("contextVar: expected `name` or `name*`, got " & identNode.repr, identNode)
+
+  proc parsePrivateOverride(opts: NimNode): bool =
+    ## Unwraps the argument of `{.contextVar: (private: true|false).}` —
+    ## `(private: true)` parses as a one-field `nnkTupleConstr` holding an
+    ## `nnkExprColonExpr`, and `true`/`false` there arrive as `nnkIdent`
+    ## (bare identifiers, not bool literals — the argument is untyped).
+    ## Any other shape is a compile error naming the one accepted form.
+    if opts.kind == nnkTupleConstr and opts.len == 1 and
+        opts[0].kind == nnkExprColonExpr and opts[0][0].eqIdent("private") and
+        opts[0][1].kind == nnkIdent and opts[0][1].strVal in ["true", "false"]:
+      return opts[0][1].strVal == "true"
+    error("contextVar: expected `(private: true)` or `(private: false)`, " &
+          "got " & opts.repr, opts)
+
+  proc contextVarImpl(def: NimNode, hasPrivateOverride: bool,
+                       overridePrivate: bool): NimNode =
+    ## `let name* {.contextVar.} = default` (T inferred), `let name*
+    ## {.contextVar.}: T = default` (explicit T), or `var name*
+    ## {.contextVar.}: T` (must-bind) — expands to exactly one symbol,
+    ## `let name* = newContextVar(...)` or `newRequiredContextVar(...)`.
+    ## See docs/src/contextvars.md, "The `{.contextVar.}` pragma". The
+    ## `let`/`var` choice is enforced here, not just documented: a
+    ## defaulted key must be a `let`, a must-bind key must be a `var` —
+    ## the same split between `newContextVar` and `newRequiredContextVar`
+    ## the call site makes, moved to the declaration site. `hasPrivateOverride`
+    ## selects between the export-derived default (`{.contextVar.}`) and the
+    ## explicit `{.contextVar: (private: ...).}` override, common to both
+    ## pragma arities below.
+    if def.kind notin {nnkLetSection, nnkVarSection}:
+      error("contextVar: must annotate a `let` or `var` statement", def)
+    if def.len != 1:
+      error("contextVar: supports exactly one identifier per statement", def)
+    let identDefs = def[0]
+    if identDefs.kind != nnkIdentDefs or identDefs.len != 3:
+      error("contextVar: expected a single `name[*][: T] [= default]` " &
+            "identifier definition, got " & identDefs.repr, identDefs)
+    let (nameNode, nameStr, derivedPrivate) = splitContextVarNameAndPrivate(identDefs[0])
+    let private = if hasPrivateOverride: overridePrivate else: derivedPrivate
+    let typAnnotation = identDefs[1]
+    let value = identDefs[2]
+
+    if value.kind == nnkEmpty:
+      if typAnnotation.kind == nnkEmpty:
+        error("contextVar: must-bind keys need an explicit type, e.g. " &
+              "`var " & nameStr & "*: T {.contextVar.}`", identDefs)
+      if def.kind != nnkVarSection:
+        error("contextVar: a must-bind key (no `= default`) needs `var`, " &
+              "not `let` — spell it `var " & nameStr & "*: " &
+              typAnnotation.repr & " {.contextVar.}`", def)
+    elif def.kind != nnkLetSection:
+      error("contextVar: a defaulted key (`= default`) needs `let`, not " &
+            "`var` — spell it `let " & nameStr & "*" &
+            (if typAnnotation.kind != nnkEmpty: ": " & typAnnotation.repr
+             else: "") & " {.contextVar.} = " & value.repr & "`", def)
+
+    let ctorCall =
+      if value.kind == nnkEmpty:
+        quote do: newRequiredContextVar[`typAnnotation`](`nameStr`, private = `private`)
+      elif typAnnotation.kind != nnkEmpty:
+        quote do: newContextVar[`typAnnotation`](`nameStr`, `value`, private = `private`)
+      else:
+        quote do: newContextVar(`nameStr`, `value`, private = `private`)
+
+    result = newNimNode(nnkLetSection)
+    result.add newIdentDefs(nameNode, newEmptyNode(), ctorCall)
+
+  macro contextVar*(def: untyped): untyped =
+    ## Default form: `dumpContext` privacy is derived from the declaration's
+    ## own export marker (star -> `private = false`, no star -> `private =
+    ## true`). See docs/src/contextvars.md, "The `{.contextVar.}` pragma".
+    contextVarImpl(def, hasPrivateOverride = false, overridePrivate = false)
+
+  macro contextVar*(opts, def: untyped): untyped =
+    ## Override form: `{.contextVar: (private: true|false).}` decouples
+    ## `dumpContext` visibility from the export marker for this one
+    ## declaration — e.g. an exported key that should still be
+    ## dump-private, or an unexported key surfaced for cross-module
+    ## debugging. See docs/src/contextvars.md, "The `{.contextVar.}`
+    ## pragma", "Overriding dump-visibility".
+    contextVarImpl(def, hasPrivateOverride = true,
+                    overridePrivate = parsePrivateOverride(opts))

--- a/chronos/futures.nim
+++ b/chronos/futures.nim
@@ -11,6 +11,7 @@
 {.push raises: [].}
 
 import ./[config, srcloc]
+import ./internal/contextnode
 
 export srcloc
 
@@ -28,8 +29,28 @@ type
 
   # Internal type, not part of API
   InternalAsyncCallback* = object
-    function*: CallbackFunc
-    udata*: pointer
+    function: CallbackFunc
+    udata: pointer
+    context: ContextNodeBase
+      ## Continuation-local context captured at scheduling time. A
+      ## native `ref` field, MM-managed. Nil for callbacks scheduled
+      ## outside any binding and for internal trampolines that don't
+      ## fire user code. `SentinelCallback` (asyncengine.nim) must be a
+      ## `template`, not `const`: Nim 2.x rejects `const` of an object
+      ## with a `ref` field, and a module-level `let` is
+      ## gcsafe-inaccessible from `poll`.
+      ##
+      ## `function`/`udata`/`context` are private to this module -
+      ## only `capturingCallback`/`bareCallback` below can construct an
+      ## `InternalAsyncCallback`.
+
+  InternalCancelCallback* = object
+    function: CallbackFunc
+    context: ContextNodeBase
+      ## Same capture/lifetime discipline as
+      ## `InternalAsyncCallback.context` above. Private to this
+      ## module - only `capturingCancelCallback` and the no-capture
+      ## construction in `internalInitFutureBase` build one.
 
   FutureState* {.pure.} = enum
     Pending, Completed, Cancelled, Failed
@@ -65,7 +86,7 @@ type
       ## a spot in each future for that first one - the seq below will stay
       ## empty until a second callback is added
     internalCallbacks*: seq[InternalAsyncCallback]
-    internalCancelcb*: CallbackFunc
+    internalCancelcb*: InternalCancelCallback
     internalChild*: FutureBase
     internalState*: FutureState
     internalFlags*: FutureFlags
@@ -103,6 +124,128 @@ func raiseFutureDefect(msg: static string, fut: FutureBase) {.
     noinline, noreturn.} =
   raise (ref FutureDefect)(msg: msg, cause: fut)
 
+# --- InternalAsyncCallback: read-only accessors ------------------------------
+#
+# `function`/`udata`/`context` are private (see the type above). UFCS
+# makes `callable.function` / `.udata` / `.context` reads compile
+# unchanged at every existing call site.
+
+func function*(acb: InternalAsyncCallback): CallbackFunc {.inline.} =
+  acb.function
+
+func udata*(acb: InternalAsyncCallback): pointer {.inline.} =
+  acb.udata
+
+func context*(acb: InternalAsyncCallback): ContextNodeBase {.inline.} =
+  acb.context
+
+# --- InternalCancelCallback: read-only accessors -----------------------------
+#
+# `function`/`context` are private (see the type above, defined beside
+# `InternalAsyncCallback`). UFCS makes `callable.function` / `.context`
+# reads compile the same way as `InternalAsyncCallback`'s.
+
+func function*(acb: InternalCancelCallback): CallbackFunc {.inline.} =
+  acb.function
+
+func context*(acb: InternalCancelCallback): ContextNodeBase {.inline.} =
+  acb.context
+
+# --- Continuation-local context: dispatcher-facing primitives ---------------
+#
+# `ContextNodeBase` is deliberately unnameable outside modules that
+# import `contextnode.nim` directly; `asyncengine.nim` reaches it only
+# by inference, so `currentAsyncContext`, the constructors below, and
+# `withRestoredContext`/`pinContext` all live here rather than in
+# `chronos/contextvars.nim`.
+
+var currentAsyncContext* {.threadvar.}: ContextNodeBase
+  ## Per-thread head of the binding chain. Chronos is single-thread-
+  ## per-dispatcher, so this is effectively per-dispatcher.
+
+template captureContextInto*(dest: var ContextNodeBase) =
+  ## Capture the ambient context into `dest`. Call only on a freshly
+  ## declared local, never an object literal field or `result` -
+  ## otherwise refc's reset-then-assign copy-out doubles the
+  ## write-barrier cost of every callback construction.
+  if not isNil(currentAsyncContext):
+    dest = currentAsyncContext
+
+template capturingCallback*(fn: CallbackFunc, ud: pointer = nil): InternalAsyncCallback =
+  ## Construct an AsyncCallback that captures the current continuation-local
+  ## context, so the callback fires under the bindings live at its
+  ## registration site. Use at every scheduling site whose callback must
+  ## observe registration-time bindings — whether the callback is
+  ## application code or chronos-internal (transport loops, combinators,
+  ## the continuation pump all qualify); use `bareCallback` only for
+  ## context-neutral trampolines that neither read contextVars nor fire
+  ## code that does.
+  ##
+  ## Must be a template, not a proc returning by value: constructs into
+  ## a fresh local via `captureContextInto` (see its doc for why).
+  ## Param is `ud`, not `udata`: template substitution would otherwise
+  ## rewrite the `acb.udata` field access below too.
+  var acb: InternalAsyncCallback
+  acb.function = fn
+  acb.udata = ud
+  captureContextInto(acb.context)
+  acb
+
+template bareCallback*(fn: CallbackFunc, ud: pointer = nil): InternalAsyncCallback =
+  ## Construct an AsyncCallback for chronos-internal scaffolding (IOCP
+  ## completion repackaging, idle-loop sentinels, fd-readiness
+  ## trampolines) that doesn't itself read contextVars — no context
+  ## capture. Downstream user-visible callbacks still carry their own
+  ## context from their original `capturingCallback` site.
+  ##
+  ## Must be a template, like `SentinelCallback` in asyncengine.nim.
+  ## Param is `ud`, not `udata`, for the same substitution reason as
+  ## `capturingCallback`.
+  InternalAsyncCallback(function: fn, udata: ud, context: nil)
+
+template contextCallback*(fn: CallbackFunc, ud: pointer,
+                          ctx: ContextNodeBase): InternalAsyncCallback =
+  ## Construct an AsyncCallback carrying a context captured earlier
+  ## rather than the ambient one here — for dispatch trampolines that
+  ## stored the registrant's context at arm time and reconstruct the
+  ## fired callback from it because the dispatching thread has no
+  ## ambient binding of its own (e.g. Windows IOCP completion
+  ## processing in `poll()`).
+  InternalAsyncCallback(function: fn, udata: ud, context: ctx)
+
+template capturingCancelCallback*(fn: CallbackFunc): InternalCancelCallback =
+  ## Construct the value stored in `internalCancelcb`, capturing context
+  ## at construction like `capturingCallback` - the handler must observe the
+  ## context bound at `cancelCallback=` time, not whatever's ambient
+  ## when it fires.
+  var cb: InternalCancelCallback
+  cb.function = fn
+  captureContextInto(cb.context)
+  cb
+
+template withRestoredContext*(newCtx: ContextNodeBase, body: untyped) =
+  ## Context switch with identity fast path. Sound only when `body`
+  ## cannot dangle the binder chain across a suspend — i.e. body is not
+  ## a continuation pump, or the pump's entry re-pins (`pinContext`).
+  let chronosCtxPrev = currentAsyncContext        # one TLS read
+  if newCtx == chronosCtxPrev:                    # identity - no writes,
+    body                                          # no try/finally
+    when defined(chronosDebug):
+      doAssert currentAsyncContext == newCtx,
+        "identity arm violated: a pump body went through " &
+        "withRestoredContext without its own pinContext"
+  else:
+    currentAsyncContext = newCtx
+    try: body
+    finally: currentAsyncContext = chronosCtxPrev
+
+template pinContext*(body: untyped) =
+  ## Unconditional entry/exit guard ("the pin"), no fast path ever — for
+  ## bodies that may suspend mid-binder (continuation pumps).
+  let chronosCtxPrev = currentAsyncContext
+  try: body
+  finally: currentAsyncContext = chronosCtxPrev
+
 when chronosFutureId:
   var currentID* {.threadvar.}: uint
   template id*(fut: FutureBase): uint = fut.internalId
@@ -128,8 +271,12 @@ proc internalInitFutureBase*(fut: FutureBase, loc: ptr SrcLoc,
   if FutureFlag.OwnCancelSchedule in flags:
     # Owners must replace `cancelCallback` with `nil` if they want to ignore
     # cancellations
-    fut.internalCancelcb = proc(_: pointer) =
+    proc raiseNonCancellable(_: pointer) =
       raiseAssert "Cancellation request for non-cancellable future"
+    # `fut` is freshly allocated, so `internalCancelcb.context` is
+    # already nil from the allocator's zero-fill - write only the
+    # `function` field rather than a whole-struct literal.
+    fut.internalCancelcb.function = raiseNonCancellable
 
   if state != FutureState.Pending:
     fut.internalLocation[LocationKind.Finish] = loc

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -19,10 +19,15 @@ import std/[atomics, deques, heapqueue, tables, typetraits]
 import results
 import ../[config, effects, futures, osdefs, oserrno, osutils, timer]
 
-import ./[asyncmacro, errors]
+import ./[asyncmacro, callbackqueue, errors]
 
 export Port
 export deques, effects, errors, futures, timer, results
+# `CallbackQueue` itself stays unnameable outside this module (mirroring
+# `./mpsc`'s `MpscQueue`), but `asyncfutures.nim`'s `cancelSoon` still
+# reaches `loop.callbacks.addLast(...)` directly, so `addLast` alone
+# needs to be in scope there via this re-export.
+export callbackqueue.addLast
 
 export
   asyncmacro.async, asyncmacro.await, asyncmacro.awaitne
@@ -76,9 +81,15 @@ type
 
   DispatcherBase = object of RootRef
     timers*: HeapQueue[TimerCallback]
-    callbacks*: Deque[AsyncCallback]
-    idlers*: Deque[AsyncCallback]
-    ticks*: Deque[AsyncCallback]
+    # `CallbackQueue` (./callbackqueue), not `std/deques`: avoids the
+    # refc hidden-return-slot cost `std/deques.popFirst` pays on every
+    # dequeue. `callbacks` stays public - `asyncfutures.nim` reaches it
+    # directly (`loop.callbacks.addLast(...)` in `cancelSoon`) and isn't
+    # touched in this change; `idlers`/`ticks` have no callers outside
+    # this module and are privatized.
+    callbacks*: CallbackQueue[AsyncCallback]
+    idlers: CallbackQueue[AsyncCallback]
+    ticks: CallbackQueue[AsyncCallback]
     trackers*: Table[string, TrackerBase]
     counters*: Table[string, TrackerCounter]
     inEventLoop: bool
@@ -163,7 +174,8 @@ template processTimersGetTimeout(loop, timeout: untyped) =
     if curTime < lastFinish:
       break
 
-    loop.callbacks.addLast(loop.timers.pop().function)
+    let callable = loop.timers.pop().function
+    loop.callbacks.addLast(callable)
 
   if loop.timers.len > 0:
     timeout = (lastFinish - curTime).getAsyncTimestamp()
@@ -187,15 +199,18 @@ template processTimers(loop: untyped) =
 
     if curTime < loop.timers[0].finishAt:
       break
-    loop.callbacks.addLast(loop.timers.pop().function)
+    let callable = loop.timers.pop().function
+    loop.callbacks.addLast(callable)
 
 template processIdlers(loop: untyped) =
   if len(loop.idlers) > 0:
-    loop.callbacks.addLast(loop.idlers.popFirst())
+    let callable = loop.idlers.popFirst()
+    loop.callbacks.addLast(callable)
 
 template processTicks(loop: untyped) =
   while len(loop.ticks) > 0:
-    loop.callbacks.addLast(loop.ticks.popFirst())
+    let callable = loop.ticks.popFirst()
+    loop.callbacks.addLast(callable)
 
 template processCallbacks(loop: untyped) =
   when chronosStrictReentrancy:
@@ -391,9 +406,9 @@ elif defined(windows):
       ioPort: port,
       handles: initHashSet[AsyncFD](),
       timers: initHeapQueue[TimerCallback](),
-      callbacks: initDeque[AsyncCallback](64),
-      idlers: initDeque[AsyncCallback](),
-      ticks: initDeque[AsyncCallback](),
+      callbacks: initCallbackQueue[AsyncCallback](64),
+      idlers: initCallbackQueue[AsyncCallback](),
+      ticks: initCallbackQueue[AsyncCallback](),
       trackers: initTable[string, TrackerBase](),
       counters: initTable[string, TrackerCounter](),
     )
@@ -748,7 +763,7 @@ elif defined(windows):
 
     when not chronosStrictReentrancy:
       # All callbacks done, skip `processCallbacks` at start.
-      loop.callbacks.addFirst(SentinelCallback)
+      loop.callbacks.prependNoGrow(SentinelCallback)
 
   proc closeSocket*(fd: AsyncFD, aftercb: CallbackFunc = nil) =
     ## Closes a socket and ensures that it is unregistered.
@@ -830,8 +845,10 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     var res = PDispatcher(
       selector: selector,
       timers: initHeapQueue[TimerCallback](),
-      callbacks: initDeque[AsyncCallback](chronosInitialSize),
-      idlers: initDeque[AsyncCallback](),
+      callbacks: initCallbackQueue[AsyncCallback](chronosInitialSize),
+      idlers: initCallbackQueue[AsyncCallback](),
+      # `ticks` is deliberately left at its zero value - `CallbackQueue`'s
+      # zero value is already a valid, empty queue that grows lazily.
       keys: newSeq[ReadyKey](chronosInitialSize),
       trackers: initTable[string, TrackerBase](),
       counters: initTable[string, TrackerCounter](),
@@ -1222,7 +1239,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
 
     when not chronosStrictReentrancy:
       # All callbacks done, skip `processCallbacks` at start.
-      loop.callbacks.addFirst(SentinelCallback)
+      loop.callbacks.prependNoGrow(SentinelCallback)
 
 else:
   proc initAPI() = discard

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -20,14 +20,24 @@ import results
 import ../[config, effects, futures, osdefs, oserrno, osutils, timer]
 
 import ./[asyncmacro, callbackqueue, errors]
+when defined(windows):
+  import ./contextnode
+    # For `ContextNodeBase`, naming `CompletionData.context` below -
+    # `futures.nim` imports it without re-exporting.
 
 export Port
-export deques, effects, errors, futures, timer, results
-# `CallbackQueue` itself stays unnameable outside this module (mirroring
-# `./mpsc`'s `MpscQueue`), but `asyncfutures.nim`'s `cancelSoon` still
-# reaches `loop.callbacks.addLast(...)` directly, so `addLast` alone
-# needs to be in scope there via this re-export.
-export callbackqueue.addLast
+export deques, effects, errors, timer, results
+# `CallbackQueue` backs the privatized `callbacks`/`idlers`/`ticks`
+# queues and isn't itself public, mirroring `./mpsc`'s `MpscQueue`.
+# The capturing constructors and context primitives are excluded so
+# plain `import chronos` doesn't expose them, while `import
+# chronos/internal/asyncengine` or `chronos/futures` still can;
+# `InternalAsyncCallback`/`InternalCancelCallback` stay exported since
+# they're already nameable via `AsyncCallback` and
+# `InternalFutureBase.internalCancelcb*`.
+export futures except capturingCallback, bareCallback, contextCallback,
+  capturingCancelCallback, currentAsyncContext, context, withRestoredContext,
+  pinContext, captureContextInto
 
 export
   asyncmacro.async, asyncmacro.await, asyncmacro.awaitne
@@ -83,11 +93,8 @@ type
     timers*: HeapQueue[TimerCallback]
     # `CallbackQueue` (./callbackqueue), not `std/deques`: avoids the
     # refc hidden-return-slot cost `std/deques.popFirst` pays on every
-    # dequeue. `callbacks` stays public - `asyncfutures.nim` reaches it
-    # directly (`loop.callbacks.addLast(...)` in `cancelSoon`) and isn't
-    # touched in this change; `idlers`/`ticks` have no callers outside
-    # this module and are privatized.
-    callbacks*: CallbackQueue[AsyncCallback]
+    # dequeue. Privatized - every touch site lives in this module.
+    callbacks: CallbackQueue[AsyncCallback]
     idlers: CallbackQueue[AsyncCallback]
     ticks: CallbackQueue[AsyncCallback]
     trackers*: Table[string, TrackerBase]
@@ -103,9 +110,13 @@ type
 proc sentinelCallbackImpl(arg: pointer) {.gcsafe, noreturn.} =
   raiseAssert "Sentinel callback MUST not be scheduled"
 
-const
-  SentinelCallback = AsyncCallback(function: sentinelCallbackImpl,
-                                   udata: nil)
+template SentinelCallback(): AsyncCallback =
+  ## Sentinel value placed in the callbacks deque to delimit a batch.
+  ## A `template`, not `const` or `let`, because `AsyncCallback.context`
+  ## is a `ref` field: Nim 2.x rejects `const` of an object containing
+  ## a `ref` field, and a module-level `let` is gcsafe-inaccessible
+  ## from dispatcher procs like `poll`.
+  bareCallback(sentinelCallbackImpl, nil)
 
 proc isSentinel(acb: AsyncCallback): bool =
   acb == SentinelCallback
@@ -140,8 +151,12 @@ template processThreadCallbacks(loop) =
       # Move the callbacks to the regular callback list - this ensures we don't
       # starve the rest of the pipeline if the callbacks themselves keep adding
       # stuff
+      #
+      # `bareCallback`: the scheduling site was on another thread whose
+      # context (thread-local GC memory) cannot be captured here — the
+      # callback fires with an empty context.
       loop.callbacks.addLast(
-        AsyncCallback(function: node.callback, udata: node.udata)
+        bareCallback(node.callback, node.udata)
       )
       deallocShared(node)
 
@@ -212,21 +227,48 @@ template processTicks(loop: untyped) =
     let callable = loop.ticks.popFirst()
     loop.callbacks.addLast(callable)
 
-template processCallbacks(loop: untyped) =
+template fireWithContext(callable: untyped) =
+  # Restore the context captured at the callback's scheduling site
+  # (via `capturingCallback`), with an identity fast path when the ambient
+  # context already matches.
+  withRestoredContext(callable.context):
+    # `callable.function`/`.udata` are UFCS calls to private-field
+    # getters in `futures.nim` - parenthesize `callable.function` so it
+    # parses as "call the function value with udata", not a 2-arg UFCS
+    # call on the getter.
+    (callable.function)(callable.udata)
+
+template processCallbacksBody(loop: untyped) =
   when chronosStrictReentrancy:
     # Process existing callbacks but not those that follow, to allow the network
     # to regain control regularly
     for _ in 0 ..< len(loop.callbacks):
       let callable = loop.callbacks.popFirst()
       if not(isNil(callable.function)):
-        callable.function(callable.udata)
+        fireWithContext(callable)
   else:
     while true:
       let callable = loop.callbacks.popFirst()  # len must be > 0 due to sentinel
       if isSentinel(callable):
         break
       if not(isNil(callable.function)):
-        callable.function(callable.udata)
+        fireWithContext(callable)
+
+template processCallbacks(loop: untyped) =
+  # Debug-only net: every callback batch must exit with the same
+  # ambient context it entered with. The snapshot is a per-invocation
+  # local, not a module global, because a nested `waitFor` inside a
+  # running callback can legally re-enter this template with a
+  # different ambient context.
+  when defined(chronosDebug):
+    let chronosDebugPreBatch = currentAsyncContext
+    try:
+      processCallbacksBody(loop)
+    finally:
+      doAssert currentAsyncContext == chronosDebugPreBatch,
+        "context leaked across a callback batch"
+  else:
+    processCallbacksBody(loop)
 
 proc raiseAsDefect*(exc: ref Exception, msg: string) {.noreturn, noinline.} =
   # Reraise an exception as a Defect, where it's unexpected and can't be handled
@@ -288,6 +330,19 @@ elif defined(windows):
       errCode*: OSErrorCode
       bytesCount*: uint32
       udata*: pointer
+      context: ContextNodeBase
+        ## Registrant's context, captured via `captureContextInto` at
+        ## the site that arms the overlapped completion (e.g.
+        ## `registerWaitable`, a stream server's `start()`). Nil unless
+        ## an arm site explicitly captures, reproducing the
+        ## empty-context fail-closed default for the rest.
+        ##
+        ## Private: a public field would make `ContextNodeBase`
+        ## structurally reachable via plain `import chronos` on
+        ## Windows. Same-module code (this file) may still read it
+        ## directly; `stream.nim` writes it through the
+        ## `captureContextInto(var CompletionData)` overload defined
+        ## right after this type section.
 
     CustomOverlapped* = object of OVERLAPPED
       data*: CompletionData
@@ -327,6 +382,13 @@ elif defined(windows):
       Ok, Timeout
 
     AsyncFD* = distinct int
+
+  template captureContextInto*(dest: var CompletionData) =
+    ## `CompletionData`-typed overload of
+    ## `captureContextInto(var ContextNodeBase)` (futures.nim), for
+    ## call sites — `stream.nim`'s accept-loop registration — that
+    ## cannot write the private `context` field directly.
+    captureContextInto(dest.context)
 
   proc hash(x: AsyncFD): Hash {.borrow.}
   proc `==`*(x: AsyncFD, y: AsyncFD): bool {.borrow, gcsafe.}
@@ -485,7 +547,13 @@ elif defined(windows):
     ## NOTE: This is private procedure, not supposed to be publicly available,
     ## please use ``waitForSingleObject()``.
     let loop = getThreadDispatcher()
-    var ovl = RefCustomOverlapped(data: CompletionData(cb: cb))
+    # Capture into a fresh local, not directly into the object-literal
+    # field below - same discipline `captureContextInto`'s own doc
+    # comment requires of every caller (avoids refc's reset-then-assign
+    # double write-barrier on a field of a freshly-constructed object).
+    var registrantCtx: ContextNodeBase
+    captureContextInto(registrantCtx)
+    var ovl = RefCustomOverlapped(data: CompletionData(cb: cb, context: registrantCtx))
 
     var whandle = (ref PostCallbackData)(
       ioPort: loop.getIoHandler(),
@@ -732,8 +800,12 @@ elif defined(windows):
             else:
               OSErrorCode(rtlNtStatusToDosError(res))
         customOverlapped.data.bytesCount = events[i].dwNumberOfBytesTransferred
-        let acb = AsyncCallback(function: customOverlapped.data.cb,
-                                udata: cast[pointer](customOverlapped))
+        # Fire under whatever context the arm site captured into
+        # `CompletionData.context`; nil reproduces `bareCallback`'s
+        # empty-context behavior. See the contextvars user documentation.
+        let acb = contextCallback(customOverlapped.data.cb,
+                                   cast[pointer](customOverlapped),
+                                   customOverlapped.data.context)
         loop.callbacks.addLast(acb)
       else:
         hasWakeup = true
@@ -774,7 +846,7 @@ elif defined(windows):
     # not supported so we discard the return value.
     discard closeFd(SocketHandle(fd))
     if not(isNil(aftercb)):
-      loop.callbacks.addLast(AsyncCallback(function: aftercb))
+      loop.callbacks.addLast(capturingCallback(aftercb))
 
   proc closeHandle*(fd: AsyncFD, aftercb: CallbackFunc = nil) =
     ## Closes a (pipe/file) handle and ensures that it is unregistered.
@@ -787,7 +859,7 @@ elif defined(windows):
     discard closeFd(HANDLE(fd))
 
     if not(isNil(aftercb)):
-      loop.callbacks.addLast(AsyncCallback(function: aftercb))
+      loop.callbacks.addLast(capturingCallback(aftercb))
 
   proc unregisterAndCloseFd*(fd: AsyncFD): Result[void, OSErrorCode] =
     ## Unregister from system queue and close asynchronous socket.
@@ -918,7 +990,12 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     let loop = getThreadDispatcher()
     var newEvents = {Event.Read}
     withData(loop.selector, cint(fd), adata) do:
-      let acb = AsyncCallback(function: cb, udata: udata)
+      # Assignment overwrite fires =destroy on the prior reader,
+      # releasing its captured context - re-arming is leak-safe.
+      # Assign via a temp: the destination is an existing heap field,
+      # not a fresh local, so direct assignment misses the
+      # write-barrier elision `capturingCallback` relies on.
+      let acb = capturingCallback(cb, udata)
       adata.reader = acb
       if not(isNil(adata.writer.function)):
         newEvents.incl(Event.Write)
@@ -931,8 +1008,8 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     let loop = getThreadDispatcher()
     var newEvents: set[Event]
     withData(loop.selector, cint(fd), adata) do:
-      # We need to clear `reader` data, because `selectors` don't do it
-      adata.reader = default(AsyncCallback)
+      # Assignment fires =destroy on the prior reader - context released.
+      adata.reader.reset()
       if not(isNil(adata.writer.function)):
         newEvents.incl(Event.Write)
     do:
@@ -946,7 +1023,9 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     let loop = getThreadDispatcher()
     var newEvents = {Event.Write}
     withData(loop.selector, cint(fd), adata) do:
-      let acb = AsyncCallback(function: cb, udata: udata)
+      # Assign via a temp: same write-barrier-elision reason as
+      # `addReader2` above.
+      let acb = capturingCallback(cb, udata)
       adata.writer = acb
       if not(isNil(adata.reader.function)):
         newEvents.incl(Event.Read)
@@ -959,8 +1038,9 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     let loop = getThreadDispatcher()
     var newEvents: set[Event]
     withData(loop.selector, cint(fd), adata) do:
-      # We need to clear `writer` data, because `selectors` don't do it
-      adata.writer = default(AsyncCallback)
+      # Same as removeReader2 above: assignment fires =destroy on the
+      # prior writer, releasing its captured context.
+      adata.writer.reset()
       if not(isNil(adata.reader.function)):
         newEvents.incl(Event.Read)
     do:
@@ -1040,16 +1120,16 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
 
       if not(isNil(adata.reader.function)):
         loop.callbacks.addLast(adata.reader)
-        adata.reader = default(AsyncCallback)
+        adata.reader.reset()
 
       if not(isNil(adata.writer.function)):
         loop.callbacks.addLast(adata.writer)
-        adata.writer = default(AsyncCallback)
+        adata.writer.reset()
 
     # We can't unregister file descriptor from system queue here, because
     # in such case processing queue will stuck on poll() call, because there
     # can be no file descriptors registered in system queue.
-    var acb = AsyncCallback(function: continuation)
+    var acb = capturingCallback(continuation)
     loop.callbacks.addLast(acb)
 
   proc closeHandle*(fd: AsyncFD, aftercb: CallbackFunc = nil) =
@@ -1079,7 +1159,10 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       var data: SelectorData
       let sigfd = ? loop.selector.registerSignal(signal, data)
       withData(loop.selector, sigfd, adata) do:
-        adata.reader = AsyncCallback(function: cb, udata: udata)
+        # Assign via a temp: same write-barrier-elision reason as
+        # `addReader2` above.
+        let acb = capturingCallback(cb, udata)
+        adata.reader = acb
       do:
         return err(osdefs.EBADF)
       ok(SignalHandle(sigfd))
@@ -1096,17 +1179,25 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       var data: SelectorData
       let procfd = ? loop.selector.registerProcess(pid, data)
       withData(loop.selector, procfd, adata) do:
-        adata.reader = AsyncCallback(function: cb, udata: udata)
+        # Assign via a temp: same write-barrier-elision reason as
+        # `addReader2` above.
+        let acb = capturingCallback(cb, udata)
+        adata.reader = acb
       do:
         return err(osdefs.EBADF)
       ok(ProcessHandle(procfd))
 
     proc removeSignal2*(signalHandle: SignalHandle): Result[void, OSErrorCode] =
       ## Remove watching signal ``signal``.
+      # SelectorData drop on unregister2 cascades =destroy onto
+      # adata.reader's AsyncCallback, releasing its captured context.
       getThreadDispatcher().selector.unregister2(cint(signalHandle))
 
     proc removeProcess2*(procHandle: ProcessHandle): Result[void, OSErrorCode] =
       ## Remove process' watching using process' descriptor ``procfd``.
+      # Same as removeSignal2 above: SelectorData drop on unregister2
+      # cascades =destroy onto adata.reader's AsyncCallback, releasing
+      # its captured context.
       getThreadDispatcher().selector.unregister2(cint(procHandle))
 
     proc addSignal*(signal: int, cb: CallbackFunc,
@@ -1271,10 +1362,12 @@ proc setTimer*(at: Moment, cb: CallbackFunc,
   ## timestamp ``at``. You can also pass ``udata`` to callback.
   let loop = getThreadDispatcher()
   result = TimerCallback(finishAt: at,
-                         function: AsyncCallback(function: cb, udata: udata))
+                         function: capturingCallback(cb, udata))
   loop.timers.push(result)
 
 proc clearTimer*(timer: TimerCallback) {.inline.} =
+  # Overwrite releases the captured context ref, same as any other
+  # `field = default(T)` site.
   timer.function = default(AsyncCallback)
 
 proc addTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil) {.
@@ -1307,6 +1400,8 @@ proc removeTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil) =
             break
         res
   if index != -1:
+    # heapqueue.del fires =destroy on the removed TimerCallback's
+    # function field, releasing its captured context.
     loop.timers.del(index)
 
 proc removeTimer*(at: int64, cb: CallbackFunc, udata: pointer = nil) {.
@@ -1326,7 +1421,7 @@ proc callSoon*(cbproc: CallbackFunc, udata: pointer = nil) =
   ## Schedule `cbproc` to be called as soon as possible.
   ## The callback is called when control returns to the event loop.
   doAssert(not isNil(cbproc))
-  callSoon(AsyncCallback(function: cbproc, udata: udata))
+  callSoon(capturingCallback(cbproc, udata))
 
 when hasThreadSupport:
   type DispatcherHandle* = distinct (ptr Dispatcher)
@@ -1379,8 +1474,10 @@ when hasThreadSupport:
     doAssert(not isNil(cbproc))
     let current = gDisp.handle() # Don't init a new dispatcher with getThreadDispatcher()
     if distinctBase(current) == distinctBase(disp):
-      # Same thread: add directly to the callbacks deque
-      distinctBase(current).callbacks.addLast(AsyncCallback(function: cbproc, udata: udata))
+      # Same thread: add directly to the callbacks deque, capturing
+      # context like `callSoon`. The cross-thread branch below fires
+      # with an empty context - unreachable from the target thread.
+      distinctBase(current).callbacks.addLast(capturingCallback(cbproc, udata))
     else:
       # Cross-thread: enqueue to shared MPSC queue
       let node = createShared(ThreadCallbackNode)
@@ -1414,24 +1511,28 @@ proc callIdle*(cbproc: CallbackFunc, data: pointer) =
   ## iteration if there no network events available, not when the loop is
   ## actually "idle".
   doAssert(not isNil(cbproc))
-  callIdle(AsyncCallback(function: cbproc, udata: data))
+  callIdle(capturingCallback(cbproc, data))
 
 proc callIdle*(cbproc: CallbackFunc) =
   callIdle(cbproc, nil)
 
 proc internalCallTick*(acb: AsyncCallback) =
-  ## Schedule ``cbproc`` to be called after all scheduled callbacks, but only
-  ## when OS system queue finished processing events.
+  ## Schedule ``acb`` to be called after all scheduled callbacks, but only
+  ## when OS system queue finished processing events. Caller-supplied
+  ## AsyncCallback - caller decides whether to use `capturingCallback` or
+  ## `bareCallback`.
   getThreadDispatcher().ticks.addLast(acb)
 
 proc internalCallTick*(cbproc: CallbackFunc, data: pointer) =
   ## Schedule ``cbproc`` to be called after all scheduled callbacks when
-  ## OS system queue processing is done.
+  ## OS system queue processing is done. No context capture - `cbproc`
+  ## is treated as an internal trampoline. Use
+  ## `internalCallTick(capturingCallback(cb, data))` to opt into capture.
   doAssert(not isNil(cbproc))
-  internalCallTick(AsyncCallback(function: cbproc, udata: data))
+  internalCallTick(bareCallback(cbproc, data))
 
 proc internalCallTick*(cbproc: CallbackFunc) =
-  internalCallTick(AsyncCallback(function: cbproc, udata: nil))
+  internalCallTick(bareCallback(cbproc, nil))
 
 proc runForever*() =
   ## Begins a never ending global dispatcher poll loop.

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -180,7 +180,7 @@ proc finish(fut: FutureBase, state: FutureState, loc: ptr SrcLoc) =
   fut.checkFinished(loc)
 
   fut.internalState = state
-  fut.internalCancelcb = nil # release cancellation callback memory
+  fut.internalCancelcb.reset() # release cancellation callback memory
 
   if not(isNil(fut.internalCallback.function)):
     callSoon(move(fut.internalCallback))
@@ -189,8 +189,9 @@ proc finish(fut: FutureBase, state: FutureState, loc: ptr SrcLoc) =
   var callbacks = move(fut.internalCallbacks)
   for item in callbacks.mitems():
     if not(isNil(item.function)):
-      callSoon(item)
-    item = default(AsyncCallback) # release memory as early as possible
+      callSoon(move(item))
+    else:
+      item.reset() # release memory as early as possible
 
   when chronosFutureTracking:
     scheduleDestructor(fut)
@@ -256,6 +257,12 @@ proc cancelAndSchedule(future: FutureBase, loc: ptr SrcLoc) =
 template cancelAndSchedule*(future: FutureBase) =
   cancelAndSchedule(future, getSrcLocation())
 
+template fireCancelCallback(future: FutureBase) =
+  # Fire with the context captured when `cancelCallback=` was set, not
+  # whatever context happens to be ambient when `tryCancel` runs.
+  withRestoredContext(future.internalCancelcb.context):
+    (future.internalCancelcb.function)(cast[pointer](future))
+
 proc tryCancel(future: FutureBase, loc: ptr SrcLoc): bool =
   ## Perform an attempt to cancel ``future``.
   ##
@@ -280,13 +287,13 @@ proc tryCancel(future: FutureBase, loc: ptr SrcLoc): bool =
     # If you hit this assertion, you should have used the `CancelledError`
     # mechanism and/or use a regular `addCallback`
     when chronosStrictFutureAccess:
-      doAssert isNil(future.internalCancelcb),
+      doAssert isNil(future.internalCancelcb.function),
         "futures returned from `{.async.}` functions must not use " &
         "`cancelCallback`"
     tryCancel(future.internalChild, loc)
   else:
-    if not(isNil(future.internalCancelcb)):
-      future.internalCancelcb(cast[pointer](future))
+    if not(isNil(future.internalCancelcb.function)):
+      fireCancelCallback(future)
     if FutureFlag.OwnCancelSchedule notin future.internalFlags:
       cancelAndSchedule(future, loc)
     future.cancelled()
@@ -295,6 +302,8 @@ template tryCancel*(future: FutureBase): bool =
   tryCancel(future, getSrcLocation())
 
 proc clearCallbacks(future: FutureBase) =
+  # reset() fires =destroy on the dropped AsyncCallback(s), which
+  # releases each one's captured context. No explicit release needed.
   future.internalCallback.reset()
   future.internalCallbacks.reset()
 
@@ -306,10 +315,16 @@ proc addCallback*(future: FutureBase, cb: CallbackFunc, udata: pointer) =
   if future.finished():
     callSoon(cb, udata)
   else:
+    # `capturingCallback` captures the current contextVar bindings; the
+    # dispatcher restores them in `processCallbacks` before firing.
     if isNil(future.internalCallback.function):
-      future.internalCallback = AsyncCallback(function: cb, udata: udata)
+      # Assign via a temp: `internalCallback` is an existing heap
+      # field, not a fresh local, so direct assignment misses refc's
+      # write-barrier elision.
+      let acb = capturingCallback(cb, udata)
+      future.internalCallback = acb
     else:
-      future.internalCallbacks.add AsyncCallback(function: cb, udata: udata)
+      future.internalCallbacks.add capturingCallback(cb, udata)
 
 proc addCallback*(future: FutureBase, cb: CallbackFunc) =
   ## Adds the callbacks proc to be called when the future completes.
@@ -322,8 +337,8 @@ proc removeCallback*(future: FutureBase, cb: CallbackFunc,
   ## Remove future from list of callbacks - this operation may be slow if there
   ## are many registered callbacks!
   doAssert(not isNil(cb))
-  # Make sure to release memory associated with callback, or reference chains
-  # may be created!
+  # reset() / keepItIf trigger =destroy on the dropped AsyncCallback,
+  # which releases its captured context (if any).
   if future.internalCallback.function == cb and future.internalCallback.udata == udata:
     future.internalCallback.reset()
 
@@ -363,7 +378,11 @@ proc `cancelCallback=`*(future: FutureBase, cb: CallbackFunc) =
   when chronosStrictFutureAccess:
     doAssert not future.finished(),
       "cancellation callback must be set before finishing the future"
-  future.internalCancelcb = cb
+  # `capturingCancelCallback` captures the current contextVar bindings at
+  # registration time - the handler must observe that context, not
+  # whatever's ambient when `tryCancel` eventually invokes it.
+  let icb = capturingCancelCallback(cb)
+  future.internalCancelcb = icb
 
 {.push stackTrace: off.}
 proc futureContinue*(fut: FutureBase) {.raises: [], gcsafe.}
@@ -373,38 +392,52 @@ proc internalContinue(fut: pointer) {.raises: [], gcsafe.} =
   GC_unref(asFut)
   futureContinue(asFut)
 
+template scheduleContinuation(fut, next: FutureBase) =
+  ## Registers `internalContinue` to resume `futureContinue`'s pump over
+  ## `fut.internalClosure` once `next` completes.
+  GC_ref(fut)
+  next.addCallback(CallbackFunc(internalContinue), cast[pointer](fut))
+
 proc futureContinue*(fut: FutureBase) {.raises: [], gcsafe.} =
   # This function is responsible for calling the closure iterator generated by
   # the `{.async.}` transformation either until it has completed its iteration
   #
   # Every call to an `{.async.}` proc is redirected to call this function
   # instead with its original body captured in `fut.closure`.
-  while true:
-    # Call closure to make progress on `fut` until it reaches `yield` (inside
-    # `await` typically) or completes / fails / is cancelled
-    let next: FutureBase = fut.internalClosure(fut)
-    if fut.internalClosure.finished(): # Reached the end of the transformed proc
-      break
 
-    if next == nil:
-      raiseAssert "Async procedure (" & ($fut.location[LocationKind.Create]) &
-                  ") yielded `nil`, are you await'ing a `nil` Future?"
+  # A suspend inside a `withValue` binder is a plain `return`, not an
+  # unwind, so the binder's `finally` doesn't run - `pinContext`
+  # unconditionally saves/restores `currentAsyncContext` here on every
+  # entry and resume; there is no safe fast path to skip it.
+  {.cast(gcsafe).}:
+    pinContext:
+      while true:
+        # Call closure to make progress on `fut` until it reaches `yield` (inside
+        # `await` typically) or completes / fails / is cancelled
+        let next: FutureBase = fut.internalClosure(fut)
+        if fut.internalClosure.finished(): # Reached the end of the transformed proc
+          break
 
-    if not next.finished():
-      # We cannot make progress on `fut` until `next` has finished - schedule
-      # `fut` to continue running when that happens
-      GC_ref(fut)
-      next.addCallback(CallbackFunc(internalContinue), cast[pointer](fut))
+        if next == nil:
+          raiseAssert "Async procedure (" & ($fut.location[LocationKind.Create]) &
+                      ") yielded `nil`, are you await'ing a `nil` Future?"
 
-      # return here so that we don't remove the closure below
-      return
+        if not next.finished():
+          # We cannot make progress on `fut` until `next` has finished - schedule
+          # `fut` to continue running when that happens. `addCallback` captures
+          # the iterator's current context (set by any enclosing `withValue`),
+          # so on resume the continuation sees the right bindings.
+          scheduleContinuation(fut, next)
 
-    # Continue while the yielded future is already finished.
+          # return here so that we don't remove the closure below
+          return
 
-  # `futureContinue` will not be called any more for this future so we can
-  # clean it up
-  fut.internalClosure = nil
-  fut.internalChild = nil
+        # Continue while the yielded future is already finished.
+
+      # `futureContinue` will not be called any more for this future so we can
+      # clean it up
+      fut.internalClosure = nil
+      fut.internalChild = nil
 
 {.pop.}
 
@@ -774,14 +807,10 @@ proc `or`*[T, Y](fut1: Future[T], fut2: Future[Y]): Future[void] =
   var retFuture = newFuture[void]("chronos.or()")
   orImpl(fut1, fut2)
 
-proc cancelSoon(future: FutureBase, aftercb: CallbackFunc, udata: pointer,
-                loc: ptr SrcLoc) {.raises: [].} =
-  ## Perform cancellation ``future`` and call ``aftercb`` callback when
-  ## ``future`` become finished (completed with value, failed or cancelled).
-  ##
-  ## NOTE: Compared to the `tryCancel()` call, this procedure call guarantees
-  ## that ``future``will be finished (completed with value, failed or cancelled)
-  ## as quickly as possible.
+proc scheduleCancelRetry(future: FutureBase, loc: ptr SrcLoc) {.raises: [].} =
+  ## Initiate cancellation of ``future``, retrying delivery of the
+  ## cancellation signal once per tick until it succeeds or ``future``
+  ## becomes finished on its own.
   proc checktick(udata: pointer) {.gcsafe, raises: [].} =
     # We trying to cancel Future on more time, and if `cancel()` succeeds we
     # return early.
@@ -793,6 +822,21 @@ proc cancelSoon(future: FutureBase, aftercb: CallbackFunc, udata: pointer,
     if not(future.finished()):
       internalCallTick(checktick)
 
+  if not(tryCancel(future, loc)):
+    # Cancellation signal was not delivered, so we trying to deliver it one
+    # more time after async tick. But we need to check case, when future was
+    # finished but our completion callback is not yet invoked.
+    if not(future.finished()):
+      internalCallTick(checktick)
+
+proc cancelSoon(future: FutureBase, aftercb: CallbackFunc, udata: pointer,
+                loc: ptr SrcLoc) {.raises: [].} =
+  ## Perform cancellation ``future`` and call ``aftercb`` callback when
+  ## ``future`` become finished (completed with value, failed or cancelled).
+  ##
+  ## NOTE: Compared to the `tryCancel()` call, this procedure call guarantees
+  ## that ``future``will be finished (completed with value, failed or cancelled)
+  ## as quickly as possible.
   proc continuation(udata: pointer) {.gcsafe.} =
     # We do not use `callSoon` here because we was just scheduled from `poll()`.
     if not(isNil(aftercb)):
@@ -802,18 +846,33 @@ proc cancelSoon(future: FutureBase, aftercb: CallbackFunc, udata: pointer,
     # We could not schedule callback directly otherwise we could fall into
     # recursion problem.
     if not(isNil(aftercb)):
-      let loop = getThreadDispatcher()
-      loop.callbacks.addLast(AsyncCallback(function: aftercb, udata: udata))
+      callSoon(capturingCallback(aftercb, udata))
     return
 
   future.addCallback(continuation)
   # Initiate cancellation process.
-  if not(tryCancel(future, loc)):
-    # Cancellation signal was not delivered, so we trying to deliver it one
-    # more time after async tick. But we need to check case, when future was
-    # finished but our completion callback is not yet invoked.
-    if not(future.finished()):
-      internalCallTick(checktick)
+  scheduleCancelRetry(future, loc)
+
+proc cancelSoon(future: FutureBase, acb: AsyncCallback,
+                loc: ptr SrcLoc) {.raises: [].} =
+  ## Same as the `CallbackFunc`/`pointer` overload above, except `acb` is
+  ## scheduled or registered as-is rather than unpacked into a fresh
+  ## callback: whatever context `acb` carries (see `capturingCallback`)
+  ## is what fires, not whatever happens to be ambient at the
+  ## `cancelSoon` call site or whenever cancellation eventually
+  ## completes.
+  if future.finished():
+    if not(isNil(acb.function)):
+      callSoon(acb)
+    return
+
+  if not(isNil(acb.function)):
+    if isNil(future.internalCallback.function):
+      future.internalCallback = acb
+    else:
+      future.internalCallbacks.add acb
+
+  scheduleCancelRetry(future, loc)
 
 template cancelSoon*(fut: FutureBase, cb: CallbackFunc, udata: pointer) =
   cancelSoon(fut, cb, udata, getSrcLocation())
@@ -822,7 +881,7 @@ template cancelSoon*(fut: FutureBase, cb: CallbackFunc) =
   cancelSoon(fut, cb, nil, getSrcLocation())
 
 template cancelSoon*(fut: FutureBase, acb: AsyncCallback) =
-  cancelSoon(fut, acb.function, acb.udata, getSrcLocation())
+  cancelSoon(fut, acb, getSrcLocation())
 
 template cancelSoon*(fut: FutureBase) =
   cancelSoon(fut, nil, nil, getSrcLocation())
@@ -1325,7 +1384,10 @@ proc idleAsync*(): Future[void] {.
     discard
 
   retFuture.cancelCallback = cancellation
-  callIdle(continuation, nil)
+  # `continuation` is an internal trampoline that doesn't read
+  # contextVars, so schedule it via `bareCallback` rather than
+  # `capturingCallback` to avoid needlessly capturing the caller's context.
+  callIdle(bareCallback(continuation, nil))
   retFuture
 
 proc withTimeout*[T](fut: Future[T], timeout: Duration): Future[bool] {.

--- a/chronos/internal/callbackqueue.nim
+++ b/chronos/internal/callbackqueue.nim
@@ -1,0 +1,192 @@
+#
+#                     Chronos
+#
+#  (c) Copyright 2026-Present Status Research & Development GmbH
+#
+#                Licensed under either of
+#    Apache License, version 2.0, (LICENSE-APACHEv2)
+#                MIT license (LICENSE-MIT)
+
+## Move-based, seq-backed FIFO queue used for chronos's dispatcher queues
+## (`DispatcherBase.callbacks`/`idlers`/`ticks`), replacing `std/deques`
+## there.
+##
+## `std/deques.popFirst` returns `T` by value: under `--mm:refc` this
+## lowers to a hidden-return-slot reset-then-assign, paying three
+## write-barrier calls per `ref` field of `T` instead of one. `std/deques`
+## cannot be fixed in place, since the fix requires a `template` and a
+## stdlib proc API cannot become one. `--mm:orc` is unaffected either way.
+##
+## Interface is exactly five entry points: `initCallbackQueue`, `addLast`
+## (sink), `prependNoGrow` (sink; sole caller is sentinel re-insertion in
+## `asyncengine.nim`'s `poll()`), `popFirst` (a `template` — see below),
+## `len`.
+
+{.push raises: [], gcsafe.}
+
+import ../config
+
+type
+  CallbackQueue*[T] = object
+    ## Seq-backed queue with monotonic logical `head`/`tail` positions
+    ## held as `uint`, wrapping around at `high(uint) + 1` instead of
+    ## ever overflow-erroring. `tail - head`, unsigned, is congruent
+    ## mod `2^wordsize` and so recovers the true logical length across
+    ## any number of wraps, as long as it never exceeds `cap` (asserted
+    ## in `isFull`). Logical positions are folded into `[0, cap)` only
+    ## at slot access (`slotIndex`), never by clamping `head`/`tail`.
+    ##
+    ## The zero value is a valid, empty queue that lazily grows from
+    ## capacity `0` on first `addLast`, matching `std/deques`; relied
+    ## on by `asyncengine.nim`'s POSIX `Dispatcher.ticks` field.
+    data: seq[T]
+    head: uint
+    tail: uint
+
+# --- index primitives ---------------------------------------------------
+
+func capMask(cap: int): uint {.inline.} =
+  # `let`-bound rather than inlined into the `and` below: identical
+  # codegen, but keeps the operand resolvable by symbolic-execution
+  # tooling verifying this module's index arithmetic.
+  let capMinusOne = cap - 1
+  doAssert cap > 0 and (cap and capMinusOne) == 0,
+    "CallbackQueue.capMask(): capacity must be a positive power of two"
+  uint(capMinusOne)
+
+func slotIndex(pos: uint, cap: int): int {.inline.} =
+  ## Fold a monotonic (possibly-wrapped) logical position into
+  ## `[0, cap)`. `cap` being a power of two makes this correct across a
+  ## `pos` wrap too, which `prependNoGrow`'s `dec head` relies on when
+  ## `head == 0`. `mask` is `let`-bound for the same symbolic-execution
+  ## resolvability reason as `capMask` above.
+  let mask = capMask(cap)
+  int(pos and mask)
+
+func queueLen(head, tail: uint): int {.inline.} =
+  ## `tail - head`, unsigned: congruent mod `2^wordsize`, so this is the
+  ## true logical length regardless of wraps — no ordering comparison
+  ## between `head`/`tail` is meaningful any more.
+  int(tail - head)
+
+func isFull(head, tail: uint, cap: int): bool {.inline.} =
+  let n = queueLen(head, tail)
+  doAssert n >= 0 and n <= cap,
+    "CallbackQueue.isFull(): length invariant violated - `tail - head` " &
+    "(mod 2^wordsize) must never exceed capacity"
+  n >= cap
+
+func growTargetCap(cap: int): int {.inline.} =
+  doAssert cap >= 0, "CallbackQueue.growTargetCap(): capacity must not be negative"
+  if cap == 0: 8 else: cap * 2
+
+# --- public interface -----------------------------------------------------
+
+proc initCallbackQueue*[T](initialCap: int = 8): CallbackQueue[T] =
+  ## Construct a queue with capacity rounded up to the next power of two
+  ## (`slotIndex`'s bitmask folding requires it). Not required before use —
+  ## see the zero-value note on `CallbackQueue` above — but dispatcher
+  ## constructors call this to size the backing store up front and avoid
+  ## early growth churn.
+  var cap = 1
+  while cap < initialCap:
+    cap = cap * 2
+  CallbackQueue[T](data: newSeq[T](cap), head: 0'u, tail: 0'u)
+
+func len*[T](q: CallbackQueue[T]): int {.inline.} =
+  queueLen(q.head, q.tail)
+
+proc grow[T](q: var CallbackQueue[T]) =
+  ## Whole-region relocation: one or two `copyMem` segments (two only
+  ## when the live region wraps in the old backing), each followed by a
+  ## matching `zeroMem` of the vacated region — `copyMem` doesn't touch
+  ## the MM, so without it the old seq's destructor would double-decref
+  ## the relocated `ref` fields.
+  # `supportsCopyMem(T)` (std/typetraits) is unusable here: it rejects
+  # any `ref`-containing T, including the real `InternalAsyncCallback`/
+  # `InternalCancelCallback` this queue already relocates safely via
+  # the copyMem+zeroMem move below. Nim exposes no public trait for
+  # the actual invariant ("no custom =destroy/=copy/=sink/=trace"), so
+  # this catches the most likely misuse instead — T itself being a
+  # seq/string, whose move semantics this queue does not model.
+  static: doAssert not (T is (seq or string)),
+    "CallbackQueue.grow(): T must not be a seq/string — grow() relocates " &
+    "slots via raw copyMem+zeroMem, valid for a T whose move is a plain " &
+    "bit-copy (refs/ptrs/procs and structs of them), not guaranteed for " &
+    "seq/string or a T with custom lifecycle hooks"
+  let oldCap = q.data.len
+  let n = queueLen(q.head, q.tail)
+  doAssert n == oldCap, "CallbackQueue.grow(): called on a non-full queue"
+  let newCap = growTargetCap(oldCap)
+  var newData = newSeq[T](newCap)
+  if n > 0:
+    let startIdx = slotIndex(q.head, oldCap)
+    let firstSeg = min(n, oldCap - startIdx)
+    copyMem(addr newData[0], addr q.data[startIdx], firstSeg * sizeof(T))
+    zeroMem(addr q.data[startIdx], firstSeg * sizeof(T))
+    if firstSeg < n:
+      let rest = n - firstSeg
+      copyMem(addr newData[firstSeg], addr q.data[0], rest * sizeof(T))
+      zeroMem(addr q.data[0], rest * sizeof(T))
+  q.data = newData
+  q.head = 0'u
+  q.tail = uint(n)
+
+proc addLast*[T](q: var CallbackQueue[T], item: chronosSink T) =
+  if isFull(q.head, q.tail, q.data.len):
+    grow(q)
+  let idx = slotIndex(q.tail, q.data.len)
+  # `item` is a spent `sink` parameter used exactly once, here — assign
+  # directly so Nim's own move analysis applies. Do not wrap this in
+  # `chronosMoveSink`, which is for lvalue reads (see `popFirst` below),
+  # not already-sink parameters.
+  q.data[idx] = item
+  inc q.tail
+
+proc prependNoGrow*[T](q: var CallbackQueue[T], item: chronosSink T) =
+  ## Push onto the front. Precondition: `q` must not be full — unlike
+  ## `addLast`, there is no growth path here, so the caller must never
+  ## invoke this on a full queue. Not a general push-front primitive;
+  ## intended for re-inserting an item into a queue known to have
+  ## spare capacity (e.g. re-inserting a sentinel at the front of an
+  ## already-fully-drained batch).
+  doAssert not isFull(q.head, q.tail, q.data.len),
+    "CallbackQueue.prependNoGrow(): queue unexpectedly full"
+  dec q.head
+  let idx = slotIndex(q.head, q.data.len)
+  q.data[idx] = item
+
+when defined(chronosDebug) and chronosUseSink:
+  # Gated on chronosUseSink, not just chronosDebug: on the no-sink
+  # codepath `chronosMoveSink` is an identity passthrough, so no move
+  # ever clears the slot and this check would fail unconditionally.
+  proc chronosCheckVacatedSlot[T](item: T) {.inline.} =
+    ## Debug-only guardrail: every slot `popFirst` vacates must end up
+    ## default-valued, catching a path that bypasses the fused-move
+    ## discipline below. A standalone proc, not inlined into `popFirst`'s
+    ## `when` body: Nim 1.6 fails to resolve `default(T)`'s `T` when the
+    ## call sits inside a `when` nested in a generic `template`.
+    doAssert item == default(T),
+      "CallbackQueue.chronosCheckVacatedSlot(): a vacated slot retained a " &
+      "non-nil ghost value after popFirst() — a slot-vacating path " &
+      "bypassed the fused-move discipline"
+
+template popFirst*[T](q: var CallbackQueue[T]): T =
+  ## Fused dequeue. A `template`, not a `proc`: a proc returning `T` by
+  ## value pays refc's hidden-return-slot reset-then-assign lowering
+  ## regardless of `{.inline.}`. Callers must consume the result directly
+  ## in a `let` binding at the call site so the moved-out value lands in
+  ## a fresh caller-frame local rather than through an intermediate hop.
+  ##
+  ## The vacated slot is cleared via `chronosMoveSink`, an lvalue read of
+  ## a live queue slot — unlike `addLast`/`prependNoGrow` above, which assign
+  ## already-spent `sink` parameters directly.
+  doAssert q.tail != q.head, "CallbackQueue.popFirst(): queue is empty"
+  let chronosQueueIdx = slotIndex(q.head, q.data.len)
+  inc q.head
+  when defined(chronosDebug) and chronosUseSink:
+    let chronosPopped = chronosMoveSink(q.data[chronosQueueIdx])
+    chronosCheckVacatedSlot(q.data[chronosQueueIdx])
+    chronosPopped
+  else:
+    chronosMoveSink(q.data[chronosQueueIdx])

--- a/chronos/internal/contextnode.nim
+++ b/chronos/internal/contextnode.nim
@@ -1,0 +1,42 @@
+#
+#                     Chronos
+#
+#  (c) Copyright 2015 Dominik Picheta
+#  (c) Copyright 2018-2025 Status Research & Development GmbH
+#
+#                Licensed under either of
+#    Apache License, version 2.0, (LICENSE-APACHEv2)
+#                MIT license (LICENSE-MIT)
+
+## Base type of the continuation-local binding chain — split into its own
+## dependency-free leaf module so `chronos/futures.nim` can import it (for
+## `InternalAsyncCallback`'s `context` field type) without exporting it.
+##
+## The `next` field is private to this module: chain nodes are
+## constructed only by the public contextvars layer's binder, and a
+## public field would let user code link a node into a cycle. Keeping
+## it private confines chain mutation to `linkNode` below.
+
+{.push raises: [].}
+
+type
+  ContextNodeBase* = ref object of RootObj
+    ## Base of the per-task continuation-local binding chain. The public
+    ## contextvars layer layers keyed nodes on this base — a
+    ## non-generic subtype carrying the owning key's identity and a
+    ## generic subtype adding the bound `value: T` — so the chain is
+    ## heterogeneous in value type and the lookup walk compares key
+    ## identities to find the right node.
+    next: ContextNodeBase
+      ## Private — read via `nextNode`, written via `linkNode` only.
+
+func nextNode*(node: ContextNodeBase): ContextNodeBase {.inline.} =
+  ## Read-only chain traversal for the lookup walk in
+  ## the public contextvars layer.
+  node.next
+
+proc linkNode*(node, prev: ContextNodeBase) {.inline.} =
+  ## Link a freshly-constructed binding node to the chain head it is
+  ## about to shadow. Call exactly once per node, before the node is
+  ## published as the new chain head.
+  node.next = prev

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -13,7 +13,22 @@ import std/deques
 import stew/[ptrops, shims/sequninit]
 import results
 import ".."/[asyncloop, config, handles, bipbuffer, osdefs, osutils, oserrno]
+import ../futures except capturingCallback, bareCallback, contextCallback,
+  capturingCancelCallback, currentAsyncContext, context, withRestoredContext,
+  pinContext, captureContextInto
+  # `captureContextInto` is excluded here too: every call site in this
+  # file resolves to the Windows-only `captureContextInto(var
+  # CompletionData)` overload, reached instead through the direct
+  # `asyncengine` import below.
 import ./[common, ipnet]
+
+when defined(windows):
+  import ../internal/asyncengine
+    # Direct import, bypassing `asyncloop.nim`'s filtered re-export, for
+    # the `captureContextInto(var CompletionData)` overload only — the
+    # accept-loop registration sites below need it; `asyncloop.nim`
+    # deliberately excludes it from its own export surface so it can't
+    # widen the public surface through `import chronos`.
 
 export results
 
@@ -1244,6 +1259,13 @@ when defined(windows):
 
       server.aovl.data = CompletionData(cb: continuationSocket,
                                         udata: cast[pointer](server))
+      # Registration-time capture: this explicit `accept()` call is the
+      # registration site (mutually exclusive with `start()`'s handler-
+      # driven accept loop above - see the `doAssert` at the top of this
+      # proc), so the continuation should observe whatever context is
+      # ambient right here, not whatever's ambient whenever the OS
+      # happens to complete the `AcceptEx`.
+      captureContextInto(server.aovl.data)
       server.apending = true
       let res = loop.acceptEx(SocketHandle(server.sock),
                               SocketHandle(server.asock),
@@ -1286,6 +1308,8 @@ when defined(windows):
 
       server.aovl.data = CompletionData(cb: continuationPipe,
                                         udata: cast[pointer](server))
+      # See the matching comment on the TCP branch above.
+      captureContextInto(server.aovl.data)
       server.apending = true
       let res = connectNamedPipe(HANDLE(server.sock),
                                  cast[POVERLAPPED](addr server.aovl))
@@ -1841,6 +1865,12 @@ proc start2*(server: StreamServer): Result[void, OSErrorCode] =
   doAssert(not(isNil(server.function)), "You should not start the server " &
            "unless you have processing callback configured!")
   if server.status == ServerStatus.Starting:
+    when defined(windows):
+      # Registration-time capture for the accept loop's persistent
+      # `CompletionData`, mirroring the POSIX path's capture inside
+      # `resumeAccept()`'s `addReader2` call - the registrant's context
+      # is the one bound when `start()` runs, not when the server was built.
+      captureContextInto(server.aovl.data)
     ? server.resumeAccept()
     server.status = ServerStatus.Running
   ok()

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Core concepts](./concepts.md)
 - [`async` functions](./async_procs.md)
 - [Errors and exceptions](./error_handling.md)
+- [Context variables](./contextvars.md)
 - [Threads](./threads.md)
 - [Tips, tricks and best practices](./tips.md)
 - [Porting code to `chronos`](./porting.md)

--- a/docs/src/contextvars.md
+++ b/docs/src/contextvars.md
@@ -1,0 +1,853 @@
+# Context variables
+
+Context variables provide continuation-local storage: dynamically-scoped
+values that follow a logical task through `await` suspensions, callback
+registrations and combinators, while concurrent tasks remain isolated from
+each other. They serve the same role as Python's `contextvars` module in
+`asyncio`: request IDs, authenticated users, tracing spans and similar
+"ambient" data that would otherwise have to be threaded through every
+procedure signature.
+
+<!-- toc -->
+
+## Usage
+
+```nim
+import chronos
+import chronos/contextvars
+
+type User = object
+  name: string
+
+let currentUser* {.contextVar.} = User(name: "anonymous")
+
+proc audit(action: string) =
+  # Reads the innermost binding for the current logical task,
+  # or the declared default when no binder is in scope.
+  echo currentUser.value.name, ": ", action
+
+proc handleRequest(user: User) {.async.} =
+  currentUser.withValue(user):
+    await sleepAsync(10.milliseconds)   # binding survives suspension
+    audit("query")                      # sees `user`, not the default
+```
+
+(The `{.contextVar.}` pragma needs Nim 2.x; see below. On Nim 1.6, spell
+`currentUser`'s declaration as `let currentUser* = newContextVar("currentUser", User(name: "anonymous"), private = false)`.)
+
+A context variable is a value (a `ContextVar[T]` key), not a family of
+generated identifiers. `let currentUser* {.contextVar.} = User(...)`
+declares exactly one symbol, `currentUser`, whose type is
+`ContextVar[User]`; every operation on it is a uniform, ordinary call:
+
+- `cv.value` returns the innermost binding for the current logical task, or
+  the key's default when nothing is bound (see [Required variables](#required-variables)
+  for the no-default case).
+- `ctx[cv]` performs the same read, against a captured `AsyncContext` snapshot
+  instead of the ambient chain (see [Inspecting contexts](#inspecting-contexts)).
+- `cv.withValue(v): body` binds `cv` to `v` for the dynamic extent of
+  `body`, restoring the previous binding on every exit path (normal,
+  exception, `CancelledError`).
+
+`withValue` shares a name with `std/tables`'s `Table.withValue` but not a
+meaning: `Table.withValue(key, value)` is a conditional-if-present,
+mutate-in-place accessor, while `ContextVar[T].withValue(v)` is an
+unconditional bind. The two coexist without ambiguity because Nim
+overloads dispatch on receiver type, the same ordinary verb-sharing as
+`len`/`[]` across the standard library.
+
+Bindings nest (innermost wins) and propagate into tasks spawned within the
+binder's extent. Two additional primitives, `currentContext()` and
+`withContext(ctx, body)`, snapshot and restore the full binding chain for
+synchronous-callback boundaries that don't go through `await`.
+
+## The `{.contextVar.}` pragma
+
+> **Requires Nim 2.x.** `{.contextVar.}` relies on macro pragmas attached
+> to `let`/`var` sections, a capability the Nim compiler only gained in
+> the 2.x series: the 1.6 compiler never invokes a macro attached this
+> way, so the pragma silently fails to expand there. On Nim 1.6, declare
+> keys with the raw constructors, [`newContextVar`/`newRequiredContextVar`](#the-raw-constructors),
+> directly.
+
+`{.contextVar.}` is the recommended way to declare a key: it derives both
+the key's name and its `dumpContext` privacy from the declaration site
+itself, the same way an ordinary `let`/`var`'s export marker already
+governs every other kind of visibility in the module. It attaches between
+the star and the type, the same position `{.threadvar.}` uses and for
+the same reason: the parser's own `let`/`var` grammar has to do the
+star/type/default parsing (`contextVar name*: T = default` is not
+parseable Nim), so the pragma only rewrites the right-hand side after the
+parser has already done its job.
+
+```nim
+let requestId* {.contextVar.} = ""              # T inferred; star -> exported
+let currentScope* {.contextVar.}: Scope = nil   # explicit T (polymorphic default)
+let internalCounter {.contextVar.} = 0          # no star -> private
+var traceId* {.contextVar.}: string             # must-bind: no default
+```
+
+All four forms expand to exactly one symbol (a `let`/`var` binding a
+`newContextVar`/`newRequiredContextVar` call), never a second, derived
+identifier. `x*: T {.contextVar.}` (pragma after the type) is not
+accepted; `x* {.contextVar.}: T` is the only order the grammar admits.
+
+The `let`/`var` choice above is not just convention. The macro rejects
+the wrong one at compile time: a defaulted key (has `= default`) must be
+declared `let`; a must-bind key (no default) must be declared `var`.
+`var requestId* {.contextVar.} = ""` and `let traceId* {.contextVar.}: string`
+both fail to compile, with an error naming the correct spelling, rather
+than silently accepting a keyword that doesn't match the key's arity.
+
+The star controls two things at once, both derived from the same marker:
+whether the symbol itself is exported (ordinary Nim visibility), and
+whether the key registers with `dumpContext` (star -> `private = false`,
+no star -> `private = true`; see [Privacy and the raw constructors](#privacy-and-the-raw-constructors)
+below). Explicit `[T]` is needed only when the default is a polymorphic
+literal (`nil`) or absent entirely (must-bind); `let requestId*
+{.contextVar.} = ""` and `var traceId* {.contextVar.}: string` both settle
+`T` without it.
+
+### Overriding dump-visibility
+
+The star-derived default covers the common case, but export and
+dump-visibility are two different axes, and occasionally a declaration
+needs them to disagree: an exported key whose value is still
+too sensitive for a debug dump, or an unexported key a maintainer wants
+surfaced in `dumpContext` for local debugging without changing its export
+marker. `{.contextVar: (private: true|false).}` breaks the derivation for
+that one declaration, leaving every other declaration's default
+unaffected:
+
+```nim
+let requestId* {.contextVar: (private: true).} = ""     # exported, still dump-private
+let internalCounter {.contextVar: (private: false).} = 0  # unexported, still dumped
+```
+
+The argument form composes with everything above it (explicit `[T]`,
+the must-bind `var` form, the `let`/`var` grammar enforcement); it only
+ever changes which `private` value reaches the underlying constructor
+call. Omitting the argument (plain `{.contextVar.}`) keeps the
+star-derived default; reach for the override only when a declaration's
+export marker and its intended dump-visibility need to differ.
+
+### The raw constructors
+
+The pragma is sugar over two public, documented primitives: a distinct
+name per arity, not two overloads of one name, because a bool-typed
+default would otherwise collide with the must-bind constructor's own
+`private: bool` parameter during overload resolution:
+
+```nim
+proc newContextVar*[T](name: string, default: T, private = true): ContextVar[T]
+proc newRequiredContextVar*[T](name: string, private = true): ContextVar[T]
+```
+
+Call one directly when a key's name needs to be computed, when a key
+belongs to a runtime-indexed family the pragma can't mint (one
+declaration, one symbol; see [Keys as values](#keys-as-values) below), or
+when composing another macro around key declarations. Each carries its
+name as an explicit string, rather than one the compiler infers from the
+identifier: the same DRY wart PEP 567's `ContextVar("name")` carries at
+every raw call site. `cv.name`, `cv.hasDefault`, and `cv.private` are
+read-only accessor procs over the same three values on any
+`ContextVarBase`, sugar-declared or raw-constructed alike.
+
+### Privacy and the raw constructors
+
+`{.contextVar.}` keeps a key's name and privacy in lockstep with the
+declaration's own export marker, so they can never drift apart. The raw
+constructors cannot offer that guarantee: their `private` parameter is an
+ordinary value argument, entirely decoupled from the enclosing
+`let`/`var`'s own `*`. This decoupling is deliberate, not an oversight: a
+non-exported `let` constructed with `newContextVar(..., private = false)`
+still appears in *other* modules' `dumpContext`/`$ctx` output, even though
+nothing outside its own module can read or bind it. Symmetrically,
+an exported key constructed with `private = true` is reachable but
+invisible to introspection. Neither case is a bug; both are pinned,
+negative-tested behavior.
+
+Both raw constructors' `private` **defaults to `true`**, mirroring the
+`{.contextVar.}` pragma's own no-star-means-private mapping, and fail-safe
+in the direction that matters: a key missing from a debug dump is
+discoverable (grep the constructor call, add `private = false`), while a
+sensitive value that leaked into a dump because a call site forgot the
+argument is not. Pass `private = false` explicitly to register a
+raw-constructed key for `dumpContext`, or prefer the pragma, whose star
+marker sets this automatically.
+
+## Semantics notes
+
+A key's default is fixed once, at construction:
+`newContextVar(name, default)` evaluates `default` exactly once, the way
+PEP 567's `ContextVar(name, default=...)` does, not on every unbound read.
+There is no per-read expression to keep cheap and side-effect-free,
+because there is no per-read evaluation at all.
+
+That trade introduces a hazard: for a `ref`-typed
+`T`, a non-nil default is **one shared instance**, returned by every
+unbound read across the whole process, not a fresh instance per read. Two
+unrelated call sites that both read an unbound key with a mutable `ref`
+default are handed the *same* object:
+
+```nim
+type Settings = ref object
+  flags: seq[string]
+
+let defaultSettings = Settings(flags: @[])
+let currentSettings* {.contextVar.} = defaultSettings
+
+proc corrupt() =
+  currentSettings.value.flags.add "oops"   # mutates the shared default --
+                                            # every future unbound reader
+                                            # now sees "oops" too
+```
+
+Treat a `ref`-typed default as an immutable shared singleton. If a key
+needs a fresh instance per unbound read, bind it explicitly with
+`withValue` at the point of use instead of relying on the default; a lazy
+`proc(): T` factory default is not offered: nothing in chronos needs one
+today.
+
+### Reads inside your own `{.cast(gcsafe).}` blocks
+
+`cv.value`, `cv.withValue`, and `cv.isBound` are templates, and each
+expands a narrowly-scoped `{.cast(gcsafe).}` into its caller: a key is
+typically a module-level `let` holding a `ref`, so the read is formally a
+global access, and the cast is what lets it appear in `{.gcsafe.}` code
+(sound because keys are write-once at construction; see
+[Registry and key lifetime](#registry-and-key-lifetime)).
+
+Current Nim (through 2.2.x and devel at the time of writing) mishandles
+*nested* `{.cast(gcsafe).}` blocks: when an inner cast block ends, the
+compiler's effect tracking clears the enforcement outright instead of
+restoring the enclosing block's state, so every statement *after* the
+inner block loses the outer cast's protection. This is not specific to
+chronos (two hand-written nested blocks reproduce it), but calling one
+of the templates above inside your own cast block is an easy way to
+trigger it, and the resulting "is not GC-safe" errors point at unrelated
+statements after the call. Until the compiler fix propagates, hoist the
+read above your cast block:
+
+```nim
+proc handler() {.gcsafe.} =
+  let user = currentUser.value      # read first, outside the cast
+  {.cast(gcsafe).}:
+    touchGlobalState(user)
+    runCallbacks()                  # stays covered by the outer cast
+```
+
+On a fixed compiler the hoist is unnecessary but harmless.
+
+## Required variables
+
+A key may omit its default entirely, using `newRequiredContextVar[T]`
+(or the pragma's must-bind form, `var name* {.contextVar.}: T`):
+
+```nim
+var traceId* {.contextVar.}: string    # must-bind: no default
+```
+
+This declares a *must-bind* key, the analog of PEP 567's default-less
+`ContextVar`. Reading `traceId.value` (or `ctx[traceId]`) while no
+`withValue` binder is in scope raises `UnboundContextVarDefect` on both
+paths; see [Implementation](#implementation) for why they're the same
+read under the hood. The Defect's `varName: string` field names the
+unbound key (`"traceId"` here):
+
+```nim
+proc handler() {.async: (raises: []).} =
+  # traceId.value here would raise UnboundContextVarDefect unless a
+  # caller already bound it.
+  traceId.withValue(newTraceId()):
+    await process()
+```
+
+`UnboundContextVarDefect` is a `Defect`, not a `CatchableError`. That's
+deliberate, for two reasons:
+
+- Reading a must-bind key before it's bound is a contract violation (the
+  caller forgot a `withValue` somewhere up the call chain), not a
+  recoverable runtime condition like a failed network call. `Defect` is
+  chronos's (and Nim's) vocabulary for "this is a bug," the same category
+  as an out-of-bounds index or a failed `doAssert`.
+- `Defect`s sit outside Nim's `raises` effect tracking. A must-bind read
+  can therefore happen inside an `{.async: (raises: []).}` proc (the
+  common case for handler code that doesn't want to widen its raises
+  list) without forcing every caller to declare or catch it. This
+  diverges from PEP 567, whose `ctx[var]` raises a catchable
+  `LookupError`; see [Divergences from cited precedent](#divergences-from-cited-precedent) below.
+
+Everything else about a must-bind key is identical to a defaulted one: the
+binder (`withValue`), spawn-time inheritance, propagation across `await`,
+and restore-on-every-exit-path all use the exact same code path; only the
+read's behavior on a miss differs. `dumpContext` is the one exception to
+"behaves like the read"; see [Inspecting contexts](#inspecting-contexts)
+for why introspection never raises.
+
+### Checking boundness without reading
+
+`cv in ctx` (`` `contains`(ctx: AsyncContext, cv: ContextVar[T]): bool ``)
+and its ambient counterpart `cv.isBound` answer "is this key bound here?"
+without raising and without returning a value: the non-raising complement
+to the Defect above, for callers that want to branch on boundness rather
+than catch a Defect or fall back to a default:
+
+```nim
+if traceId in currentContext():
+  logSpan(traceId.value)
+```
+
+This is identity-correct, unlike inferring boundness from `dumpContext`'s
+`bound` field: two keys can share a `name` (see [Registry and key lifetime](#registry-and-key-lifetime)),
+and `dumpContext` groups its output by that name, so it cannot distinguish
+which of two same-name keys is the one actually bound. `in`/`isBound` test
+the key itself, by identity, so they answer correctly even in that case.
+Works identically for a defaulted key: `cv in ctx` is `false` when
+unbound even though `cv.value` would still return the default.
+
+## Binding multiple variables
+
+There is no combined "bind several at once" form; binding multiple keys
+together is ordinary nested `withValue` blocks, one per key:
+
+```nim
+let currentUser* {.contextVar.} = User(name: "anonymous")
+let requestId* {.contextVar.} = ""
+
+proc handleRequest(user: User, reqId: string) {.async.} =
+  currentUser.withValue(user):
+    requestId.withValue(reqId):
+      await sleepAsync(10.milliseconds)
+      audit("query")   # sees both currentUser.value and requestId.value
+```
+
+Each `withValue` layer adds one `try`/`finally` frame, so the cost scales
+with the number of keys bound at a given point, not with the number of
+keys declared in scope elsewhere. Independent keys don't interact with
+each other, so the nesting order between them is arbitrary: binding
+`requestId` inside `currentUser` or the other way around produces the same
+observable bindings either way.
+
+## Spawn-time inheritance
+
+A task spawned inside a binder (calling an `async` proc, `asyncSpawn`, or
+registering a callback) inherits the spawner's binding chain as it existed
+at the point of spawning. Because the chain is immutable, later re-binding
+in the parent is invisible to the already-spawned child and vice versa:
+a child's nested binding never leaks back to the parent.
+
+Chain nodes own their bound value inline, so a `currentContext()` snapshot
+(or a pending callback's captured chain) remains sound after the binder
+that created it has exited.
+
+## Keys as values
+
+A `ContextVar[T]` is an ordinary value: it can be passed as a generic proc
+parameter, stored in a `seq`/`array`, or used as a `Table` key. A generic
+proc over the key itself, not just over its value type, works for free:
+
+```nim
+proc readOrDefault[T](cv: ContextVar[T]): T =
+  cv.value      # `cv` is a runtime value here -- ordinary generic
+                # dispatch, no macro expansion involved
+```
+
+chronos's own benchmark suite uses a runtime-indexed *array* of keys to
+build a chain-depth ladder that a one-declaration-one-symbol pragma
+cannot mint (`benchmarks/bench_contextvars.nim`):
+
+```nim
+var chainVars: array[16, ContextVar[int]]
+for i in 0 ..< chainVars.len:
+  chainVars[i] = newContextVar[int]("chain" & $(i + 1), 0)
+
+# chainVars[i] is a value like any other -- index it, pass it, store it:
+chainVars[3].withValue(1):
+  discard chainVars[3].value
+```
+
+Two keys constructed with identical arguments (same name, same type,
+same default) are still distinct: ref identity is key identity (see
+[Implementation](#implementation)). `chainVars[0] != chainVars[1]` even
+where their names happen to collide, and binding one is never observable
+through the other.
+
+## Bridging independent callbacks
+
+`withValue` binds for the dynamic extent of one body inside one logical
+task. A resource's independently-registered setup and teardown hooks (an
+`onConnect` and a separate `onDisconnect`) are not that shape: two
+independently-scheduled callbacks with no `await` or shared call stack
+between them are, by construction, not a single logical task, and no
+binder can span them. The dispatcher restores the context it captured at
+scheduling time around *every* callback invocation (`fireWithContext` in
+`chronos/internal/asyncengine.nim`), so nothing one callback binds
+survives into a second, separately-scheduled callback: the next callback
+observes whatever context it captured at its own registration.
+
+An exit hook that never captured a snapshot runs under whatever
+context was ambient at its own registration (typically empty), never
+under another task's binding.
+
+For that shape, use `currentContext()`/`withContext()` to capture a
+snapshot in the enter hook and restore it in the exit hook:
+
+```nim
+var connContexts: Table[Connection, AsyncContext]
+
+proc onConnect(conn: Connection) =
+  currentUser.withValue(conn.authedUser):
+    connContexts[conn] = currentContext()   # snapshot, not a push
+
+proc onDisconnect(conn: Connection) =
+  withContext(connContexts[conn]):
+    audit("session ended")   # sees currentUser.value == conn.authedUser
+  connContexts.del(conn)
+```
+
+`currentContext()` captures the whole binding chain as an immutable
+snapshot that outlives the binder that created it; `withContext` runs code
+under that snapshot without disturbing the caller's own chain on exit.
+Because a snapshot is a value, not a chain mutation, the same snapshot can
+be used from `withContext` any number of times, including from multiple
+callbacks interleaved on the same dispatcher.
+
+`AsyncContext` values are thread-affine: the chain they reference is
+thread-local, garbage-collected memory (see [Migration and compatibility](#migration-and-compatibility)
+on cross-thread scheduling), so a snapshot captured on one thread must not
+be sent to or restored on another: "any number of times" means any
+number of callbacks on the capturing thread.
+
+chronos has no imperative token API (PEP 567's `ContextVar.set()`/
+`Token.reset()` shape): within a single logical task, `withValue`
+expresses every binding lifecycle, and across independent callbacks a
+token could not work anyway: the dispatcher's restore-at-fire discipline
+described above unwinds any push a callback leaves behind.
+`tests/testcontextvarssurface.nim` pins the absence of a token API as a
+compile-time check.
+
+## Inspecting contexts
+
+A default-initialized `AsyncContext` (`var ctx: AsyncContext`, never
+assigned from `currentContext()`) is the *empty* context, the same one
+every task starts with before any key is ever bound. Running under it via
+`withContext` installs no bindings at all: a defaulted key reads its own
+default, exactly as if no binder were ever entered, and a must-bind key
+raises `UnboundContextVarDefect`, same as an unbound ambient read.
+
+Three primitives exist purely for debugging and don't participate in the
+hot paths at all: they cost nothing unless a program actually calls them.
+
+### Identity
+
+Two `AsyncContext` snapshots compare equal with `==` iff they reference
+the same underlying chain head:
+
+```nim
+let a = currentContext()
+let b = currentContext()
+a == b            # true: no binding changed between the two captures
+
+currentUser.withValue(someUser):
+  let c = currentContext()
+  a == c          # false: `c` was captured inside a new binder
+```
+
+This is identity equality (same chain-head pointer), not a value-by-value
+comparison of bindings: two snapshots built independently that happen to
+carry the same bindings are not `==`. `hash*(ctx: AsyncContext): Hash`
+matches the same identity (a pointer-identity hash), so `AsyncContext`
+works as a `Table`/`HashSet` key.
+
+### `dumpContext`
+
+`dumpContext(ctx: AsyncContext): seq[ContextVarEntry]` enumerates every
+*registered* (non-private) key constructed anywhere in the program
+(across every module, defaulted or must-bind) as it stands in `ctx`,
+sorted by name:
+
+```nim
+type ContextVarEntry* = object
+  name*: string
+  bound*: bool
+  value*: string
+```
+
+A private key (no star, or raw-constructed with `private = true`) never
+appears here. See [The `{.contextVar.}` pragma](#the-contextvar-pragma)
+for how the star maps to this filter, [Registry and key lifetime](#registry-and-key-lifetime)
+for why a private key still registers, and
+[Privacy and the raw constructors](#privacy-and-the-raw-constructors) for
+the raw constructors' export-decoupling caveat.
+
+Every registered key appears exactly once, bound or not, so a dump shows
+everything that *could* be bound: the picture a debugger or log dump
+actually wants. An unbound defaulted key shows `bound: false` and the
+value its read would actually return (the rendered default); an unbound
+must-bind key shows `bound: false` and a fixed `<unbound>` placeholder.
+Calling `dumpContext` never raises `UnboundContextVarDefect` the way the
+key's own read would, because introspection has to stay total to be
+useful as a debugging tool. A value is rendered via `$` when the key's
+type has one (checked with `when compiles`); otherwise it's shown as a
+placeholder. A `ref`-typed key whose value is nil renders as the literal
+string `"nil"` without calling `$` at all: `when compiles($v)` only
+proves a matching overload exists, not that it tolerates a nil receiver,
+and `dumpContext` walks every registered key including ones no caller has
+bound yet.
+
+`` `$`(ctx: AsyncContext): string `` renders the same information as a
+single `{name: value, ...}` string, in the same sorted order, for quick
+`echo`/logging use. Its format is not a stable, parseable contract: only
+`dumpContext`'s structured `seq[ContextVarEntry]` is.
+
+### Cost
+
+All three are zero-cost in the sense that matters for this feature:
+nothing on the read, bind, capture, or fire hot paths changed to support
+them. `==` is one pointer comparison. `dumpContext` costs one walk of the
+process-wide registry (see [Registry and key lifetime](#registry-and-key-lifetime))
+plus one `$`-render per key, paid only when `dumpContext` is actually
+called.
+
+The no-lock argument behind that walk (see [Registry and key lifetime](#registry-and-key-lifetime))
+assumes a static single-binary deployment, where every key is constructed
+on the main thread before any other thread exists. It does not hold
+across `dlopen`/shared-library boundaries: a library loaded after other
+threads already exist can construct keys concurrently with readers on
+those other threads, and unloading it leaves dangling registry entries.
+Neither shape is a chronos use case today, but embedding chronos in a
+plugin/shared-library host would need to revisit this registry's
+construction discipline.
+
+## Migration and compatibility
+
+- On Nim 1.6, `{.contextVar.}` is unavailable (see [The `{.contextVar.}`
+  pragma](#the-contextvar-pragma)); use the raw constructors there.
+- The feature is additive: code that never constructs a `ContextVar` pays
+  one pointer field per `AsyncCallback` and a pointer copy per capture.
+- Cross-thread scheduling (`callSoon` on another thread's dispatcher via
+  `DispatcherHandle`) fires the callback with an *empty* context: the
+  origin thread's chain is thread-local, garbage-collected memory and
+  cannot be shared. Same-thread scheduling through the same API captures
+  normally.
+- **Windows IOCP completions carry the registrant's context**, the same
+  registration-time-capture contract as the epoll/kqueue paths: a
+  completion fires with the context captured when its `OVERLAPPED` record
+  was armed, not the context ambient when it fires. See
+  [Capture discipline](#capture-discipline) for which sites capture and
+  how the fallback behaves.
+
+## Divergences from cited precedent
+
+The uniform `.value`/`ctx[cv]`/`.withValue` vocabulary follows the shape
+every mature ecosystem converged on: Python PEP 567 (`var.get()`,
+`ctx[var]`), Kotlin (`coroutineContext[Key]`), Java JEP 446 ScopedValue
+(`sv.get()`, `ScopedValue.where(sv, v).run(...)`), .NET `AsyncLocal`
+(`v.Value`). None of them mint derived identifiers per variable: that's
+the design principle this API borrows. Where chronos's design diverges
+from those precedents:
+
+- **PEP 567**: an unbound read there raises a catchable `LookupError`;
+  here it raises `UnboundContextVarDefect`, a `Defect` (see
+  [Required variables](#required-variables) for the raises-tracking
+  rationale, a Nim-specific constraint Python has no analog of). Python's
+  `Context.run(fn)` value-isolated execution is also not offered;
+  `withContext`'s mutate-and-restore covers chronos's callback-boundary
+  cases (see [Bridging independent callbacks](#bridging-independent-callbacks)).
+- **Kotlin** couples a key and its value type through a companion object
+  declared on the value type. chronos keeps independent factories
+  (`newContextVar[T]`/`newRequiredContextVar[T]`) instead: Nim has no
+  companion-object idiom, and the coupling wouldn't buy anything here.
+- **JEP 446** forbids rebinding a `ScopedValue` within the same dynamic
+  scope. chronos keeps arbitrary LIFO re-shadowing: `cv.withValue` nests
+  freely, and the innermost binding always wins.
+- **.NET** `AsyncLocal.Value` is an imperative setter with forward flow
+  (`asyncLocal.Value = x` mutates ambient state going forward). Only its
+  read spelling is cited here; the imperative-write model itself was
+  rejected; see [Bridging independent callbacks](#bridging-independent-callbacks)
+  above.
+
+## Performance
+
+The design goal is cost proportional to use: a program that never
+constructs a `ContextVar` should pay a cost indistinguishable, on every
+hot path, from a build without the feature at all. This is measured, not
+assumed: every number below comes from `benchmarks/bench_contextvars.nim`,
+run under both memory managers.
+
+**refc** (chronos's most latency-sensitive consumers pin `--mm:refc`
+unconditionally) and **orc** both show the dispatcher-level headline
+metrics (`callSoon` schedule+fire, sleepAsync await chains, future
+create/await, and the two memory metrics) landing within the same
+run-to-run measurement noise as a pre-contextvars build, on both memory
+managers; these come from the capture/restore substrate, which this
+redesign left untouched.
+
+Where the redesign *does* change measured cost is the per-node lookup
+inside a bound chain walk. An RTTI-based per-node dispatch (an `of` test
+against a distinct per-declaration subtype) was evaluated and rejected in
+favor of the raw pointer compare used today; the difference is clearest
+reading a key bound at chain depth 16 (the benchmark's worst case: the
+read walks every intervening binding) under refc:
+
+| metric (median, 4 runs/leg)                                  | result |
+|----------------------------------------------------------------|--------|
+| refc, chain read @ depth 16, `of` dispatch -> pointer dispatch | 44-57 ns -> 8-10 ns (~5-6x) |
+| orc, chain read, all depths                                    | overlapping old/new ranges -- noise-neutral |
+| `callSoon` / sleep-chain / future-churn, both MMs               | comparable to the prior design -- within measurement noise |
+| memory (pending future, queued callback), both MMs             | byte-identical |
+
+Per-call-class cost, confirmed by inspecting the generated C at each site
+rather than inferred from throughput alone, and unaffected by this
+redesign (substrate-level):
+
+- leaf callback fire: one thread-local load + one predicted branch.
+- continuation resume: the above plus one unconditional save/restore
+  pair, required for correctness; a suspended continuation must not
+  leak a stale binding into whatever fires next.
+- user-callback construction: one thread-local load + one predicted
+  branch; barrier-free on refc, and on orc the context copy is skipped
+  entirely when no binder is live.
+- registering a callback on a heap-allocated future (e.g. a cancel
+  callback): one write-barrier call per `ref` field under refc, paid
+  once, at the point ownership transfers into the heap field.
+
+Struct cost: `sizeof(AsyncCallback)` grows by one pointer field (8 B);
+a pending future's two embedded callbacks add 16 B combined.
+
+A related, separately-motivated fix ships alongside this feature: the
+dispatcher's internal callback queues previously used `std/deques`,
+whose `popFirst` returns its element by value: a pre-existing cost
+(present before contextvars, on the queue's original single `ref`
+field) that contextvars' second `ref` field doubled. The dispatcher
+now uses a small purpose-built queue (`chronos/internal/callbackqueue.nim`)
+whose dequeue is barrier-free on the copy-out; this restores
+queue-transport cost per hop to parity with what the pre-contextvars
+codebase already paid on its one field.
+
+## Internals
+
+The rest of this document describes the implementation for chronos
+contributors extending the context-variable substrate itself; application
+code using the API above does not need it.
+
+### Implementation
+
+A key (`ContextVar[T]`) is a `ref object` inheriting a non-generic
+`ContextVarBase`, which carries the name, the `dumpContext` render hook,
+and the registry link. Ref identity IS key identity: `ContextVar[T]`
+defines no custom `` `==` `` (Nim's builtin ref `==` is already identity
+comparison), and `hash*(cv: ContextVarBase): Hash` is a pointer-identity
+hash paired with that same `==`, never a custom, value-based one, so
+two keys compare and hash equal only when they're the same allocation:
+`let alias = someKey` compares equal to `someKey` (the intended re-export
+pattern), while two keys built from identical constructor arguments are
+distinct (see [Keys as values](#keys-as-values)). This identity hash is
+what makes `ContextVar[T]` usable as a genuine `Table`/`HashSet` key, not
+just a value stored under some other key. A value-`object` key was
+rejected for the same reason as the `==`/`hash` pairing: a copy would get
+its own address and silently stop being "the same key."
+
+A context is an immutable, singly-linked chain of nodes, one per active
+binding, each carrying the key it was bound under alongside the bound
+value. A chain node needs to expose its key *without* knowing the node's
+value type (the lookup walk visits every node on a chain regardless of
+which `T` each one carries), so the key field lives one layer below the
+generic `ContextNode[T]`, on a non-generic `ContextNodeKeyed` base
+inserted between it and the chain's own `ContextNodeBase`. `withValue` is
+the only code that ever builds a `ContextNode[T]`, and it always tags the
+node with the very `ContextVar[T]` whose `T` matches the node's own type
+parameter. So a node's real type is never in question once its key is
+known, and the lookup walk's cast from `ContextNodeKeyed` to
+`ContextNode[T]` is sound by that construction invariant, not by a runtime
+type tag.
+
+That invariant holds because every node reachable through an
+`AsyncContext` was built by `withValue`, and `AsyncContext` itself can't
+be fabricated from an arbitrary `ContextNodeBase`. `AsyncContext* =
+object` wraps its chain head in a field private to this module: the only
+route to a populated value in safe Nim is `currentContext()`'s own
+capture, so no safe construction (not even from code that imports
+`chronos/internal/contextnode` directly) can hand `withContext` a
+snapshot whose chain wasn't built the normal way. This guarantee covers
+every safe-Nim construction route; `cast[AsyncContext](node)` bypasses it
+the same way a `cast` bypasses any Nim type's invariants.
+
+The key field itself is stored as a raw `pointer` (`cast[pointer](cv)`)
+rather than a traced `ContextVarBase` reference: `withValue` can run on
+any thread once a key exists, and under `--mm:refc` the GC heap is
+per-thread bookkeeping, so a traced ref field pointing at a key allocated
+on a different thread increfs through the wrong thread's heap the moment
+a second thread binds that key, reproducibly crashing under
+`-d:useGcAssert`. A raw pointer sidesteps reference counting on every
+memory manager, the same approach the prior registry design used for its
+own `ptr` field. It is sound because node keys are only ever *compared*,
+never dereferenced (`dumpContext` renders through the registry's own live
+refs, not through the chain), and because keys are process-lifetime by
+construction discipline (see [Registry and key lifetime](#registry-and-key-lifetime)
+below).
+
+Lookup (`` `[]`(AsyncContext, ContextVar[T]): T ``, the one real chain
+walk) compares `node.key == cast[pointer](cv)` while walking (one
+pointer comparison per node) and, on a match, reads the value out via
+`cast[ContextNode[T]](node)`. `.value` is not a second read path: it's
+`template value(cv) = currentContext()[cv]`, so the ambient spelling and
+the snapshot spelling (`ctx[cv]`) are two spellings of this one walk.
+Under a `chronosDebug` build, the cast is preceded by `doAssert node of
+ContextNode[T]`, a checked downcast verifying the construction invariant
+above, the same debug-only discipline `chainBalance` and the construction
+lock below already use elsewhere in this module; release builds pay
+nothing for it.
+
+### Registry and key lifetime
+
+Every key, private or not, links itself into a process-wide intrusive
+list at construction, via a private `nextRegistered: ContextVarBase`
+field threaded through `ContextVarBase` itself, so the registry costs no
+separate allocation. Registration keeps a key alive for the life of the
+process: a permanent, by-design leak, matching what a purely static,
+module-level-global design would have gotten for free. This applies to
+private keys too: a chain node's `key` field is an untraced raw pointer
+(see [Implementation](#implementation) above), so an unregistered key
+would have no other process-lifetime guarantee, and a chain node built
+from a since-collected private key would dangle: a later key reusing the
+freed address would then compare pointer-equal to the stale `node.key`
+and read back the wrong value. `private` governs only `dumpContext`'s
+enumeration filter, never a key's lifetime.
+
+`newContextVar`/`newRequiredContextVar` are supported only *before* any
+`createThread` call, the same write-once-then-read-only discipline the
+registry already needs, enforced two ways.
+
+The first is automatic, needs no setup, and runs in every build,
+including a release build: on a key's first registration, chronos stamps
+the constructing thread with a process-lifetime generation counter (not
+`getThreadId()`, whose OS-level ids are recycled once a thread exits, and
+so cannot tell a returning thread from an unrelated later one reusing its
+id) and records that generation; every later registration doAsserts it
+is running on the same thread, before either constructor's registry
+mutation ever runs, so a violation leaves the registry exactly as it was.
+A second thread constructing a key corrupts the GC heap under `--mm:refc`,
+since a chain node's `key` field is an untraced raw pointer into whichever
+thread built its key (see [Implementation](#implementation) above), and
+this check fires the moment that hazard actually occurs: unconditionally,
+because the hazard it prevents is not itself limited to debug builds, and
+the construction path it runs on is cold.
+
+Neither check makes a first construction on a thread that then exits
+safe (the registry is left holding a reference into a dead thread's
+heap), and while the guard keeps refusing every other thread's
+construction from that point on, nothing makes the process itself sound
+again.
+
+The second is `lockContextVarConstruction()`, a stricter, `chronosDebug`-
+only opt-in boundary: chronos does not wrap or intercept thread creation,
+so nothing flips this lock automatically. Call it yourself at your
+program's own construction/thread-creation boundary (the test suite is
+its only caller today), and every `newContextVar`/`newRequiredContextVar`
+call after that point asserts, on any thread, not just a different one
+from the first. Neither check is a substitute for the other: the
+automatic check catches the cross-thread case with no setup but tolerates
+further same-thread construction after other threads already exist, while
+the lock catches that too, but only once an application opts in. No lock
+is paid on any path in a release build, and the lock itself runs only
+under `chronosDebug`.
+
+Applications are encouraged to call `lockContextVarConstruction()` at
+their own thread-creation boundary in `chronosDebug` builds and in CI,
+rather than relying on the automatic check alone: a construction-
+discipline violation is far cheaper to catch there than to chase down as
+an intermittent failure in production.
+
+Duplicate name strings are representable (two independently-constructed
+keys can share a `name`, matching PEP 567) and accepted as
+cosmetic-only: `dumpContext` may show two entries with the same label, and
+`UnboundContextVarDefect.varName` may be non-unique, but same-name keys
+never alias: binding one is never observable through the other,
+regardless of whether they share a name.
+
+The render hook (feeding `dumpContext`/`` `$` ``) is instantiated once per
+`T`, inside whichever raw constructor built the key, and stored on
+`ContextVarBase` as a `{.nimcall.}` pointer, the same `when T is ref`
+nil-guard and `when compiles($v)` fallback ladder as before, generic code
+degraded to a plain proc pointer so a non-generic base field can hold it.
+
+### Capture discipline
+
+The obligation this section places on every scheduling-site author: a
+context-blind trampoline (`bareCallback`) is sound only when everything
+it fires either captured its own context at registration or is itself
+context-neutral. `bareCallback` doesn't check this: it just fires with
+an empty context, so a bare trampoline that starts firing
+context-sensitive code without one of the other two constructors upstream
+reintroduces a leak silently.
+
+Every `AsyncCallback` construction site must pick one of three
+constructors defined in `chronos/futures.nim`:
+
+- `capturingCallback(fn, udata)`: for every scheduling site whose callback
+  must observe registration-time bindings (`addCallback`, `callSoon`,
+  `setTimer`, `addReader`/`addWriter`, `addSignal`/`addProcess`, `callIdle`,
+  `closeSocket`/`closeHandle` after-callbacks), whether the callback is
+  application code or chronos-internal. Captures the current context.
+- `bareCallback(fn, udata)`: for chronos-internal trampolines (sentinels,
+  cross-thread queue draining, the low-level per-operation IOCP
+  read/write completion trampolines, `internalCallTick`'s `CallbackFunc`
+  overloads) where no meaningful registration-time context exists: those
+  trampolines only drive an internal future to completion, and that
+  future's own awaiter already carries its own captured context. Fires
+  with an empty context.
+- `contextCallback(fn, udata, ctx)`: for reconstructing a callback from
+  a context value captured *earlier* rather than the ambient one at the
+  call site. Windows IOCP completion dispatch (`poll()` in
+  `asyncengine.nim`) is the only caller: it fires every completion with
+  whatever `CompletionData.context` an upstream arm site
+  (`registerWaitable`, a stream server's `start()`) stored via
+  `captureContextInto`, or an empty context if the arm site didn't opt
+  in, the same fail-closed default as `bareCallback`. A stream server's
+  accept loop captures its context once, at `start()`, and reuses it for
+  every connection the server accepts, so a caller that binds a large
+  value around `start()` pins it for the server's entire lifetime, not
+  just for one call.
+
+`internalCallTick` also has an `AsyncCallback`-taking overload
+(`internalCallTick(acb: AsyncCallback)`) that schedules whatever
+`AsyncCallback` the caller already built: the caller picks the
+constructor when building that value. Only the convenience `CallbackFunc`
+overloads (`internalCallTick(cbproc, data)`) default to `bareCallback` and
+are therefore context-blind by design.
+
+Only `capturingCallback`/`bareCallback`/`contextCallback` can construct an
+`InternalAsyncCallback`: `function`/`udata`/`context` are private to
+`chronos/futures.nim`, and no other module can read or modify a field
+after construction (existing readers go through the exported
+`function()`/`udata()`/`context()` getters). A raw
+`AsyncCallback(function: ..., udata: ...)` literal, or a direct field
+assignment, anywhere outside `chronos/futures.nim` fails to compile:
+`tests/testcontextvarsguardrails.nim` pins this with `not compiles(...)`
+checks.
+
+Which constructor a given scheduling site calls is not something the type
+system can check: the three share a shape, so picking the wrong one
+compiles fine. `tests/testcontextvarssurface.nim` and
+`tests/testcontextvarsguardrails.nim` enumerate every known
+construction/capture site and pin its expected behavior; extending the
+pins is part of adding a scheduling site.
+
+### Tests
+
+Tests live under `tests/testcontextvars*.nim`: construction and the
+registry, ambient and `withValue` semantics, async propagation across the
+dispatcher's scheduling sites, cross-module export rules, and the
+compile-time and runtime drift guardrails above. Four of them (the
+leak-guard, cross-thread-construction, dead-recording-thread, and
+construction-lock suites) run from a standalone driver
+(`tests/testcontextvarsstandalone.nim`) instead of `tests/testall.nim`:
+the construction lock is a one-way switch that stays engaged for the
+rest of the process once set, the leak-guard test deliberately lets a
+Defect escape `poll` to prove the corruption check fires, and the
+dead-recording-thread suite needs a process where no key has been
+constructed yet to exercise its full scenario, so none of them can
+safely share a process with a suite that constructs keys at runtime:
+the driver runs each suite in its own subprocess.

--- a/tests/contextvarsexportfixture.nim
+++ b/tests/contextvarsexportfixture.nim
@@ -1,0 +1,34 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Cross-module fixture for `testcontextvarsexport.nim`. Declares one
+## starred (exported) and one non-starred (module-private) key via the
+## `{.contextVar.}` pragma, plus one raw-constructed key that is itself
+## unexported but dump-visible (`private = false`, passed explicitly
+## against the raw constructor's own `private = true` default) — the
+## export-decoupling case documented in docs/src/contextvars.md,
+## "Privacy and the raw constructor".
+
+import ../chronos/contextvars
+
+when (NimMajor, NimMinor) >= (2, 0):
+  # `{.contextVar.}` is 2.x-only — macro pragmas on `let`/`var` sections
+  # don't exist in the 1.6 compiler — so the export-marker-derived pair
+  # below, and every test in testcontextvarsexport.nim that names them,
+  # are gated the same way.
+  let exportedVar* {.contextVar.} = 1
+  let privateVar {.contextVar.} = 2
+
+let rawUnexportedRegistered = newContextVar("rawUnexportedRegistered", 3,
+                                             private = false)
+  ## No `*`: unreachable by name from an importing module. Still
+  ## dump-visible (`private = false`, passed explicitly here — the
+  ## constructor itself now defaults to `private = true`), so it
+  ## surfaces in another module's `dumpContext` regardless — the raw
+  ## constructor's `private` param is decoupled from Nim's own export
+  ## marker, unlike the pragma above.

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -16,9 +16,22 @@ import
     testasyncsemaphore, testmpsc, testcallbackqueue,
   ]
 
+import
+  ./[testcontextvarsasync, testcontextvarsguardrails,
+     testcontextvarssurface, testcontextvarsexport, testcontextvars]
+  # Import order among these five is not load-bearing: the one-way
+  # chronosDebug construction lock lives in its own file
+  # (tests/testcontextvarslock.nim, its own step in chronos.nimble's
+  # test task), never imported here.
+
 when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):
   # `poll` engine do not support signals and processes
   import ./[testsignal, testproc]
 
   # Must be imported last to check for Pending futures
   import testutils
+
+# Unconditional (unlike testutils above, which the `poll` engine never
+# imports): the contextvars binder-balance check must run on every
+# engine, so it lives in its own file, imported last.
+import testcontextvarsbalance

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -13,7 +13,7 @@ import
     testmacro, testsync, testsoon, testtime, testfut, testaddress, testdatagram,
     teststream, testserver, testbugs, testnet, testasyncstream, testhttpserver,
     testshttpserver, testhttpclient, testratelimit, testfutures, testthreadsync,
-    testasyncsemaphore, testmpsc,
+    testasyncsemaphore, testmpsc, testcallbackqueue,
   ]
 
 when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):

--- a/tests/testcallbackqueue.nim
+++ b/tests/testcallbackqueue.nim
@@ -1,0 +1,255 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Tests for `chronos/internal/callbackqueue.nim`'s `CallbackQueue[T]`,
+## independent of the contextvars suite: growth mid-drain (including
+## while a callback reentrantly schedules more work), ordering,
+## integrity across a Defect unwind, and ref-field preservation under
+## repeated growth.
+
+import unittest2
+import ../chronos/internal/callbackqueue
+
+{.used.}
+
+type
+  TestPayload = ref object
+    value: int
+
+  TestItem = object
+    tag: int
+    payload: TestPayload
+
+proc newItem(tag: int): TestItem =
+  TestItem(tag: tag, payload: TestPayload(value: tag))
+
+proc drain(q: var CallbackQueue[TestItem]): seq[int] =
+  ## Pop everything currently in `q` (a plain len-snapshot drain, no
+  ## sentinel), in FIFO order, returning the popped tags.
+  let n = q.len
+  for _ in 0 ..< n:
+    let item = q.popFirst()
+    result.add(item.tag)
+
+suite "CallbackQueue: basic semantics":
+  test "zero-value queue is valid and empty":
+    # Zero value must be usable without an `initCallbackQueue` call --
+    # asyncengine.nim's `ticks` field relies on this.
+    var q: CallbackQueue[TestItem]
+    check q.len == 0
+
+    # First addLast on a never-initialized queue must lazily grow from
+    # capacity zero rather than fault.
+    q.addLast(newItem(1))
+    check q.len == 1
+    check q.popFirst().tag == 1
+    check q.len == 0
+
+  test "FIFO order, single push/pop":
+    var q = initCallbackQueue[TestItem]()
+    q.addLast(newItem(1))
+    q.addLast(newItem(2))
+    q.addLast(newItem(3))
+    check q.len == 3
+    check q.popFirst().tag == 1
+    check q.popFirst().tag == 2
+    check q.popFirst().tag == 3
+    check q.len == 0
+
+  test "initCallbackQueue rounds capacity up to a power of two":
+    # No public `cap` accessor, so this exercises the rounding
+    # indirectly: a non-power-of-two initial capacity must still accept
+    # at least that many items without growing prematurely.
+    var q = initCallbackQueue[TestItem](5)
+    for i in 0 ..< 5:
+      q.addLast(newItem(i))
+    check q.len == 5
+    for i in 0 ..< 5:
+      check q.popFirst().tag == i
+
+  test "prependNoGrow ordering: sentinel re-insertion at the front":
+    # Mirrors the sole real caller: asyncengine.nim's poll() re-inserts
+    # a sentinel at the front of an already-fully-drained batch.
+    var q = initCallbackQueue[TestItem]()
+    q.addLast(newItem(10))
+    discard q.popFirst() # drain to empty, as the real caller always does
+    check q.len == 0
+
+    q.prependNoGrow(newItem(999))
+    q.addLast(newItem(1))
+    q.addLast(newItem(2))
+    check q.len == 3
+    check q.popFirst().tag == 999
+    check q.popFirst().tag == 1
+    check q.popFirst().tag == 2
+
+  test "sentinel field fidelity through moves (full-struct value, not identity)":
+    # The sentinel is compared by full-struct value (see `isSentinel` in
+    # asyncengine.nim); its `ref` field (`context`, mirrored here by
+    # `payload`) must survive as the same ref, not a copy, across
+    # addLast/popFirst and a growth relocation.
+    var q = initCallbackQueue[TestItem](2)
+    let sentinel = newItem(-1)
+    let sentinelPayloadAddr = cast[int](sentinel.payload)
+
+    q.addLast(sentinel)
+    # Force growth while the sentinel is still queued.
+    q.addLast(newItem(1))
+    q.addLast(newItem(2))
+    q.addLast(newItem(3))
+
+    let popped = q.popFirst()
+    check popped.tag == -1
+    check popped == sentinel
+    check cast[int](popped.payload) == sentinelPayloadAddr
+    check popped.payload.value == -1
+
+    discard drain(q)
+
+suite "CallbackQueue: growth":
+  test "growth preserves order, non-wrapped region":
+    var q = initCallbackQueue[TestItem](2)
+    const count = 50
+    for i in 0 ..< count:
+      q.addLast(newItem(i))
+    check q.len == count
+    for i in 0 ..< count:
+      check q.popFirst().tag == i
+    check q.len == 0
+
+  test "wrapped-region growth: live region spans the physical end of the buffer":
+    # Advances head/tail past the wrap boundary before growing, so
+    # grow() must relocate a live region physically split across the end
+    # and start of the backing array (two copyMem segments), not a
+    # contiguous one.
+    var q = initCallbackQueue[TestItem](4)
+    for i in 0 ..< 4:
+      q.addLast(newItem(i))
+    for i in 0 ..< 3:
+      check q.popFirst().tag == i
+    check q.len == 1
+
+    for i in 4 ..< 8:
+      q.addLast(newItem(i))
+    check q.len == 5 # item 3 (never popped) + items 4..7, post-grow
+
+    q.addLast(newItem(8))
+    check q.len == 6
+
+    let popped = drain(q)
+    check popped == @[3, 4, 5, 6, 7, 8]
+
+  test "repeated growth cycles preserve ref-field values under memory pressure":
+    # grow()'s zeroMem calls prevent a stale ref left in the old backing
+    # array from being decref'd a second time when that array's
+    # destructor runs. Repeated growth cycles interleaved with unrelated
+    # heap allocations increase the odds of surfacing a missing zeroMem
+    # as observable corruption rather than it sitting inert.
+    var q = initCallbackQueue[TestItem](2)
+    var expected: seq[int]
+    var popped: seq[int]
+    for cycle in 0 ..< 200:
+      # Push enough to force growth most cycles; pop most back off but
+      # leave a couple alive so grow() relocates a live, ref-bearing
+      # region every time.
+      for i in 0 ..< 6:
+        let tag = cycle * 10 + i
+        q.addLast(newItem(tag))
+        expected.add tag
+      for i in 0 ..< 4:
+        let item = q.popFirst()
+        popped.add item.tag
+        check item.payload.value == item.tag
+      # Unrelated heap noise encourages the allocator to reuse whatever
+      # grow() just freed.
+      discard newSeq[int](64)
+      discard newString(64)
+
+    while q.len > 0:
+      let item = q.popFirst()
+      popped.add item.tag
+      check item.payload.value == item.tag
+
+    check popped == expected
+
+  test "growth during reentrant drain across capacity boundaries":
+    # Mirrors asyncengine.nim's drain protocol: a callback fires (head
+    # already advanced) and reentrantly schedules more work onto the
+    # same queue, driving q.len past capacity while head is mid-buffer
+    # rather than fresh.
+    var q = initCallbackQueue[TestItem](4)
+    q.addLast(newItem(0))
+
+    var processed: seq[int]
+    var nextTag = 1
+    var scheduled = 1 # item 0, already scheduled above
+    const totalToSchedule = 25
+
+    while q.len > 0:
+      let item = q.popFirst()
+      processed.add(item.tag)
+      for _ in 0 ..< 2:
+        if scheduled < totalToSchedule:
+          q.addLast(newItem(nextTag))
+          inc nextTag
+          inc scheduled
+
+    check processed.len == totalToSchedule
+    for i, tag in processed:
+      check tag == i
+    check q.len == 0
+
+suite "CallbackQueue: integrity under unwind":
+  test "post-Defect-unwind queue integrity":
+    # popFirst advances head and clears the vacated slot before handing
+    # the value to the caller, so a callback that raises must not
+    # corrupt the queue for subsequent drains. The try wraps the whole
+    # drain loop (not one iteration) to reproduce an unwind out of the
+    # loop, mirroring a Defect surfacing from the real poll().
+    var q = initCallbackQueue[TestItem](4)
+    for i in 0 ..< 6:
+      q.addLast(newItem(i))
+
+    var processed: seq[int]
+    var raised = false
+    try:
+      while q.len > 0:
+        let item = q.popFirst()
+        if item.tag == 3:
+          raise (ref ValueError)(msg: "simulated callback failure")
+        processed.add(item.tag)
+    except ValueError:
+      raised = true
+
+    check raised
+    check processed == @[0, 1, 2]
+    # Item 3 was popped (head already advanced past it before the raise)
+    # but never reached `processed` -- consumed and discarded, not
+    # corrupting the queue.
+    check q.len == 2 # items 4, 5 remain, unprocessed
+
+    # Queue must remain usable after the unwind.
+    check q.popFirst().tag == 4
+    check q.popFirst().tag == 5
+    check q.len == 0
+    q.addLast(newItem(100))
+    check q.popFirst().tag == 100
+
+suite "CallbackQueue: raw-access guardrail":
+  test "private fields do not compile from outside the module":
+    # `data`/`head`/`tail` are private; every touch must go through the
+    # five public entry points.
+    check(not compiles(block:
+      var q: CallbackQueue[TestItem]
+      discard q.data))
+    check(not compiles(block:
+      var q: CallbackQueue[TestItem]
+      discard q.head))
+    check(not compiles(block:
+      var q: CallbackQueue[TestItem]
+      discard q.tail))

--- a/tests/testcontextvars.nim
+++ b/tests/testcontextvars.nim
@@ -1,0 +1,966 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Behavior tests for chronos's continuation-local storage primitive —
+## the `ContextVar[T]` key runtime. See chronos/contextvars.nim and
+## docs/src/contextvars.md.
+##
+## The one-way `chronosDebug` construction-lock suite lives in its own
+## file, tests/testcontextvarslock.nim, precisely so that a permanent,
+## process-lifetime lock on `newContextVar` doesn't impose an import
+## order on this file relative to the other contextvars test files.
+
+import std/[algorithm, sequtils, strutils, tables]
+import unittest2
+import ../chronos/contextvars
+
+when (NimMajor, NimMinor) >= (2, 0):
+  # Only the `{.contextVar.}` pragma-sugar suite at the tail of this file
+  # needs `macros` — that pragma itself is 2.x-only (macro pragmas on
+  # `let`/`var` sections don't exist in the 1.6 compiler), so the suite
+  # and this import are gated together.
+  import std/macros
+
+{.used.}
+
+# --- Test helpers --------------------------------------------------------------
+
+proc entryFor(entries: seq[ContextVarEntry], name: string): ContextVarEntry =
+  ## Looks up the one dumpContext entry with the given name. Every by-name
+  ## probe in this file goes through here rather than a bare
+  ## `filterIt(...)[0]`, which raises an uncaught IndexDefect (aborting the
+  ## whole binary) on a missing name instead of failing just the one check.
+  let matches = entries.filterIt(it.name == name)
+  doAssert matches.len == 1,
+    "expected exactly one dumpContext entry named '" & name & "', found " &
+    $matches.len
+  matches[0]
+
+# --- Scoped binding fixtures --------------------------------------------------
+
+let tracerInt = newContextVar("tracerInt", 0)
+let tracerStr = newContextVar("tracerStr", "default")
+
+# No `*` marker — module-private; value/binder must still work within
+# this same module.
+let privateOnlyVar = newContextVar("privateOnlyVar", 0)
+
+# One starred, one not — each honors its own marker independently.
+let mixedPublic* = newContextVar("mixedPublic", 10, private = false)
+let mixedPrivate = newContextVar("mixedPrivate", 20)
+
+suite "contextvars: declaration + scoped binding":
+
+  test "scoped binding visible inside body":
+    tracerInt.withValue(42):
+      check tracerInt.value == 42
+
+  test "default value when no binding in scope":
+    check tracerInt.value == 0
+
+  test "binding reverts on normal block exit":
+    tracerInt.withValue(42):
+      discard
+    check tracerInt.value == 0
+
+  test "nested bindings see innermost; restore LIFO":
+    tracerInt.withValue(1):
+      check tracerInt.value == 1
+      tracerInt.withValue(2):
+        check tracerInt.value == 2
+        tracerInt.withValue(3):
+          check tracerInt.value == 3
+        check tracerInt.value == 2
+      check tracerInt.value == 1
+    check tracerInt.value == 0
+
+  test "exception in body reverts binding":
+    expect ValueError:
+      tracerInt.withValue(99):
+        check tracerInt.value == 99
+        raise newException(ValueError, "boom")
+    check tracerInt.value == 0
+
+  test "sequential repeated binding of the same var":
+    # Re-entrant binding after a full unwind (distinct from nested/LIFO).
+    tracerInt.withValue(1):
+      check tracerInt.value == 1
+    check tracerInt.value == 0
+    tracerInt.withValue(2):
+      check tracerInt.value == 2
+    check tracerInt.value == 0
+    tracerInt.withValue(3):
+      check tracerInt.value == 3
+    check tracerInt.value == 0
+
+  test "different types bind independently":
+    tracerInt.withValue(7):
+      tracerStr.withValue("hello"):
+        check tracerInt.value == 7
+        check tracerStr.value == "hello"
+      check tracerInt.value == 7
+      check tracerStr.value == "default"
+    check tracerInt.value == 0
+    check tracerStr.value == "default"
+
+  test "non-starred (module-private) key is readable/bindable in its own module":
+    privateOnlyVar.withValue(5):
+      check privateOnlyVar.value == 5
+    check privateOnlyVar.value == 0
+
+  test "mixed declarations — starred and non-starred keys both work":
+    mixedPublic.withValue(11):
+      mixedPrivate.withValue(22):
+        check mixedPublic.value == 11
+        check mixedPrivate.value == 22
+      check mixedPublic.value == 11
+      check mixedPrivate.value == 20
+    check mixedPublic.value == 10
+
+  test "currentContext snapshot used after binder exit returns correct value":
+    # A snapshot captured inside a binder must remain valid after the
+    # binder unwinds — the chain node must own its value, not point at
+    # a since-popped stack frame.
+    proc capture(): AsyncContext =
+      tracerStr.withValue("hello from a long-gone stack frame"):
+        result = currentContext()
+
+    # Overwrite the freed stack slot so a use-after-free read would
+    # return garbage rather than the original value.
+    proc clobber() =
+      var buf: array[2048, byte]
+      for i in 0 ..< 2048: buf[i] = 0xAB.byte
+      doAssert buf[0] == 0xAB.byte  # prevent dead-code elimination
+
+    let snapshot = capture()
+    clobber()
+    withContext(snapshot):
+      check tracerStr.value == "hello from a long-gone stack frame"
+
+# --- Key construction and registry -------------------------------------------
+
+type
+  RenderWidget = ref object
+    id: int
+
+  RenderBlob = distinct int
+    ## Genuinely `$`-less on Nim >=2.x: a plain `object` is NOT
+    ## `$`-less there — `std/objectdollar` auto-derives `$` for every
+    ## object type, so `when compiles($v)` is unconditionally true for
+    ## record-style fixtures. A `distinct` type without a borrowed `$`
+    ## is what actually exercises the placeholder branch.
+
+proc `$`(w: RenderWidget): string = "Widget(" & $w.id & ")"
+  ## Deterministic rendering for the "ref-with-$" fixture below.
+
+suite "contextvars (raw key): key construction and registry":
+  # Fixture names below follow a running `tN...` counter across this file;
+  # gaps (t17, t26) are tests that were removed rather than renumbered, so
+  # a number is never reused for an unrelated fixture.
+
+  test "defaulted key stores name, hasDefault, and registers":
+    let k = newContextVar("t1Key", 42, private = false)
+    check k.name == "t1Key"
+    check k.hasDefault == true
+    # Registration is observable only through dumpContext — the
+    # registry-walking primitive itself is not on the public surface
+    # (see testcontextvarssurface.nim).
+    check dumpContext(currentContext()).anyIt(it.name == "t1Key")
+
+  test "private key does not appear in dumpContext":
+    let k = newContextVar("t2Key", 42, private = true)
+    check k.private == true
+    check not dumpContext(currentContext()).anyIt(it.name == "t2Key")
+
+  test "must-bind arity has hasDefault false":
+    let k = newRequiredContextVar[int]("t3Key")
+    check k.hasDefault == false
+
+  test "dumpContext renders defaults and bound values across T shapes":
+    # Early smoke check for per-T dumpContext rendering; t25 below is the
+    # authoritative render-parity case over the same T shapes.
+    let intKey = newContextVar("t4Int", 7, private = false)
+    let widgetKey = newContextVar[RenderWidget]("t4Widget", nil, private = false)
+    let blobKey = newContextVar("t4Blob", RenderBlob(3), private = false)
+
+    block:
+      let entries = dumpContext(currentContext())
+      check entries.entryFor("t4Int").value == "7"
+      check entries.entryFor("t4Widget").value == "nil"
+      check entries.entryFor("t4Blob").value == "<no-$>"
+
+    intKey.withValue(99):
+      widgetKey.withValue(RenderWidget(id: 5)):
+        blobKey.withValue(RenderBlob(11)):
+          let entries = dumpContext(currentContext())
+          check entries.entryFor("t4Int").value == "99"
+          check entries.entryFor("t4Widget").value == "Widget(5)"
+          check entries.entryFor("t4Blob").value == "<no-$>"
+
+  test "two same-T keys are distinct":
+    let k1 = newContextVar("t5Key", 1)
+    let k2 = newContextVar("t5Key", 1)
+    check k1 != k2
+
+# --- Overload resolution: a bool default/second positional arg (r4-01) ------
+# `newContextVar(name, default: T, private = true)` takes `private` as
+# its third parameter, not its second — a bool-typed default must
+# resolve there cleanly. `newRequiredContextVar` is a distinct name
+# from `newContextVar` precisely so a call like this can never collide
+# with the must-bind constructor's own `private: bool` parameter.
+
+suite "contextvars (raw key): bool-typed default resolves to the right constructor":
+
+  test "newContextVar(name, false) compiles and yields a working bool var":
+    let k = newContextVar("t5aBoolKey", false)
+    check k.hasDefault == true
+    check k.value == false
+    k.withValue(true):
+      check k.value == true
+    check k.value == false
+
+  test "newRequiredContextVar[bool] works with in/isBound and raises when unbound":
+    let k = newRequiredContextVar[bool]("t5bRequiredBool")
+    check k notin currentContext()
+    check not k.isBound
+    expect UnboundContextVarDefect:
+      discard k.value
+    k.withValue(true):
+      check k in currentContext()
+      check k.isBound
+      check k.value == true
+
+# --- Keys as values: generic parameters, seq, Table --------------------------
+# Capabilities an identifier-family design structurally could not offer,
+# since there was never a runtime value to pass around. See
+# docs/src/contextvars.md, "Keys as values".
+
+suite "contextvars (raw key): keys as values":
+
+  test "keys stored in a seq dispatch independently when read back":
+    var keys = newSeq[ContextVar[int]]()
+    for i in 0 ..< 4:
+      keys.add newContextVar("collKey" & $i, 0)
+    keys[2].withValue(99):
+      check keys[2].value == 99
+      check keys[0].value == 0
+      check keys[1].value == 0
+      check keys[3].value == 0
+
+  test "keys work as a Table key, hashed and compared by ref identity":
+    # ContextVar[T] has an identity hash (chronos/contextvars.nim), so a
+    # key works as a genuine Table *key*, not just a value. Two
+    # same-name keys are the strongest form of this claim: they compare
+    # equal on every constructor argument yet must still be distinct
+    # Table keys.
+    let a = newContextVar("tblKeyDup", 1)
+    let b = newContextVar("tblKeyDup", 1)
+    var t = initTable[ContextVar[int], string]()
+    t[a] = "first"
+    t[b] = "second"
+    check t.len == 2
+    check t[a] == "first"
+    check t[b] == "second"
+    check a != b
+
+  test "a proc generic over the key itself dispatches without macro expansion":
+    proc readOrDefault[T](cv: ContextVar[T]): T = cv.value
+    let k = newContextVar("genericParamKey", 42)
+    check readOrDefault(k) == 42
+    k.withValue(7):
+      check readOrDefault(k) == 7
+
+# --- Ambient value and withValue ---------------------------------------------
+
+suite "contextvars (raw key): ambient value and withValue":
+
+  test "unbound defaulted read returns default":
+    let k = newContextVar("t6Key", 11)
+    check k.value == 11
+
+  test "withValue binds: read inside body sees v":
+    let k = newContextVar("t7Key", 0)
+    k.withValue(42):
+      check k.value == 42
+
+  test "restore on normal exit: read after body sees default again":
+    let k = newContextVar("t8Key", 0)
+    k.withValue(42):
+      discard
+    check k.value == 0
+
+  test "nested withValue same key: LIFO shadow, each exit restores its predecessor":
+    let k = newContextVar("t9Key", 0)
+    k.withValue(1):
+      check k.value == 1
+      k.withValue(2):
+        check k.value == 2
+        k.withValue(3):
+          check k.value == 3
+        check k.value == 2
+      check k.value == 1
+    check k.value == 0
+
+  test "restore on exception: raise inside body, catch outside, read sees default":
+    let k = newContextVar("t10Key", 0)
+    expect ValueError:
+      k.withValue(42):
+        check k.value == 42
+        raise newException(ValueError, "boom")
+    check k.value == 0
+
+  test "two same-T keys bound simultaneously each read back their own value":
+    let k1 = newContextVar("t11Key1", 0)
+    let k2 = newContextVar("t11Key2", 0)
+    k1.withValue(1):
+      k2.withValue(2):
+        check k1.value == 1
+        check k2.value == 2
+      check k1.value == 1
+      check k2.value == 0
+    check k1.value == 0
+    check k2.value == 0
+
+  test "bindings of two different-T keys coexist":
+    let ik = newContextVar("t12Int", 0)
+    let sk = newContextVar("t12Str", "")
+    ik.withValue(7):
+      sk.withValue("hello"):
+        check ik.value == 7
+        check sk.value == "hello"
+      check ik.value == 7
+      check sk.value == ""
+    check ik.value == 0
+    check sk.value == ""
+
+  test "withValue on a private key works the same":
+    let k = newContextVar("t13Key", 0, private = true)
+    check k.value == 0
+    k.withValue(9):
+      check k.value == 9
+    check k.value == 0
+
+# --- Binder contract + chain-state invariants --------------------------------
+# Verifies every `withValue` binder pushes exactly one chain node and
+# pops it on every exit path, via chainLen() and the chainBalance
+# counter. Both are debug-only (when defined(chronosDebug)); the test
+# build defines it.
+
+let probeInt = newContextVar("probeInt", 0)
+
+suite "contextvars: binder contract":
+
+  when defined(chronosDebug):
+
+    test "binder pushes exactly one node and pops on normal exit":
+      let baseline = chainLen()
+      probeInt.withValue(7):
+        check chainLen() == baseline + 1
+        check probeInt.value == 7
+      check chainLen() == baseline
+
+    test "binder pops on exception":
+      let baseline = chainLen()
+      try:
+        probeInt.withValue(9):
+          check chainLen() == baseline + 1
+          raise newException(ValueError, "boom")
+      except ValueError:
+        discard
+      check chainLen() == baseline
+
+    test "nested binders nest cleanly":
+      let baseline = chainLen()
+      probeInt.withValue(1):
+        check chainLen() == baseline + 1
+        probeInt.withValue(2):
+          check chainLen() == baseline + 2
+          probeInt.withValue(3):
+            check chainLen() == baseline + 3
+          check chainLen() == baseline + 2
+        check chainLen() == baseline + 1
+      check chainLen() == baseline
+
+    test "binder balance counter zeroes after every binder":
+      let baseline = chainBalance
+      probeInt.withValue(1):
+        check chainBalance == baseline + 1
+      check chainBalance == baseline
+      probeInt.withValue(2):
+        probeInt.withValue(3):
+          check chainBalance == baseline + 2
+      check chainBalance == baseline
+
+# --- AsyncContext identity (==) ----------------------------------------------
+
+let identA = newContextVar("identA", 0)
+
+suite "contextvars: AsyncContext identity (==)":
+
+  test "two captures with no intervening binding change are equal":
+    let a = currentContext()
+    let b = currentContext()
+    check a == b
+
+  test "capture inside a new binder is unequal to an outer capture":
+    let outer = currentContext()
+    identA.withValue(1):
+      let inner = currentContext()
+      check not (inner == outer)
+
+  test "capture after restore is equal to the pre-binder capture":
+    let before = currentContext()
+    identA.withValue(1):
+      discard currentContext()
+    let after = currentContext()
+    check after == before
+
+  test "nested binder captures are pairwise unequal; restore re-equalizes":
+    let c0 = currentContext()
+    identA.withValue(1):
+      let c1 = currentContext()
+      check not (c1 == c0)
+      identA.withValue(2):
+        let c2 = currentContext()
+        check not (c2 == c1)
+        check not (c2 == c0)
+      let c1Again = currentContext()
+      check c1Again == c1
+    let c0Again = currentContext()
+    check c0Again == c0
+
+  test "hash matches == identity: two equal snapshots hash equal":
+    let a = currentContext()
+    let b = currentContext()
+    check a == b
+    check hash(a) == hash(b)
+
+  test "AsyncContext works as a Table key":
+    var t: Table[AsyncContext, int]
+    let outer = currentContext()
+    t[outer] = 1
+    identA.withValue(1):
+      let inner = currentContext()
+      t[inner] = 2
+      check t[outer] == 1
+      check t[inner] == 2
+    check t[currentContext()] == 1
+
+# --- Snapshot AsyncContext and [] --------------------------------------------
+
+let snapOuter = newContextVar("snapOuter", 0)
+
+suite "contextvars (raw key): snapshot AsyncContext and []":
+
+  test "snapshot sees the bound value without needing to be installed":
+    snapOuter.withValue(11):
+      let snap = currentContext()
+      check snap[snapOuter] == 11
+
+  test "snapshot outlives the binder that captured it; ambient reverts, snapshot doesn't":
+    var snap: AsyncContext
+    snapOuter.withValue(22):
+      snap = currentContext()
+    # The ambient reader has reverted, but the snapshot still walks its
+    # own captured chain rather than the (now-reverted) ambient one.
+    check snapOuter.value == 0
+    check snap[snapOuter] == 22
+
+  test "snapshot of an outer context read while an inner binding is ambient returns the OUTER value":
+    snapOuter.withValue(1):
+      let outerSnap = currentContext()
+      snapOuter.withValue(2):
+        check snapOuter.value == 2             # ambient sees the innermost binder
+        check outerSnap[snapOuter] == 1         # snapshot still sees the outer value
+      check snapOuter.value == 1
+
+  test "defaulted-unbound snapshot returns the default":
+    check currentContext()[snapOuter] == 0
+
+  test "currentContext() captured inside withValue outlives the binder (raw key)":
+    let k = newContextVar("t14Key", 0)
+    var snap: AsyncContext
+    k.withValue(42):
+      snap = currentContext()
+      check snap[k] == 42
+    check snap[k] == 42
+
+  test "snapshot captured before a later bind is unaffected by it":
+    let k = newContextVar("t15Key", 0)
+    let snap = currentContext()
+    check snap[k] == 0
+    k.withValue(99):
+      check snap[k] == 0
+    check snap[k] == 0
+
+  test "snapshot == and hash: identity semantics, usable as a Table key":
+    let a = currentContext()
+    let b = currentContext()
+    check a == b
+    check hash(a) == hash(b)
+
+    let k = newContextVar("t16Key", 0)
+    k.withValue(1):
+      let c = currentContext()
+      check c != a
+
+    var t = initTable[AsyncContext, string]()
+    t[a] = "outer"
+    check t[b] == "outer"
+
+# --- Must-bind (default-less) keys -------------------------------------------
+
+let mustBindVar = newRequiredContextVar[int]("mustBindVar")    # must-bind: no default
+
+suite "contextvars: must-bind (default-less) keys":
+
+  test "reading unbound raises UnboundContextVarDefect":
+    expect UnboundContextVarDefect:
+      discard mustBindVar.value
+
+  test "UnboundContextVarDefect carries the key's name":
+    try:
+      discard mustBindVar.value
+      check false
+    except UnboundContextVarDefect as e:
+      check e.varName == "mustBindVar"
+
+  test "snapshot reader's UnboundContextVarDefect also carries the key's name":
+    let snap = currentContext()
+    try:
+      discard snap[mustBindVar]
+      check false
+    except UnboundContextVarDefect as e:
+      check e.varName == "mustBindVar"
+
+  test "reading bound works":
+    mustBindVar.withValue(5):
+      check mustBindVar.value == 5
+
+  test "binding reverts on block exit; unbound read raises again":
+    mustBindVar.withValue(5):
+      discard
+    expect UnboundContextVarDefect:
+      discard mustBindVar.value
+
+  test "nested must-bind rebinding restores LIFO, same as a defaulted key":
+    mustBindVar.withValue(1):
+      check mustBindVar.value == 1
+      mustBindVar.withValue(2):
+        check mustBindVar.value == 2
+      check mustBindVar.value == 1
+
+  test "snapshot reader raises on an unbound snapshot":
+    let snap = currentContext()   # nothing bound anywhere for mustBindVar
+    expect UnboundContextVarDefect:
+      discard snap[mustBindVar]
+
+  test "snapshot reader returns the bound value when bound in the snapshot":
+    mustBindVar.withValue(9):
+      let snap = currentContext()
+      check snap[mustBindVar] == 9
+
+suite "contextvars (raw key): must-bind Defect parity":
+
+  test "unbound must-bind .value raises UnboundContextVarDefect with varName":
+    let k = newRequiredContextVar[int]("t18Key")
+    try:
+      discard k.value
+      check false
+    except UnboundContextVarDefect as e:
+      check e.varName == "t18Key"
+
+  test "unbound must-bind ctx[cv] raises UnboundContextVarDefect, same fields":
+    let k = newRequiredContextVar[int]("t19Key")
+    let snap = currentContext()
+    try:
+      discard snap[k]
+      check false
+    except UnboundContextVarDefect as e:
+      check e.varName == "t19Key"
+
+  test "bound must-bind read returns the value on both paths, no raise":
+    let k = newRequiredContextVar[int]("t20Key")
+    k.withValue(5):
+      check k.value == 5
+      check currentContext()[k] == 5
+
+  test "defaulted key ctx[cv] miss returns default, symmetric with .value":
+    let k = newContextVar("t21Key", 11)
+    check currentContext()[k] == 11
+    check currentContext()[k] == k.value
+
+# --- Boundness probe: contains / isBound --------------------------------------
+
+suite "contextvars (raw key): contains / isBound":
+
+  test "duplicate-name keys: in/isBound answers by identity, not by name":
+    # dumpContext groups by name, so it cannot tell these two apart --
+    # `in`/`isBound` test the key itself and must.
+    let a = newContextVar("t31Dup", 1)
+    let b = newContextVar("t31Dup", 1)
+    a.withValue(99):
+      check a in currentContext()
+      check a.isBound
+      check b notin currentContext()
+      check not b.isBound
+
+  test "must-bind key unbound: false, does not raise":
+    let k = newRequiredContextVar[int]("t31MustBind")
+    check k notin currentContext()
+    check not k.isBound
+
+  test "must-bind key bound: true":
+    let k = newRequiredContextVar[int]("t31MustBindBound")
+    k.withValue(5):
+      check k in currentContext()
+      check k.isBound
+
+  test "defaulted key unbound: false, even though .value returns the default":
+    let k = newContextVar("t31Defaulted", 7)
+    check k notin currentContext()
+    check k.value == 7
+
+# --- dumpContext / $ ----------------------------------------------------------
+
+type NoDollarPtr = ptr int
+  ## Has no `$`: unlike an `object` (which gets one for free from
+  ## `std/objectdollar`), a bare pointer type has no such fallback.
+
+static:
+  doAssert not compiles((block:
+    var chronosProbeVal: NoDollarPtr
+    $chronosProbeVal)),
+    "control: NoDollarPtr must genuinely have no `$`, or the " &
+    "placeholder-path test below is vacuous"
+
+type DerefDollarRef = ref object
+  ## `$` dereferences `field` — calling it on a nil value would crash,
+  ## which is exactly what the nil-safe render path must avoid.
+  field: int
+
+proc `$`(r: DerefDollarRef): string = "field=" & $r.field
+
+# Starred: dumpContext only ever sees a starred key's state — these
+# fixtures test dumpContext itself, so they must be visible to it.
+let dumpDefaulted* = newContextVar("dumpDefaulted", 7, private = false)
+let dumpMustBind* = newRequiredContextVar[string]("dumpMustBind", private = false)  # must-bind
+let dumpNoDollar* = newContextVar[NoDollarPtr]("dumpNoDollar", nil, private = false)
+let dumpRefNilDefault* = newContextVar[DerefDollarRef]("dumpRefNilDefault", nil, private = false)
+
+suite "contextvars: dumpContext and $":
+
+  test "unbound defaulted key: bound=false, value is the rendered default":
+    let entries = dumpContext(currentContext())
+    let e = entries.entryFor("dumpDefaulted")
+    check e.bound == false
+    check e.value == "7"
+
+  test "bound defaulted key: bound=true, value is the bound value":
+    dumpDefaulted.withValue(99):
+      let entries = dumpContext(currentContext())
+      let e = entries.entryFor("dumpDefaulted")
+      check e.bound == true
+      check e.value == "99"
+
+  test "unbound must-bind key: bound=false, placeholder value, dumpContext does not raise":
+    # dumpContext must complete normally even though dumpMustBind.value
+    # itself would raise UnboundContextVarDefect here.
+    let entries = dumpContext(currentContext())
+    let e = entries.entryFor("dumpMustBind")
+    check e.bound == false
+    check e.value == "<unbound>"
+
+  test "bound must-bind key: bound=true, value is the bound value":
+    dumpMustBind.withValue("hello"):
+      let entries = dumpContext(currentContext())
+      let e = entries.entryFor("dumpMustBind")
+      check e.bound == true
+      check e.value == "hello"
+
+  test "a type with no `$` renders as the <no-$> placeholder":
+    # The generic render hook has no per-T type-name string to splice
+    # in (unlike the old macro's per-arm renderer proc, which captured
+    # the type expression's `repr` at macro-expansion time) — a fixed
+    # placeholder replaces the old `<TypeName>` form. See t4/t25 above.
+    let entries = dumpContext(currentContext())
+    let e = entries.entryFor("dumpNoDollar")
+    check e.bound == false
+    check e.value == "<no-$>"
+
+  test "`$`(ctx) renders {name: value, ...} via the same machinery as dumpContext":
+    dumpDefaulted.withValue(55):
+      let s = $currentContext()
+      check "dumpDefaulted: 55" in s
+
+  test "ref-typed key with nil value renders as \"nil\" without calling $ (would crash otherwise)":
+    let entries = dumpContext(currentContext())
+    let e = entries.entryFor("dumpRefNilDefault")
+    check e.bound == false
+    check e.value == "nil"
+
+  test "bound ref-typed key with a non-nil value renders via $":
+    dumpRefNilDefault.withValue(DerefDollarRef(field: 42)):
+      let entries = dumpContext(currentContext())
+      let e = entries.entryFor("dumpRefNilDefault")
+      check e.bound == true
+      check e.value == "field=42"
+
+  test "entries are sorted by name":
+    let entries = dumpContext(currentContext())
+    var names: seq[string]
+    for e in entries: names.add e.name
+    check names == sorted(names)
+
+suite "contextvars (raw key): dumpContext and $":
+
+  test "dumpContext on empty context: defaulted, must-bind, private semantics":
+    let defaultedKey = newContextVar("t22Defaulted", 5, private = false)
+    let mustBindKey = newRequiredContextVar[int]("t22MustBind", private = false)
+    discard newContextVar("t22Private", 9, private = true)
+
+    let entries = dumpContext(currentContext())
+
+    let defaultedEntry = entries.entryFor("t22Defaulted")
+    check defaultedEntry.bound == false
+    check defaultedEntry.value == "5"
+
+    let mustBindEntry = entries.entryFor("t22MustBind")
+    check mustBindEntry.bound == false
+    check mustBindEntry.value == "<unbound>"
+
+    check not entries.anyIt(it.name == "t22Private")
+    check defaultedKey.value == 5
+    check mustBindKey.hasDefault == false
+
+  test "dumpContext on a bound snapshot: bound=true, value rendered; fresh snapshot reverts to default":
+    let k = newContextVar("t23Key", 1, private = false)
+    var boundEntry: ContextVarEntry
+    k.withValue(77):
+      boundEntry = dumpContext(currentContext()).entryFor("t23Key")
+    check boundEntry.bound == true
+    check boundEntry.value == "77"
+
+    let freshEntry = dumpContext(currentContext()).entryFor("t23Key")
+    check freshEntry.bound == false
+    check freshEntry.value == "1"
+
+  test "`$` format parity and sorted order":
+    let zKey = newContextVar("t24Zeta", 1, private = false)
+    let aKey = newContextVar("t24Alpha", 2, private = false)
+    let mKey = newContextVar("t24Mid", 3, private = false)
+    zKey.withValue(10):
+      aKey.withValue(20):
+        mKey.withValue(30):
+          let ctx = currentContext()
+          let s = $ctx
+          check s[0] == '{'
+          check s[^1] == '}'
+          check s.contains("t24Alpha: 20")
+          check s.contains("t24Mid: 30")
+          check s.contains("t24Zeta: 10")
+          check s.find("t24Alpha") < s.find("t24Mid")
+          check s.find("t24Mid") < s.find("t24Zeta")
+
+          var names: seq[string]
+          for entry in dumpContext(ctx):
+            names.add entry.name
+          check names == sorted(names)
+
+  test "render parity: ref-with-$, ref nil default, $-less distinct, plain int":
+    # Authoritative render-parity case for these T shapes; t4 above is
+    # only the early smoke check.
+    let refKey = newContextVar[RenderWidget]("t25Ref", RenderWidget(id: 3), private = false)
+    let nilKey = newContextVar[RenderWidget]("t25Nil", nil, private = false)
+    let blobKey = newContextVar("t25Blob", RenderBlob(4), private = false)
+    let intKey = newContextVar("t25Int", 8, private = false)
+
+    block:
+      let entries = dumpContext(currentContext())
+      check entries.entryFor("t25Ref").value == "Widget(3)"
+      check entries.entryFor("t25Nil").value == "nil"
+      check entries.entryFor("t25Blob").value == "<no-$>"
+      check entries.entryFor("t25Int").value == "8"
+
+    refKey.withValue(RenderWidget(id: 9)):
+      nilKey.withValue(RenderWidget(id: 1)):
+        blobKey.withValue(RenderBlob(2)):
+          intKey.withValue(41):
+            let entries = dumpContext(currentContext())
+            check entries.entryFor("t25Ref").value == "Widget(9)"
+            check entries.entryFor("t25Nil").value == "Widget(1)"
+            check entries.entryFor("t25Blob").value == "<no-$>"
+            check entries.entryFor("t25Int").value == "41"
+
+# --- Empty (default/nil) AsyncContext ----------------------------------------
+
+let emptyCtxDefaulted = newContextVar("emptyCtxDefaulted", 3)
+let emptyCtxMustBind = newRequiredContextVar[int]("emptyCtxMustBind")    # must-bind
+
+suite "contextvars: empty (default/nil) AsyncContext":
+
+  test "withContext over a default AsyncContext installs no bindings":
+    var emptyCtx: AsyncContext   # zero value: no capture was ever taken
+    withContext(emptyCtx):
+      check emptyCtxDefaulted.value == 3      # defaulted key reads its default
+      expect UnboundContextVarDefect:
+        discard emptyCtxMustBind.value        # must-bind key raises
+
+# The declaration-pragma sugar below, and everything that exercises it,
+# is 2.x-only: macro pragmas on `let`/`var` sections (what `{.contextVar.}`
+# relies on) do not exist in the 1.6 compiler. See chronos/contextvars.nim's
+# gate on the pragma's implementation for the underlying constraint.
+when (NimMajor, NimMinor) >= (2, 0):
+  # --- {.contextVar.} declaration sugar ----------------------------------------
+
+  let t27Key* {.contextVar.} = 5
+
+  let t28Hidden {.contextVar.} = "hidden"
+    ## No star -> private = true. Absence from `dumpContext` is what the
+    ## test checks; the symbol itself stays reachable within this module
+    ## (unlike cross-module unreachability, which
+    ## tests/testcontextvarsexport.nim covers).
+
+  var t29MustBind* {.contextVar.}: string
+
+  let t30WidgetVar* {.contextVar.}: RenderWidget = nil
+
+  template t32Wrapper(nm: untyped; body: untyped): untyped =
+    ## Forwards to the sugar macro from inside another template, so the
+    ## identifier arrives as whatever node kind the wrapper's own
+    ## parameter resolves to (probing the nnkIdent/nnkSym duality
+    ## `splitContextVarNameAndPrivate` handles) — the successor to the
+    ## old macro's `declareViaMacro`/`declareViaSym` arm-name probes,
+    ## which tested the same nnkIdent/nnkSym duality for the statement
+    ## macro this pragma replaced.
+    let nm* {.contextVar.} = body
+
+  t32Wrapper(t32Wrapped, 777)
+
+  suite "contextvars (raw key): {.contextVar.} declaration sugar":
+
+    test "starred let, T inferred: name, registration, and value":
+      check t27Key.name == "t27Key"
+      check t27Key.value == 5
+      check dumpContext(currentContext()).anyIt(it.name == "t27Key")
+
+    test "unstarred: private, absent from dumpContext":
+      check t28Hidden.name == "t28Hidden"
+      check t28Hidden.private == true
+      check not dumpContext(currentContext()).anyIt(it.name == "t28Hidden")
+
+    test "must-bind var form: unbound read raises with varName":
+      check t29MustBind.hasDefault == false
+      try:
+        discard t29MustBind.value
+        check false
+      except UnboundContextVarDefect as e:
+        check e.varName == "t29MustBind"
+      t29MustBind.withValue("bound"):
+        check t29MustBind.value == "bound"
+
+    test "explicit-T-with-nil-default ref form":
+      check t30WidgetVar.name == "t30WidgetVar"
+      check t30WidgetVar.value == nil
+      check dumpContext(currentContext()).entryFor("t30WidgetVar").value == "nil"
+
+    test "one-symbol emission: no derived identifiers":
+      check declared(t27Key)
+      check not declared(withT27Key)
+      check not declared(T27KeySlot)
+      check not declared(t27KeyContextVarReg)
+      check not declared(t27KeyContextVarRender)
+
+    test "wrapper-template composition: sugar invoked through a forwarding template":
+      check t32Wrapped.name == "t32Wrapped"
+      check t32Wrapped.value == 777
+
+  # --- {.contextVar.} grammar enforcement (var/let) ----------------------------
+  # The pragma macro rejects the wrong keyword rather than silently
+  # accepting it: a defaulted key (has `= default`) must be a `let`; a
+  # must-bind key (no default) must be a `var`. `when not compiles` proves
+  # the rejection is a compile error, not a runtime check.
+
+  static:
+    doAssert not compiles((var t33WrongKeyword {.contextVar.} = 5)),
+      "a defaulted {.contextVar.} key spelled with `var` must not compile " &
+      "— defaulted keys require `let`"
+    doAssert not compiles((let t34WrongKeyword {.contextVar.}: int)),
+      "a must-bind {.contextVar.} key spelled with `let` must not compile " &
+      "— must-bind keys require `var`"
+
+  # --- {.contextVar.} grammar enforcement (single identifier) ------------------
+  # Nim's own pragma-on-identifier syntax admits only one name per
+  # `{.contextVar.}`-tagged declaration (a second name in the same
+  # `IdentDefs` is already a parser-level error, before the macro ever
+  # runs), so the macro's own `def.len != 1` arity check — guarding a
+  # `let`/`var` *section* carrying more than one declaration — has no
+  # ordinary-syntax way to reach it. `t35MultiIdentDecl` drives it
+  # directly by handing the macro a hand-built two-declaration section,
+  # the same macro-composition approach `t32Wrapper` above uses to reach
+  # the nnkIdent/nnkSym duality.
+
+  macro t35MultiIdentDecl(): untyped =
+    var multi = newNimNode(nnkLetSection)
+    multi.add newIdentDefs(ident("t35A"), newEmptyNode(), newLit(1))
+    multi.add newIdentDefs(ident("t35B"), newEmptyNode(), newLit(2))
+    getAst(contextVar(multi))
+
+  static:
+    doAssert not compiles((t35MultiIdentDecl())),
+      "a {.contextVar.} section naming more than one declaration must " &
+      "not compile — the pragma supports exactly one identifier per " &
+      "declaration"
+
+  # --- {.contextVar.} pragma-argument override (dump-visibility) --------------
+  # `{.contextVar: (private: <bool>).}` decouples a declaration's
+  # dumpContext visibility from its own export marker — see
+  # docs/src/contextvars.md, "The `{.contextVar.}` pragma", "Overriding
+  # dump-visibility". Default (no argument) behavior is unchanged and
+  # covered above; these tests cover both override directions, the
+  # argument's interaction with the let/var grammar enforcement, and a
+  # `not compiles` pin for a malformed argument.
+
+  let t36ExportedPrivate* {.contextVar: (private: true).} = 1
+    ## Exported (star) but overridden private -> absent from dumpContext
+    ## despite the star.
+
+  let t37UnexportedVisible {.contextVar: (private: false).} = 2
+    ## Unexported (no star) but overridden non-private -> present in
+    ## dumpContext despite the missing star.
+
+  var t38MustBindOverride* {.contextVar: (private: true).}: int
+    ## must-bind + override: the argument form must still enforce the
+    ## var/must-bind pairing.
+
+  suite "contextvars (raw key): {.contextVar.} pragma-argument override":
+
+    test "exported + private=true override: absent from dumpContext despite the star":
+      check t36ExportedPrivate.value == 1
+      check not dumpContext(currentContext()).anyIt(it.name == "t36ExportedPrivate")
+
+    test "unexported + private=false override: present in dumpContext despite no star":
+      check t37UnexportedVisible.value == 2
+      check dumpContext(currentContext()).anyIt(it.name == "t37UnexportedVisible")
+
+    test "override argument composes with must-bind (var) grammar":
+      check t38MustBindOverride.hasDefault == false
+      expect UnboundContextVarDefect:
+        discard t38MustBindOverride.value
+      t38MustBindOverride.withValue(9):
+        check t38MustBindOverride.value == 9
+      check not dumpContext(currentContext()).anyIt(it.name == "t38MustBindOverride")
+
+  static:
+    doAssert not compiles((var t39WrongKeyword {.contextVar: (private: true).} = 5)),
+      "a defaulted {.contextVar: (private: ...).} key spelled with `var` " &
+      "must not compile — the argument form keeps the same let/var " &
+      "enforcement the default form has"
+    doAssert not compiles((let t40BadArg {.contextVar: (private: 1).} = 5)),
+      "a malformed {.contextVar: (private: ...).} argument (a non-bool " &
+      "value) must not compile"

--- a/tests/testcontextvarsasync.nim
+++ b/tests/testcontextvarsasync.nim
@@ -1,0 +1,1125 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Async propagation tests for chronos contextvars: bindings survive
+## await, concurrent tasks stay isolated, and children inherit without
+## leaking back. See testcontextvars.nim for the sync-only baseline.
+
+import unittest2
+import ../chronos
+import ../chronos/config
+import ../chronos/contextvars
+import ../chronos/futures
+  # Whitebox: capturingCallback is excluded from the public `import chronos`
+  # surface (see chronos/internal/asyncengine.nim's `export futures except
+  # ...`); the internalCallTick pin below needs it to opt a caller-supplied
+  # AsyncCallback into context capture.
+
+when not defined(windows):
+  import std/posix
+  when chronosEventEngine in ["epoll", "kqueue"]:
+    # Signal/process registration (and asyncproc, which this file uses
+    # only for spawning a child) exists on the epoll/kqueue engines
+    # only — same gate testall.nim applies to testsignal/testproc.
+    import ../chronos/asyncproc
+
+{.used.}
+
+let asyncInt = newContextVar("asyncInt", 0)
+let asyncStr = newContextVar("asyncStr", "")
+let asyncReq = newRequiredContextVar[int]("asyncReq")    # must-bind: no default
+
+suite "contextvars: async propagation":
+
+  test "concurrent tasks with interleaved suspensions each see their own binding":
+    # Lockstep alternation via a future handshake (not timed sleeps, which
+    # don't guarantee interleaving order) so each resume must see its own
+    # binding rather than the other task's leftover.
+    var tickA, tickB: Future[void]
+    proc resetTicks() =
+      tickA = newFuture[void]("tickA")
+      tickB = newFuture[void]("tickB")
+
+    proc taskA(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(100):
+        await tickA
+        check asyncInt.value == 100
+        tickB.complete()  # hand off to B
+        resetTicks()
+        await tickA
+        check asyncInt.value == 100
+        tickB.complete()
+        return asyncInt.value
+
+    proc taskB(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(200):
+        await tickB
+        check asyncInt.value == 200
+        tickA.complete()  # hand off to A
+        await tickB
+        check asyncInt.value == 200
+        return asyncInt.value
+
+    proc driver(): Future[(int, int)] {.async: (raises: [Exception]).} =
+      resetTicks()
+      let fa = taskA()
+      let fb = taskB()
+      tickA.complete()  # kick off A
+      let a = await fa
+      let b = await fb
+      return (a, b)
+
+    let (a, b) = waitFor(driver())
+    check a == 100
+    check b == 200
+
+  test "multiple value types coexist on same context chain across await":
+    # Both vars must remain visible after an await regardless of type or
+    # position on the chain.
+    proc work(): Future[(int, string)] {.async: (raises: [CancelledError]).} =
+      check asyncInt.value == 42
+      check asyncStr.value == "tracer"
+      await sleepAsync(1.milliseconds)
+      check asyncInt.value == 42
+      check asyncStr.value == "tracer"
+      return (asyncInt.value, asyncStr.value)
+
+    proc driver(): Future[(int, string)] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(42):
+        asyncStr.withValue("tracer"):
+          return await work()
+
+    check waitFor(driver()) == (42, "tracer")
+
+  test "binding survives multiple sequential awaits":
+    proc work(): Future[int] {.async: (raises: [CancelledError]).} =
+      check asyncInt.value == 11
+      await sleepAsync(1.milliseconds)
+      check asyncInt.value == 11
+      await sleepAsync(1.milliseconds)
+      check asyncInt.value == 11
+      await sleepAsync(1.milliseconds)
+      return asyncInt.value
+
+    proc driver(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(11):
+        return await work()
+
+    check waitFor(driver()) == 11
+
+  test "child task inherits parent's context at spawn":
+    proc child(): Future[int] {.async: (raises: [CancelledError]).} =
+      check asyncInt.value == 42     # inherited from parent's binding
+      await sleepAsync(1.milliseconds)
+      check asyncInt.value == 42
+      return asyncInt.value
+
+    proc parent(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(42):
+        return await child()
+
+    check waitFor(parent()) == 42
+
+  test "parent's binding survives spawn-then-await of independent child":
+    # Deferred-await pattern: parent spawns the child future, does other
+    # work, then awaits it later. Parent's binding must survive across
+    # the intervening dispatcher returns.
+    proc child(): Future[int] {.async: (raises: [CancelledError]).} =
+      check asyncInt.value == 42      # parent's binding inherited
+      await sleepAsync(1.milliseconds)
+      asyncInt.withValue(999):           # child rebinds locally
+        await sleepAsync(1.milliseconds)
+        check asyncInt.value == 999
+      check asyncInt.value == 42      # back to inherited
+      return asyncInt.value
+
+    proc parent(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(42):
+        let f = child()           # spawn
+        check asyncInt.value == 42
+        await sleepAsync(1.milliseconds)  # parent yields, child runs
+        check asyncInt.value == 42    # parent still sees its own
+        let r = await f
+        check r == 42
+        check asyncInt.value == 42    # post-await, parent's binding intact
+        return asyncInt.value
+
+    check waitFor(parent()) == 42
+
+  test "child's nested binding does not leak back to parent":
+    proc child(): Future[void] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(999):
+        await sleepAsync(1.milliseconds)
+        check asyncInt.value == 999
+      check asyncInt.value == 42    # back to parent's binding
+
+    proc parent(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(42):
+        await child()
+        return asyncInt.value       # parent still sees its own 42
+
+    check waitFor(parent()) == 42
+
+  test "exception across await reverts binding":
+    proc work(): Future[void] {.async: (raises: [Exception]).} =
+      await sleepAsync(1.milliseconds)
+      raise newException(ValueError, "boom across await")
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      try:
+        asyncInt.withValue(77):
+          check asyncInt.value == 77
+          await work()
+          check false           # unreachable
+      except ValueError:
+        discard
+      return asyncInt.value         # binding reverted
+
+    check waitFor(driver()) == 0
+
+  test "CancelledError across await reverts binding":
+    proc longSleep(): Future[void] {.async: (raises: [CancelledError]).} =
+      await sleepAsync(1.seconds)
+
+    proc driver(): Future[int] {.async: (raises: [CancelledError]).} =
+      let f = longSleep()
+      var observed = -1
+      try:
+        asyncInt.withValue(55):
+          check asyncInt.value == 55
+          # Cancel the inner future from a sibling timer so cancellation
+          # propagates through our `await f`.
+          discard setTimer(Moment.now() + 1.milliseconds,
+                           proc(_: pointer) {.gcsafe, raises: [].} =
+                             f.cancelSoon())
+          await f
+          check false           # unreachable — cancel must propagate
+      except CancelledError:
+        observed = asyncInt.value
+      check observed == 0       # CancelledError unwound asyncInt.withValue(55)
+      return asyncInt.value
+
+    check waitFor(driver()) == 0
+
+  test "CancelledError caught inside withName sees the binding":
+    # Unlike the test above, the except handler is INSIDE the binder here,
+    # so the binding must still be visible while it runs.
+    proc longSleep(): Future[void] {.async: (raises: [CancelledError]).} =
+      await sleepAsync(1.seconds)
+
+    proc driver(): Future[int] {.async: (raises: [CancelledError]).} =
+      let f = longSleep()
+      var observedInsideHandler = -1
+      asyncInt.withValue(88):
+        check asyncInt.value == 88
+        discard setTimer(Moment.now() + 1.milliseconds,
+                         proc(_: pointer) {.gcsafe, raises: [].} =
+                           f.cancelSoon())
+        try:
+          await f
+          check false           # unreachable
+        except CancelledError:
+          observedInsideHandler = asyncInt.value   # binder still active
+      check observedInsideHandler == 88
+      return asyncInt.value         # binder reverted on normal exit
+
+    check waitFor(driver()) == 0
+
+template pinsCaptureSite(testName: string, bindValue: int, expected: int,
+                          registration: untyped) =
+  ## Owns the seenBinding/fired/driver scaffolding shared by the
+  ## scheduling-site capture-coverage tests below, which differ only in
+  ## their registration statement and the value bound at the registrant's
+  ## call site (and, for the context-blind trampoline, in the expected
+  ## value observed at fire time).
+  test testName:
+    var seenBinding = -1
+    var fired = false
+
+    proc cb(udata: pointer) {.gcsafe, raises: [], inject.} =
+      seenBinding = asyncInt.value
+      fired = true
+
+    proc driver(): Future[void] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(bindValue):
+        registration
+        while not fired:
+          await sleepAsync(1.milliseconds)
+
+    waitFor(driver())
+    check seenBinding == expected
+
+suite "contextvars: scheduling-site capture coverage":
+
+  pinsCaptureSite("callSoon callback fires with the registrant's binding",
+                   789, 789):
+    callSoon(cb, nil)
+
+  test "sleepAsync callback fires with the registrant's binding":
+    # Pinned explicitly as a regression guard on setTimer's construction site.
+    proc driver(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(456):
+        await sleepAsync(1.milliseconds)
+        return asyncInt.value
+    check waitFor(driver()) == 456
+
+  pinsCaptureSite("internalCallTick is context-blind (internal trampoline)",
+                   123, 0):
+    # Internal scheduling sites use bareCallback (no context capture), so a
+    # callback scheduled from inside asyncInt.withValue(123) must see the default.
+    internalCallTick(cb, nil)
+
+  pinsCaptureSite(
+      "internalCallTick(capturingCallback(...)) fires with the registrant's binding",
+      135, 135):
+    # internalCallTick's AsyncCallback overload leaves the capture choice to
+    # the caller; capturingCallback() is the documented opt-in counterpart
+    # to the context-blind trampoline pinned above.
+    internalCallTick(capturingCallback(cb, nil))
+
+  pinsCaptureSite("callIdle callback fires with the registrant's binding",
+                   321, 321):
+    callIdle(cb, nil)
+
+  when not defined(windows):
+    # addReader/addWriter/addSignal2/addProcess2 are POSIX-selector APIs;
+    # Windows equivalents go through separate IOCP paths.
+
+    test "addReader callback fires with the registrant's binding":
+      var seenBinding = -1
+      var fired = false
+      let (rfd, wfd) = createAsyncPipe()
+      proc onReadable(udata: pointer) {.gcsafe, raises: [].} =
+        seenBinding = asyncInt.value
+        fired = true
+
+      proc driver(): Future[void] {.async: (raises: [Exception]).} =
+        asyncInt.withValue(654):
+          register(rfd)
+          addReader(rfd, onReadable)
+          # Poke the write end to make the read end readable.
+          let buf = "x"
+          discard posix.write(cint(wfd), unsafeAddr buf[0], 1)
+          while not fired:
+            await sleepAsync(1.milliseconds)
+          removeReader(rfd)
+        closeSocket(rfd)
+        closeSocket(wfd)
+      waitFor(driver())
+      check seenBinding == 654
+
+    test "addWriter callback fires with the registrant's binding":
+      # An empty pipe's write end is immediately writable, so the callback
+      # fires on the next poll tick.
+      var seenBinding = -1
+      var fired = false
+      let (rfd, wfd) = createAsyncPipe()
+      proc onWritable(udata: pointer) {.gcsafe, raises: [].} =
+        seenBinding = asyncInt.value
+        fired = true
+
+      proc driver(): Future[void] {.async: (raises: [Exception]).} =
+        asyncInt.withValue(655):
+          register(wfd)
+          addWriter(wfd, onWritable)
+          while not fired:
+            await sleepAsync(1.milliseconds)
+          removeWriter(wfd)
+        closeSocket(rfd)
+        closeSocket(wfd)
+      waitFor(driver())
+      check seenBinding == 655
+
+    when chronosEventEngine in ["epoll", "kqueue"]:
+      # Signal/process registration exists on the epoll/kqueue engines
+      # only - same gate testall.nim applies to testsignal/testproc.
+      test "addSignal2 handler fires with the registrant's binding":
+        var seenBinding = -1
+        var sigFd: SignalHandle
+        let handlerFut = newFuture[void]("ctx.signal.handler")
+        proc signalHandler(udata: pointer) {.gcsafe.} =
+          seenBinding = asyncInt.value
+          let res = removeSignal2(sigFd)
+          if res.isErr():
+            handlerFut.fail(newException(ValueError, osErrorMsg(res.error())))
+          else:
+            handlerFut.complete()
+
+        proc driver(): Future[void] {.async: (raises: [Exception]).} =
+          asyncInt.withValue(456):
+            sigFd =
+              block:
+                let res = addSignal2(SIGUSR1, signalHandler)
+                if res.isErr():
+                  raiseAssert osErrorMsg(res.error())
+                res.get()
+            discard posix.kill(posix.getpid(), cint(SIGUSR1))
+            await handlerFut.wait(5.seconds)
+        waitFor(driver())
+        check seenBinding == 456
+
+      test "addProcess2 handler fires with the registrant's binding":
+        var seenBinding = -1
+        var pidFd: ProcessHandle
+        let handlerFut = newFuture[void]("ctx.process.handler")
+        var process: AsyncProcessRef
+        proc processHandler(udata: pointer) {.gcsafe.} =
+          seenBinding = asyncInt.value
+          let res = removeProcess2(pidFd)
+          if res.isErr():
+            handlerFut.fail(newException(ValueError, osErrorMsg(res.error())))
+          else:
+            handlerFut.complete()
+
+        proc driver(): Future[void] {.async: (raises: [Exception]).} =
+          process = await startProcess("sleep 0.3",
+                                       options = {AsyncProcessOption.EvalCommand})
+          try:
+            asyncInt.withValue(789):
+              pidFd =
+                block:
+                  let res = addProcess2(process.pid(), processHandler)
+                  if res.isErr():
+                    raiseAssert osErrorMsg(res.error())
+                  res.get()
+              await handlerFut.wait(5.seconds)
+          finally:
+            await process.closeWait()
+        waitFor(driver())
+        check seenBinding == 789
+
+  test "race() resolver fires with the awaiter's binding":
+    proc child(value: int, delayMs: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(delayMs.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(111):
+        let fa = child(222, 1)
+        let fb = child(333, 50)
+        discard await race(FutureBase(fa), FutureBase(fb))
+        let observed = asyncInt.value
+        # Drain the loser so it doesn't leak into testutils' pending check.
+        await fb.cancelAndWait()
+        return observed
+
+    check waitFor(driver()) == 111
+
+  test "allFutures() continuation fires with the awaiter's binding":
+    proc child(value: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(1.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(222):
+        let fa = child(444)
+        let fb = child(555)
+        await allFutures(fa, fb)
+        return asyncInt.value
+
+    check waitFor(driver()) == 222
+
+  test "wait(duration) resumes the awaiter under its own binding":
+    proc child(value: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(1.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(31):
+        check (await child(32).wait(1.seconds)) == 32
+        return asyncInt.value
+
+    check waitFor(driver()) == 31
+
+  test "wait(deadline future) resumes the awaiter under its own binding":
+    # Routes through waitUntilImpl, a separate path from the duration variant.
+    proc child(value: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(1.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(36):
+        let deadline = sleepAsync(1.seconds)
+        check (await child(37).wait(deadline)) == 37
+        await deadline.cancelAndWait()
+        return asyncInt.value
+
+    check waitFor(driver()) == 36
+
+  test "withTimeout() resumes the awaiter under its own binding":
+    proc child(value: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(1.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(41):
+        let fut = child(42)
+        check (await fut.withTimeout(1.seconds)) == true
+        check fut.read() == 42
+        return asyncInt.value
+
+    check waitFor(driver()) == 41
+
+  test "`or` resumes the awaiter under its own binding":
+    proc child(value: int, delayMs: int): Future[void] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(delayMs.milliseconds)
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(51):
+        let fa = child(52, 1)
+        let fb = child(53, 50)
+        await fa or fb
+        let observed = asyncInt.value
+        # Drain the loser so it doesn't trip testutils' pending check.
+        await fb.cancelAndWait()
+        return observed
+
+    check waitFor(driver()) == 51
+
+  test "join() resumes the awaiter under its own binding":
+    proc child(value: int): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncInt.withValue(value):
+        await sleepAsync(1.milliseconds)
+        return value
+
+    proc driver(): Future[int] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(61):
+        let fut = child(62)
+        await fut.join()
+        check fut.read() == 62
+        return asyncInt.value
+
+    check waitFor(driver()) == 61
+
+  pinsCaptureSite("closeHandle aftercb fires with the registrant's binding",
+                   987, 987):
+    # Tested separately from closeSocket: closeHandle has its own IOCP
+    # path on Windows.
+    let (rfd, wfd) = createAsyncPipe()
+    closeHandle(rfd, cb)
+    closeHandle(wfd)
+
+  pinsCaptureSite("closeSocket aftercb fires with the registrant's binding",
+                   321, 321):
+    let (rfd, wfd) = createAsyncPipe()
+    closeSocket(rfd, cb)
+    closeSocket(wfd)
+
+  test "cancelSoon's already-finished branch fires aftercb with the registrant's binding":
+    # When `future` is already finished at call time, cancelSoon skips the
+    # cancel-and-await path and schedules aftercb directly via
+    # callSoon(capturingCallback(aftercb, udata)) at the cancelSoon call
+    # site itself - a different capture site from the pending-future path
+    # pinned in the cancelCallback suite below.
+    var seenBinding = -1
+    var fired = false
+
+    let fut = newFuture[void]("already-finished-cancelsoon")
+    fut.complete()
+    check fut.finished()
+
+    proc aftercb(udata: pointer) {.gcsafe, raises: [].} =
+      seenBinding = asyncInt.value
+      fired = true
+
+    asyncInt.withValue(741):
+      cancelSoon(fut, aftercb, nil)
+
+    asyncInt.withValue(742):
+      poll()
+
+    check fired
+    check seenBinding == 741
+
+  test "cancelSoon(AsyncCallback) fires under the callback's own captured binding":
+    # Unlike the CallbackFunc/pointer overload above, this overload takes
+    # an already-built AsyncCallback - it must fire under the binding live
+    # when that AsyncCallback was constructed, not whatever is ambient at
+    # the cancelSoon() call site or when the future is later polled.
+    var seenBinding = -1
+    var fired = false
+
+    proc aftercb(udata: pointer) {.gcsafe, raises: [].} =
+      seenBinding = asyncInt.value
+      fired = true
+
+    var acb: AsyncCallback
+    asyncInt.withValue(111):
+      acb = capturingCallback(aftercb, nil)
+
+    let fut = newFuture[void]("already-finished-cancelsoon-acb")
+    fut.complete()
+    check fut.finished()
+
+    asyncInt.withValue(222):
+      cancelSoon(fut, acb)
+
+    asyncInt.withValue(333):
+      poll()
+
+    check fired
+    check seenBinding == 111
+
+  test "cancelSoon(AsyncCallback)'s pending branch fires under the callback's own captured binding":
+    # Sibling of the already-finished pin above: here `future` is still
+    # pending when cancelSoon() registers `acb`, so it travels through the
+    # cancel-and-await path (internalCallback/tryCancel) rather than the
+    # direct callSoon() the already-finished branch takes. `acb`'s own
+    # captured binding must still be what fires, not the binding live at
+    # the cancelSoon() call site or at poll() time.
+    var seenBinding = -1
+    var fired = false
+
+    proc aftercb(udata: pointer) {.gcsafe, raises: [].} =
+      seenBinding = asyncInt.value
+      fired = true
+
+    var acb: AsyncCallback
+    asyncInt.withValue(211):
+      acb = capturingCallback(aftercb, nil)
+
+    let fut = newFuture[void]("pending-cancelsoon-acb")
+    check not fut.finished()
+
+    asyncInt.withValue(322):
+      cancelSoon(fut, acb)
+
+    asyncInt.withValue(433):
+      while not fired:
+        poll()
+
+    check fired
+    check seenBinding == 211
+    check fut.cancelled()
+
+suite "contextvars: bridging independent callbacks":
+
+  test "currentContext()/withContext() bridges independent callbacks":
+    # An enter hook and a separately-fired exit hook share no await or call
+    # stack, so no binder spans them; currentContext()/withContext() bridge
+    # the two explicitly via a caller-held snapshot.
+    var snapshot: AsyncContext
+    var enterRan = false
+    var exitObserved = -1
+
+    proc enterCb(udata: pointer) {.gcsafe, raises: [].} =
+      asyncInt.withValue(42):
+        snapshot = currentContext()
+      enterRan = true
+
+    proc exitCb(udata: pointer) {.gcsafe, raises: [].} =
+      withContext(snapshot):
+        exitObserved = asyncInt.value
+
+    callSoon(enterCb, nil)
+    poll()
+    check enterRan
+
+    callSoon(exitCb, nil)
+    poll()
+    check exitObserved == 42
+
+suite "contextvars: cancelCallback capture":
+
+  test "cancelCallback observes the registrant's binding, not the canceller's":
+    var seenBinding = ""
+    var fired = false
+
+    let fut = newFuture[void]("owner-future")
+    asyncStr.withValue("owner"):
+      fut.cancelCallback = proc(_: pointer) {.gcsafe, raises: [].} =
+        seenBinding = asyncStr.value
+        fired = true
+
+    asyncStr.withValue("canceller"):
+      discard tryCancel(fut)
+
+    check fired
+    check seenBinding == "owner"
+
+  test "cancelCallback observes the registrant's binding through cancelSoon's checktick retry":
+    # OwnCancelSchedule means tryCancel won't auto-cancel; onCancel defers
+    # cancellation to its second call, forcing a context-blind checktick
+    # retry. The registrant's "owner" binding must hold on both invocations.
+    var observed: seq[string]
+
+    let fut = newFuture[void]("owner-future-checktick",
+                              {FutureFlag.OwnCancelSchedule})
+
+    proc onCancel(_: pointer) {.gcsafe, raises: [].} =
+      observed.add asyncStr.value
+      if observed.len >= 2:
+        fut.cancelAndSchedule()
+
+    asyncStr.withValue("owner"):
+      fut.cancelCallback = onCancel
+
+    proc driver(): Future[void] {.async: (raises: [CancelledError]).} =
+      asyncStr.withValue("canceller"):
+        cancelSoon(fut)
+        while not fut.finished():
+          await sleepAsync(1.milliseconds)
+
+    waitFor(driver())
+    check observed == @["owner", "owner"]
+
+  test "cancelCallback with no contextvars anywhere still cancels (nil context)":
+    var fired = false
+
+    let fut = newFuture[void]("no-context-future")
+    fut.cancelCallback = proc(_: pointer) {.gcsafe, raises: [].} =
+      fired = true
+
+    check tryCancel(fut)
+    check fired
+    check fut.cancelled()
+
+  test "cancelCallback fast arm fires cleanly while an unrelated task is parked mid-binder elsewhere":
+    # The fast arm must observe only its own captured context and must not
+    # clobber the nil ambient state a parked task's suspend already restored.
+    let parkedWaiter = newFuture[void]("parked-waiter")
+    var parkedObserved = -2
+
+    proc parked(): Future[void] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(777):
+        await parkedWaiter          # suspends INSIDE the binder
+        parkedObserved = asyncInt.value
+
+    let parkedFut = parked()        # suspends mid-binder; ambient restored to nil
+    check asyncInt.value == 0           # confirms no leak from `parked`'s entry
+
+    var fired = false
+    let fut = newFuture[void]("cancel-future")
+    fut.cancelCallback = proc(_: pointer) {.gcsafe, raises: [].} =
+      check asyncInt.value == 0         # own captured (nil) context, not 777
+      fired = true
+
+    check tryCancel(fut)            # fires while `parked` sits suspended
+    check fired
+    check fut.cancelled()
+    check asyncInt.value == 0           # still clean after the cancel fires
+
+    parkedWaiter.complete()
+    waitFor parkedFut
+    check parkedObserved == 777     # parked's own binding, undisturbed
+
+suite "contextvars: fast-path pins":
+  # Regression pins for withRestoredContext's identity fast arm (no write)
+  # vs. its slow arm (write + restore).
+
+  test "interleaved fast/slow-arm callbacks in one poll batch each observe their own context":
+    # Alternates fast-arm (nil capture) and slow-arm (bound capture) callbacks
+    # in one batch; each must observe its own value regardless of arm order.
+    var seen: seq[int]
+
+    proc recordCb(udata: pointer) {.gcsafe, raises: [].} =
+      seen.add asyncInt.value
+
+    callSoon(recordCb, nil)          # nil capture -> fast arm (nil == nil)
+    asyncInt.withValue(11):
+      callSoon(recordCb, nil)        # 11 capture  -> slow arm
+    callSoon(recordCb, nil)          # nil capture -> fast arm
+    asyncInt.withValue(22):
+      callSoon(recordCb, nil)        # 22 capture  -> slow arm
+    asyncInt.withValue(33):
+      callSoon(recordCb, nil)        # 33 capture  -> slow arm
+    callSoon(recordCb, nil)          # nil capture -> fast arm
+
+    poll()
+    check seen == @[0, 11, 0, 22, 33, 0]
+
+  test "bind-and-raise on the fast arm leaves the ambient context clean after the batch":
+    # The callback binds then raises a Defect (CallbackFunc is raises: []).
+    # withValue's own finally must still unwind the binding even
+    # though the fast arm itself never wrote/restored currentAsyncContext.
+    proc raiser(udata: pointer) {.gcsafe, raises: [].} =
+      asyncInt.withValue(999):
+        doAssert false, "contextvars: intentional Defect to " &
+                         "exercise the fast-arm raise path"
+
+    callSoon(raiser, nil)
+    var caught = false
+    try:
+      poll()
+    except Defect:
+      caught = true
+    check caught
+    check asyncInt.value == 0
+
+  test "bind-and-raise on the slow arm restores the prior ambient context after the batch (fireWithContext)":
+    # Captured (111) and ambient (222) contexts differ at fire time, forcing
+    # the slow arm; the callback asserting asyncInt.value == 111 before raising
+    # proves the write ran.
+    proc raiser(udata: pointer) {.gcsafe, raises: [].} =
+      check asyncInt.value == 111       # proves the slow arm's write executed
+      doAssert false, "contextvars: intentional Defect to " &
+                       "exercise the slow-arm restore path (fireWithContext)"
+
+    asyncInt.withValue(111):
+      callSoon(raiser, nil)         # captured context = 111
+
+    asyncInt.withValue(222):               # ambient at fire time = 222 != 111
+      var caught = false
+      try:
+        poll()
+      except Defect:
+        caught = true
+      check caught
+      # The finally must restore the ambient context to 222, not leave it
+      # at the callback's captured value (111).
+      check asyncInt.value == 222
+    check asyncInt.value == 0
+
+  test "bind-and-raise on the slow arm restores the prior ambient context after cancellation (fireCancelCallback)":
+    # Same slow-arm restore contract as above, through the cancelCallback
+    # fire site instead of the regular callback fire site.
+    let fut = newFuture[void]("slow-arm-cancel")
+    proc raiserCancel(_: pointer) {.gcsafe, raises: [].} =
+      check asyncInt.value == 333       # proves the slow arm's write executed
+      doAssert false, "contextvars: intentional Defect to " &
+                       "exercise the slow-arm restore path (fireCancelCallback)"
+
+    asyncInt.withValue(333):
+      fut.cancelCallback = raiserCancel   # captured context = 333
+
+    asyncInt.withValue(444):               # ambient at fire time = 444 != 333
+      var caught = false
+      try:
+        discard tryCancel(fut)
+      except Defect:
+        caught = true
+      check caught
+      check asyncInt.value == 444
+    check asyncInt.value == 0
+
+    # The Defect from raiserCancel escapes before cancelAndSchedule runs, so
+    # fut is left permanently Pending, inflating testutils' future-count
+    # checks for later tests unless completed manually here.
+    fut.complete()
+
+  test "nil-captured resume through a suspended binder leaves the ambient context clean for a later same-batch callback":
+    # A yield inside withValue is a plain return, so withValue's finally
+    # does not run for it; the resume must still restore currentAsyncContext
+    # so callbacks queued behind it in the same batch don't see a leaked binding.
+    let outerWaiter = newFuture[void]("leak-repro.outer")
+    let innerWaiter = newFuture[void]("leak-repro.inner")
+    var innerObserved = -1
+    var laterSeenBinding = -1
+    var laterFired = false
+
+    proc leaky(): Future[void] {.async: (raises: [Exception]).} =
+      await outerWaiter               # captured with nil ambient context
+      asyncInt.withValue(999):
+        await innerWaiter             # the suspend point is inside withValue's
+                                       # dynamic extent, not before it
+        innerObserved = asyncInt.value
+
+    proc laterCb(udata: pointer) {.gcsafe, raises: [].} =
+      laterSeenBinding = asyncInt.value
+      laterFired = true
+
+    let fut = leaky()                 # synchronous run to `await outerWaiter`
+    outerWaiter.complete()            # queues leaky's resume (nil-context capture)
+    callSoon(laterCb, nil)            # queued behind the resume, same batch
+    poll()
+
+    check laterFired
+    check laterSeenBinding == 0       # not leaked from leaky's still-open binder
+
+    innerWaiter.complete()
+    waitFor fut
+    check innerObserved == 999
+    check fut.finished()
+
+  test "await inside withContext survives suspension and leaves ambient restored for a later same-batch callback":
+    # Same suspend hazard as the withValue pin above, but through the public
+    # currentContext()/withContext() bridge instead of the withValue binder.
+    var boundCtx: AsyncContext
+    asyncInt.withValue(999):
+      boundCtx = currentContext()
+
+    let outerWaiter = newFuture[void]("wc-leak-repro.outer")
+    let innerWaiter = newFuture[void]("wc-leak-repro.inner")
+    var innerObserved = -1
+    var laterSeenBinding = -1
+    var laterFired = false
+
+    proc leaky(): Future[void] {.async: (raises: [Exception]).} =
+      await outerWaiter               # captured with nil ambient context
+      withContext(boundCtx):
+        await innerWaiter             # suspends INSIDE withContext's body
+        innerObserved = asyncInt.value
+
+    proc laterCb(udata: pointer) {.gcsafe, raises: [].} =
+      laterSeenBinding = asyncInt.value
+      laterFired = true
+
+    let fut = leaky()                 # synchronous run to `await outerWaiter`
+    outerWaiter.complete()            # queues leaky's resume (nil-context capture)
+    callSoon(laterCb, nil)            # queued behind the resume, same batch
+    poll()
+
+    check laterFired
+    check laterSeenBinding == 0       # not leaked from leaky's still-open withContext
+
+    innerWaiter.complete()
+    waitFor fut
+    check innerObserved == 999        # the withContext binding survived the suspend
+    check fut.finished()
+
+suite "contextvars: scheduling scenario pins":
+  # Regression pins for scenarios not exercised by the earlier suites:
+  # nested reentrancy, cross-thread isolation, capture on a finished
+  # future, and stream-server transitive-fire-site coverage.
+
+  test "nested waitFor inside a running callback observes its own binding and leaves the outer callback's context intact":
+    # Only applies to default (non-strict) builds, where a nested waitFor
+    # from a plain callback is legal and pumps the dispatcher reentrantly.
+    # Must hold: inner work sees its own binding, not the outer's; the
+    # outer's binding is exactly restored after the nested waitFor returns;
+    # and a callback queued behind outerCb in the same batch sees an empty
+    # context either way.
+    when chronosStrictReentrancy:
+      skip()
+    else:
+      var innerObserved = -1
+      var outerAfterNested = -1
+      var outerFired = false
+      var laterSeenBinding = -1
+      var laterFired = false
+
+      proc innerWork(): Future[int] {.async: (raises: [CancelledError]).} =
+        asyncInt.withValue(999):
+          await sleepAsync(1.milliseconds)
+          return asyncInt.value
+
+      proc laterCb(udata: pointer) {.gcsafe, raises: [].} =
+        laterSeenBinding = asyncInt.value
+        laterFired = true
+
+      proc outerCb(udata: pointer) {.gcsafe, raises: [].} =
+        asyncInt.withValue(500):
+          check asyncInt.value == 500
+          try:
+            innerObserved = waitFor(innerWork())
+          except CancelledError:
+            discard
+          outerAfterNested = asyncInt.value
+        outerFired = true
+
+      callSoon(outerCb, nil)   # nil capture == nil ambient at fire -> fast arm
+      callSoon(laterCb, nil)   # queued behind outerCb, same top-level batch
+      poll()
+
+      check outerFired
+      check innerObserved == 999
+      check outerAfterNested == 500
+      check laterFired
+      check laterSeenBinding == 0
+
+  test "nested waitFor inside a running callback raises under chronosStrictReentrancy, leaving the outer callback's context intact":
+    # Strict-mode counterpart above: preparePoll asserts before draining, so
+    # the nested waitFor raises instead. The assert fires before any context
+    # is touched, so the outer callback's binding must survive untouched.
+    when chronosStrictReentrancy:
+      var outerAfterRaise = -1
+      var outerFired = false
+
+      proc innerWork(): Future[int] {.async: (raises: [CancelledError]).} =
+        asyncInt.withValue(999):
+          await sleepAsync(1.milliseconds)
+          return asyncInt.value
+
+      proc outerCb(udata: pointer) {.gcsafe, raises: [].} =
+        asyncInt.withValue(500):
+          check asyncInt.value == 500
+          expect(Defect):
+            discard waitFor(innerWork())
+          outerAfterRaise = asyncInt.value
+        outerFired = true
+
+      callSoon(outerCb, nil)   # nil capture == nil ambient at fire -> fast arm
+      poll()
+
+      check outerFired
+      check outerAfterRaise == 500
+    else:
+      skip()
+
+  test "two threads with independent dispatchers never observe each other's contextVar binding":
+    # currentAsyncContext is threadvar-based, and each thread gets its own
+    # dispatcher on first use, so binding the same contextVar to different
+    # values on two threads must never cross.
+    type ThreadArg = object
+      boundValue: int
+      resultPtr: ptr int
+      readyPtr: ptr bool
+
+    proc threadProc(arg: ThreadArg) {.thread, nimcall.} =
+      asyncInt.withValue(arg.boundValue):
+        proc work(): Future[int] {.async: (raises: [CancelledError]).} =
+          await sleepAsync(1.milliseconds)
+          return asyncInt.value
+        arg.resultPtr[] = waitFor(work())
+      arg.readyPtr[] = true
+
+    var resultA, resultB: int
+    var readyA, readyB: bool
+    var threadA: Thread[ThreadArg]
+    var threadB: Thread[ThreadArg]
+    createThread(threadA, threadProc,
+                 ThreadArg(boundValue: 111, resultPtr: addr resultA,
+                           readyPtr: addr readyA))
+    createThread(threadB, threadProc,
+                 ThreadArg(boundValue: 222, resultPtr: addr resultB,
+                           readyPtr: addr readyB))
+    joinThreads(threadA, threadB)
+
+    check readyA
+    check readyB
+    check resultA == 111
+    check resultB == 222
+
+  test "cross-thread callSoon() fires with an empty context and leaves the origin thread's own binding undisturbed":
+    # A cross-thread post is drained via bareCallback (no context capture,
+    # since a binding chain is thread-local memory that can't cross threads):
+    # the callback must see the default value, and the origin thread's own
+    # binding must be unchanged afterward.
+    type CrossThreadResult = object
+      seenBinding: int
+      fired: bool
+
+    proc crossThreadCb(udata: pointer) {.nimcall, gcsafe, raises: [].} =
+      let r = cast[ptr CrossThreadResult](udata)
+      r.seenBinding = asyncInt.value
+      r.fired = true
+
+    type ThreadArg = (DispatcherHandle, ptr CrossThreadResult)
+    proc threadProc(arg: ThreadArg) {.thread, nimcall.} =
+      callSoon(arg[0], crossThreadCb, cast[pointer](arg[1]))
+
+    var res: CrossThreadResult
+    let disp = getThreadDispatcher()
+
+    asyncInt.withValue(555):
+      var thread: Thread[ThreadArg]
+      createThread(thread, threadProc, (disp.handle(), addr res))
+      # Bounded-retry rather than a single poll(): a leftover non-empty
+      # queue from a prior test would otherwise race this call against
+      # however long the new thread takes to post.
+      #
+      # Each iteration also arms a cheap no-op wakeup timer first: an
+      # otherwise-idle poll() can block on an infinite OS wait, which
+      # would turn a real cross-thread-wake engine failure into a test
+      # hang instead of a bounded failure below.
+      let deadline = Moment.now() + 5.seconds
+      while not res.fired and Moment.now() < deadline:
+        discard setTimer(Moment.now() + 100.milliseconds,
+                         proc(_: pointer) {.gcsafe, raises: [].} = discard)
+        poll()
+
+      check res.fired
+      check res.seenBinding == 0     # DEFAULT - not leaked from the origin's 555
+      check asyncInt.value == 555        # origin thread's own binding undisturbed
+      joinThreads(thread)
+
+    check asyncInt.value == 0
+
+  test "addCallback on an already-finished future captures the caller's binding, not the completer's":
+    # An already-finished future's addCallback takes the immediate-dispatch
+    # branch: only the caller's binding at addCallback-time is captured.
+    var seenBinding = -1
+    var fired = false
+
+    let fut = newFuture[void]("already-finished")
+    asyncInt.withValue(111):
+      fut.complete()               # completed under binding 111
+
+    check fut.finished()
+
+    asyncInt.withValue(222):
+      fut.addCallback(proc(udata: pointer) {.gcsafe, raises: [].} =
+        seenBinding = asyncInt.value
+        fired = true
+      )
+
+    poll()
+    check fired
+    check seenBinding == 222       # the adder's binding, not the completer's
+
+  test "stream server handler observes the context bound at start()-time registration, not creation-time or connection-time":
+    # start() is what actually registers the accept callback (and captures
+    # its context); createStreamServer() only builds the object, and the
+    # handler is asyncSpawn'ed transitively from the accept callback's own
+    # frame. creation/registration/connection are bound to different values
+    # here to make a wrong capture site observable.
+    var seenBinding = -1
+    var handlerFired = false
+    let handlerDone = newFuture[void]("stream-handler-done")
+
+    proc handler(server: StreamServer,
+                 transp: StreamTransport) {.async: (raises: []).} =
+      seenBinding = asyncInt.value
+      handlerFired = true
+      transp.close()
+      handlerDone.complete()
+
+    let ta = initTAddress("127.0.0.1:0")
+    var server: StreamServer
+    asyncInt.withValue(111):
+      server = createStreamServer(ta, handler, {ReuseAddr})  # creation-time: 111
+
+    asyncInt.withValue(222):
+      server.start()                                         # registration-time: 222
+
+    proc driver(): Future[void] {.async: (raises: [Exception]).} =
+      asyncInt.withValue(333):                                     # connection-time: 333
+        var transp = await connect(server.localAddress())
+        await handlerDone.wait(5.seconds)
+        transp.close()
+
+    waitFor(driver())
+
+    check handlerFired
+    check seenBinding == 222       # start()-time registration binding
+
+    server.stop()
+    server.close()
+    waitFor(server.join())
+
+suite "contextvars: must-bind async propagation":
+
+  test "must-bind binding propagates across await exactly like a defaulted var":
+    # Must-bind arms use the same binder/dispatcher plumbing as asyncInt/
+    # asyncStr; only the reader differs (raise vs. default on a miss).
+    proc work(): Future[int] {.async: (raises: [CancelledError]).} =
+      check asyncReq.value == 17
+      await sleepAsync(1.milliseconds)
+      check asyncReq.value == 17
+      return asyncReq.value
+
+    proc driver(): Future[int] {.async: (raises: [CancelledError]).} =
+      asyncReq.withValue(17):
+        return await work()
+
+    check waitFor(driver()) == 17
+
+  test "must-bind read with no binder anywhere, including across await, raises":
+    proc work(): Future[void] {.async: (raises: [CancelledError]).} =
+      await sleepAsync(1.milliseconds)
+      expect(UnboundContextVarDefect):
+        discard asyncReq.value
+
+    waitFor(work())
+

--- a/tests/testcontextvarsbalance.nim
+++ b/tests/testcontextvarsbalance.nim
@@ -1,0 +1,32 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Suite-final contextvars binder-balance check, split out of
+## testutils.nim so it runs on every engine — testutils.nim itself is
+## only imported when `chronosEventEngine` is epoll/kqueue/windows
+## (see testall.nim), which skips the `poll` engine entirely. Imported
+## unconditionally, last, in testall.nim.
+
+import unittest2
+import ../chronos/contextvars
+
+{.used.}
+
+suite "contextvars: suite-final binder balance":
+
+  test "contextvars binder balance (no leaked bindings)":
+    when defined(chronosDebug):
+      # `withValue` increments `chainBalance` at push, decrements at
+      # pop. A nonzero count at suite end means some `withValue` pushed
+      # a chain node without popping.
+      check chainBalance == 0
+      # Chain must also be empty at top-level (no test left a leaked
+      # binding in `currentAsyncContext`).
+      check chainLen() == 0
+    else:
+      skip()

--- a/tests/testcontextvarscrossthread.nim
+++ b/tests/testcontextvarscrossthread.nim
@@ -1,0 +1,94 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## The automatic cross-thread construction guard
+## (chronos/contextvars.nim, `newContextVar`/`newRequiredContextVar`'s
+## unconditional thread-generation check) — split out like
+## tests/testcontextvarslock.nim and tests/testcontextvarsleakguard.nim,
+## and run alongside them from tests/testcontextvarsstandalone.nim:
+## isolated per-process in CI via the driver's orchestrate mode, so it no
+## longer matters whether this file's construction runs inside a
+## dispatcher a prior suite left unsound, or ahead of the lock suite.
+## Import order among the three only matters for the driver's no-args
+## single-process mode, where this file must still run between the
+## other two for the same reasons.
+##
+## Actually constructing a context variable key from a second thread is
+## a genuine `--mm:refc` GC hazard (see docs/src/contextvars.md,
+## "Registry and key lifetime") — the guard this file tests is what
+## turns that hazard into a caught `AssertionDefect` instead, and it now
+## runs in every build, not only under `chronosDebug`.
+
+import unittest2
+import ../chronos/contextvars
+
+{.used.}
+
+const contextVarsCrossThreadSuiteName* =
+  "contextvars (raw key): cross-thread construction detection"
+
+suite contextVarsCrossThreadSuiteName:
+
+  test "newContextVar on a second thread trips the automatic thread-generation guard; registry stays intact":
+    # Construct on the main thread first: the guard records whichever
+    # thread constructs first as "the" thread. In the driver's orchestrate
+    # mode this suite runs alone in its own child process, so without
+    # this seed the child thread below would race the main thread for
+    # that role instead of reliably exercising it as the violator.
+    discard newContextVar("crossThreadMainThreadSeed", 0)
+
+    var fired = false
+
+    proc constructOnOtherThread(firedAddr: ptr bool) {.thread, nimcall.} =
+      try:
+        {.cast(gcsafe).}:
+          discard newContextVar("crossThreadKey", 1)
+      except AssertionDefect:
+        firedAddr[] = true
+
+    var otherThread: Thread[ptr bool]
+    createThread(otherThread, constructOnOtherThread, addr fired)
+    joinThread(otherThread)
+
+    check fired
+
+    # The failed cross-thread construction must not have reached the
+    # registry mutation: a subsequent main-thread construction still
+    # succeeds, which would not be reliable if the guard fired only
+    # after registerVar() already ran.
+    let k = newContextVar("afterCrossThreadAttempt", 2)
+    check k.value == 2
+
+  test "two sequential child threads each trip the guard, not only the first":
+    # Pins that the guard keeps firing for every later violating thread,
+    # not just the one that happens to run first — both threads here are
+    # seeded against the same main-thread recorder from above, so this
+    # is repeated-firing coverage, not a pin on recorder identity itself
+    # (see tests/testcontextvarsrecorderdeath.nim for the recycled-OS-id
+    # hazard, which needs a dead recording thread to exercise).
+    discard newContextVar("sequentialThreadsMainSeed", 0)
+
+    proc constructOnChildThread(firedAddr: ptr bool) {.thread, nimcall.} =
+      try:
+        {.cast(gcsafe).}:
+          discard newContextVar("sequentialThreadsKey", 1)
+      except AssertionDefect:
+        firedAddr[] = true
+
+    var firedA = false
+    var threadA: Thread[ptr bool]
+    createThread(threadA, constructOnChildThread, addr firedA)
+    joinThread(threadA)
+
+    var firedB = false
+    var threadB: Thread[ptr bool]
+    createThread(threadB, constructOnChildThread, addr firedB)
+    joinThread(threadB)
+
+    check firedA
+    check firedB

--- a/tests/testcontextvarsexport.nim
+++ b/tests/testcontextvarsexport.nim
@@ -1,0 +1,89 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Cross-module test for `{.contextVar.}`'s export-marker semantics:
+## `let name* {.contextVar.} = v` must produce a key reachable from an
+## importing module, while `let name {.contextVar.} = v` (no star) must
+## be unreachable by name — and, symmetrically, the raw constructor's
+## `private` param must be verified independent of that export marker.
+##
+## Uses a real second module (`contextvarsexportfixture.nim`) rather than
+## same-module `declared()` checks, since visibility only differs across
+## module boundaries.
+
+import unittest2
+import ../chronos/contextvars  # currentContext, AsyncContext, dumpContext
+import ./contextvarsexportfixture
+
+{.used.}
+
+when (NimMajor, NimMinor) >= (2, 0):
+  # `{.contextVar.}` is 2.x-only (see contextvarsexportfixture.nim) — the
+  # export-marker semantics it's responsible for can only be exercised
+  # where the pragma itself exists.
+  static:
+    doAssert declared(exportedVar),
+      "a starred key declared via {.contextVar.} must be reachable from " &
+      "an importing module"
+    doAssert not declared(privateVar),
+      "a non-starred key declared via {.contextVar.} must NOT be " &
+      "reachable from an importing module"
+    doAssert not declared(setExportedVar),
+      "the {.contextVar.} pragma must not generate an imperative setter " &
+      "or any other derived identifier — see the one-symbol-emission " &
+      "guardrail in testcontextvars.nim"
+
+  suite "contextvars: export marker (cross-module)":
+
+    test "starred key's value/withValue are callable from another module":
+      exportedVar.withValue(42):
+        check exportedVar.value == 42
+      check exportedVar.value == 1
+
+    test "starred key's snapshot access is callable from another module":
+      exportedVar.withValue(7):
+        let snap = currentContext()
+        check snap[exportedVar] == 7
+
+    test "non-starred key is invisible to dumpContext from an importing module":
+      # privateVar is registered (if at all) from contextvarsexportfixture.nim,
+      # not here — the module-private contract requires it to be absent from
+      # this module's dumpContext output too, not just unreachable by name.
+      let entries = dumpContext(currentContext())
+      for e in entries:
+        check e.name != "privateVar"
+
+    test "starred key IS visible to dumpContext from an importing module":
+      # Control: proves the check above isn't vacuous (registration works
+      # at all across the module boundary for the starred sibling key).
+      let entries = dumpContext(currentContext())
+      var found = false
+      for e in entries:
+        if e.name == "exportedVar":
+          found = true
+      check found
+
+static:
+  doAssert not declared(rawUnexportedRegistered),
+    "an unexported raw-constructed key must not be reachable by name " &
+    "from an importing module either — Nim's own export rules govern " &
+    "reachability regardless of the constructor's `private` argument"
+
+suite "contextvars: raw-constructor privacy decoupling (cross-module)":
+
+  test "unexported raw-constructed key registered with private=false still appears in another module's dumpContext":
+    # The export-decoupling negative case, pinned as intentional: the
+    # raw constructor's `private` param is an ordinary value argument,
+    # entirely decoupled from the enclosing `let`'s own export marker.
+    # See docs/src/contextvars.md, "Privacy and the raw constructor".
+    let entries = dumpContext(currentContext())
+    var found = false
+    for e in entries:
+      if e.name == "rawUnexportedRegistered":
+        found = true
+    check found

--- a/tests/testcontextvarsguardrails.nim
+++ b/tests/testcontextvarsguardrails.nim
@@ -1,0 +1,428 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Drift-detection guardrails for chronos's continuation-local storage
+## feature.
+##
+## Two orthogonal halves: guardrails 1-9 pin representation/identity
+## properties of the `ContextVar[T]` key runtime
+## (`chronos/contextvars.nim`) — ref identity, field privacy, absence of
+## an imperative API, chain-node unreachability, `std/tables` coexistence,
+## name-string drift, non-aliasing, and the positive inverse of the old
+## macro design's collision guardrail. The callback-capture-discipline
+## guardrails after them are substrate-level — orthogonal to the API and
+## carried over unchanged from before this redesign.
+##
+## Each check is a compile-time assertion (`static:` / `when compiles`)
+## or, where the guardrail is semantic rather than structural, a runtime
+## assertion — with a control assertion first wherever a bare `not
+## compiles` could otherwise be vacuous (e.g. a typo'd field name).
+
+import std/[sequtils, tables]
+import unittest2
+import ../chronos/contextvars
+import ../chronos/internal/contextnode
+  # Whitebox: guardrails 5 and 11 below name `ContextNodeBase` directly,
+  # which `chronos/contextvars.nim` no longer re-exports (see guardrail
+  # 11) — those checks import the internal module the same way an
+  # attacker attempting the forgery in guardrail 11 would have to.
+import ../chronos
+  # Brings `withTimeout` into scope for guardrail 9 below, and
+  # InternalAsyncCallback/AsyncCallback/InternalCancelCallback/
+  # CompletionData for the capture-discipline guardrails.
+
+{.used.}
+
+# --- Guardrail 1: ContextVar[T] is ref ---------------------------------------
+#
+# Ref identity IS key identity (see docs/src/contextvars.md,
+# "Implementation"): aliases compare equal, keys work in Table/seq for
+# free, and a default-initialized `nil` key is a detectable invalid
+# state. A value `object` key was rejected for exactly this reason.
+
+static:
+  doAssert ContextVar[int] is ref,
+    "ContextVar[T] must be a `ref object` — ref identity is key " &
+    "identity; a value object would let a copy silently break it."
+  doAssert ContextVarBase is ref,
+    "ContextVarBase must be a `ref object` too — ContextVar[T] " &
+    "inherits it, so the base carries the same identity guarantee."
+
+# --- Guardrail 2: no public mutable fields -----------------------------------
+#
+# `name`/`hasDefault`/`private` are exposed as read-only accessor procs
+# (same spelling as the private field names, so `cv.name` etc. still
+# reads via UFCS); `render`/`default`/the registry link
+# (`nextRegistered`) are not reachable at all outside
+# chronos/contextvars.nim. A writable field here would let user code
+# corrupt a key after construction — e.g. rewrite `render` to defeat
+# `dumpContext`, or flip `hasDefault` to bypass `UnboundContextVarDefect`.
+# This is also the successor to the old macro design's registry-field
+# guardrail (`ContextVarRegistration.registered`/`.next`): the new
+# registry has no separate node type, just this one private link field
+# on `ContextVarBase` itself, so its privacy is pinned here rather than
+# in a dedicated registry guardrail.
+
+static:
+  # Controls: reads must still compile, or the write probes below
+  # would be vacuous (indistinguishable from a typo'd field name).
+  doAssert compiles((let k = newContextVar("g2CtlName", 0); discard k.name)),
+    "control: `.name` must be readable — if this fails, the write " &
+    "probe below isn't probing what it claims to."
+  doAssert compiles((let k = newContextVar("g2CtlHasDefault", 0); discard k.hasDefault)),
+    "control: `.hasDefault` must be readable."
+  doAssert compiles((let k = newContextVar("g2CtlPrivate", 0); discard k.private)),
+    "control: `.private` must be readable."
+
+  doAssert not compiles((let k = newContextVar("g2Name", 0); k.name = "evil")),
+    "ContextVar[T].name must not be writable — it's a read-only " &
+    "accessor over a private field."
+  doAssert not compiles((let k = newContextVar("g2HasDefault", 0); k.hasDefault = false)),
+    "ContextVar[T].hasDefault must not be writable — flipping it " &
+    "post-construction would desync a must-bind key from its Defect."
+  doAssert not compiles((let k = newContextVar("g2Private", 0); k.private = true)),
+    "ContextVar[T].private must not be writable — flipping it " &
+    "post-construction wouldn't retroactively (un)register the key, " &
+    "so a writable field would make `.private` lie about registration."
+  doAssert not compiles((let k = newContextVar("g2Default", 0); k.default = 1)),
+    "ContextVar[T].default must not be reachable at all outside this " &
+    "module — it's on the RFC's public-surface Forbidden list."
+  doAssert not compiles((let k = newContextVar("g2Render", 0); k.render = nil)),
+    "ContextVarBase.render must not be reachable at all outside this " &
+    "module — a writable render hook would let user code corrupt " &
+    "dumpContext's output for a key it doesn't own."
+  doAssert not compiles((let k = newContextVar("g2Registry", 0); k.nextRegistered = nil)),
+    "ContextVarBase.nextRegistered (the intrusive registry link) must " &
+    "not be reachable at all outside this module — a writable link " &
+    "would let user code splice or unlink registry nodes."
+
+# --- Guardrail 3: no custom `==` on ContextVar -------------------------------
+#
+# Chain-node dispatch (the `[]` walk) depends on ref-identity
+# comparison; a value-based `==` would silently alias two distinct
+# keys constructed with the same arguments.
+
+type
+  G3UnrelatedRef = ref object
+    tag: int
+
+static:
+  doAssert not compiles(newContextVar("g3Unrelated", 0) == G3UnrelatedRef(tag: 1)),
+    "ContextVar must not compare equal to an unrelated ref type — no " &
+    "accidental converter or structural `==` should bridge the two " &
+    "hierarchies."
+
+suite "contextvars guardrails: g3 no custom ==":
+  test "two identically-constructed same-T keys compare unequal (ref identity)":
+    let k1 = newContextVar("g3Key", 0)
+    let k2 = newContextVar("g3Key", 0)
+    check k1 != k2
+
+# --- Guardrail 4: imperative set/reset stays absent --------------------------
+#
+# Binding is block-scoped only (`withValue`); no imperative token API.
+# `reset`/`set` can't be probed via `declared()` the way an absent
+# surface symbol normally would (`system.reset` makes `declared(reset)`
+# true in every module — see testcontextvarssurface.nim's note), so the
+# probe is call-shape instead: none of these verb-shaped calls with a
+# value argument may resolve against `ContextVar[T]`.
+
+static:
+  doAssert not compiles((let k = newContextVar("g4Set", 0); k.set(1))),
+    "ContextVar[T] must not have an imperative `set` — binding is " &
+    "block-scoped only via `withValue`."
+  doAssert not compiles((let k = newContextVar("g4Reset", 0); k.reset(1))),
+    "ContextVar[T] must not have an imperative `reset` taking a value."
+  doAssert not compiles((let k = newContextVar("g4Push", 0); k.push(1))),
+    "ContextVar[T] must not have a `push`-shaped imperative call."
+  doAssert not compiles((let k = newContextVar("g4Pop", 0); k.pop(1))),
+    "ContextVar[T] must not have a `pop`-shaped imperative call."
+  doAssert not compiles((let k = newContextVar("g4Free", 0); set(k, 1))),
+    "free-function `set(cv, v)` must not resolve either — same probe, " &
+    "non-UFCS call shape."
+
+# --- Guardrail 5: chain-node construction and `next` access unreachable -----
+#
+# `ContextNode`/`ContextNodeKeyed` are both unexported: neither name
+# resolves outside chronos/contextvars.nim at all, so there is no
+# `cast`-free way to construct a node or reach its `next`. Successor to
+# the old macro design's chain-privacy guardrail, which depended on
+# declaring a `contextVar` arm to obtain a nameable slot subtype to
+# probe through — first-class keys have no such subtype at all, so the
+# probe is simpler: the node types themselves are unnameable.
+# `ContextNodeBase.next` (the inherited field) stays private to
+# contextnode.nim unchanged — that half of the guardrail predates this
+# redesign.
+
+static:
+  doAssert not compiles(ContextNode[int]),
+    "ContextNode[T] must not be nameable outside chronos/contextvars.nim."
+  doAssert not compiles(ContextNodeKeyed),
+    "ContextNodeKeyed must not be nameable outside chronos/contextvars.nim either."
+  doAssert not compiles((var n: ContextNodeBase; n.next = n)),
+    "ContextNodeBase.next must stay unwritable from outside " &
+    "chronos/internal/contextnode.nim — unchanged by this redesign, " &
+    "reconfirmed here because it's the field the whole guardrail " &
+    "protects."
+  doAssert not compiles((var n: ContextNodeBase; discard n.next)),
+    "ContextNodeBase.next must stay unreadable from outside " &
+    "chronos/internal/contextnode.nim either."
+
+# --- Guardrail 6: std/tables.withValue coexistence (pinned decision 1) ------
+#
+# Overloads dispatch on receiver type, ordinary stdlib verb-sharing à
+# la `len`/`[]` — not a compile hazard. Compiles a module importing
+# both std/tables and chronos/contextvars, calling both `withValue`s
+# side by side, including once from inside a generic proc.
+
+proc g6GenericRoundtrip[T](cv: ContextVar[T], v: T): T =
+  cv.withValue(v):
+    result = cv.value
+
+suite "contextvars guardrails: g6 std/tables.withValue coexistence":
+  test "Table.withValue and ContextVar.withValue compile and behave side by side":
+    let cv = newContextVar("g6Key", 0)
+    var t = {"a": 1}.toTable
+
+    t.withValue("a", v):
+      v[] = 99
+
+    cv.withValue(7):
+      check cv.value == 7
+      check t["a"] == 99
+
+    check g6GenericRoundtrip(cv, 55) == 55
+
+# --- Guardrail 7: name-string drift -------------------------------------------
+#
+# The raw constructor's `name` argument is the DRY wart accepted for
+# non-sugar call sites; this guardrail pins that the string surfaces
+# verbatim, unmangled, on both consumers: dumpContext and
+# UnboundContextVarDefect.varName.
+
+suite "contextvars guardrails: g7 name-string drift":
+  test "raw-constructor name surfaces verbatim in dumpContext":
+    let k = newContextVar("rawNamed", 0, private = false)
+    let entries = dumpContext(currentContext()).filterIt(it.name == "rawNamed")
+    check entries.len == 1
+
+  test "raw-constructor name surfaces verbatim in UnboundContextVarDefect.varName":
+    let k = newRequiredContextVar[int]("rawNamed")
+    try:
+      discard k.value
+      check false
+    except UnboundContextVarDefect as e:
+      check e.varName == "rawNamed"
+
+# --- Guardrail 8: same-name keys don't alias ----------------------------------
+#
+# Duplicate name strings are representable and accepted as
+# cosmetic-only (matching PEP 567): dumpContext may show two entries
+# with the same label. What's pinned instead is the semantic property —
+# binding one same-name key is never observable through the other.
+
+suite "contextvars guardrails: g8 same-name keys don't alias":
+  test "binding one of two same-name same-T keys leaves the other's default; both list in dumpContext":
+    let a = newContextVar("g8Dup", 1, private = false)
+    let b = newContextVar("g8Dup", 1, private = false)
+
+    a.withValue(99):
+      check a.value == 99
+      check b.value == 1
+
+    check a.value == 1
+    check b.value == 1
+
+    let entries = dumpContext(currentContext()).filterIt(it.name == "g8Dup")
+    check entries.len == 2
+
+# --- Guardrail 9: positive inverse of the old collision guardrail -----------
+#
+# The old macro's per-arm `withName` collided with an already-declared
+# symbol of the same name (`timeout` vs. chronos's own `withTimeout`
+# combinator) — a compile ERROR. First-class keys mint no derived
+# identifiers, so this bug class is unrepresentable: a key literally
+# named "timeout" and chronos's `withTimeout` coexist without conflict.
+# Proof is compile-and-run, not `not compiles`, since the claim is the
+# ABSENCE of an error — this deletes the old design's collision-error
+# guardrail (and its duplicate-arm variant) outright, rather than
+# re-deriving it, since the mechanism that produced the error no longer
+# exists.
+
+let timeout* = newContextVar("timeout", 5, private = false)
+  ## Deliberately named to match the old collision case — the old
+  ## macro would have refused this declaration outright.
+
+suite "contextvars guardrails: g9 no collision with chronos's own symbols":
+  test "a key literally named `timeout` coexists with chronos's withTimeout":
+    check timeout.value == 5
+    check declared(withTimeout)
+
+# --- Guardrail 10: private-key registration closes the chain-node UAF -------
+#
+# A chain node's `key` field is an untraced raw pointer (see
+# chronos/contextvars.nim's `ContextNodeKeyed` comment): the pointee must
+# outlive every node that could reference it. Before this fix, a private
+# key registered nowhere, so nothing but its own (possibly stack-scoped)
+# `let` kept it alive; a captured `AsyncContext` whose chain still held a
+# node pointing at that key's address, taken after the key's binding
+# `let` went out of scope, was a use-after-free — worse, a *silent* one:
+# a later, unrelated key allocated at the freed address would compare
+# pointer-equal to the stale `node.key` and read back the dead key's
+# bound value instead of its own default. Registering every key,
+# private or not, closes this: the key stays alive for the process's
+# life regardless of `private`, so the address can never be reused while
+# a chain node can still reference it.
+
+var g10CapturedCtx: AsyncContext
+
+proc g10ConstructBindCapture() =
+  let privateKey = newContextVar("g10Private", 111, private = true)
+  privateKey.withValue(222):
+    g10CapturedCtx = currentContext()
+
+suite "contextvars guardrails: g10 private-key registration closes chain-node UAF":
+  test "GC after the binding proc returns leaves the captured context safe to walk, and a later key doesn't alias it":
+    g10ConstructBindCapture()
+    GC_fullCollect()
+
+    # Must not crash walking/rendering the captured chain.
+    let entries = dumpContext(g10CapturedCtx)
+    check not entries.anyIt(it.name == "g10Private")
+
+    # A key constructed after collection must read its own default, not
+    # the collected private key's bound value — the failure mode this
+    # guardrail exists to catch if registration is ever narrowed again.
+    let freshKey = newContextVar("g10Fresh", 999)
+    check g10CapturedCtx[freshKey] == 999
+
+# --- Guardrail 11: AsyncContext cannot be forged from a bare chain node -----
+#
+# `AsyncContext` wraps its chain-head node in a private field precisely so
+# that no safe-Nim code outside chronos/contextvars.nim — not even code
+# that imports chronos/internal/contextnode directly, as this file does
+# above — can construct one from an arbitrary `ContextNodeBase`. This
+# guardrail closes safe construction routes; it does not and cannot cover
+# `cast[AsyncContext](node)`, which remains outside the guarantee the same
+# way `cast` sits outside every other Nim type's invariants. Before this
+# guardrail existed, `AsyncContext* = distinct ContextNodeBase` let a
+# `ContextNodeBase` allocated by plain `new` convert straight into an
+# `AsyncContext` that `withContext` would accept unvalidated; the chain
+# walk's cast to `ContextNodeKeyed` then read past that allocation — a
+# silent out-of-bounds read indistinguishable from the empty context. See
+# docs/src/contextvars.md, "Implementation".
+
+static:
+  doAssert not compiles(block:
+    var n: ContextNodeBase
+    new(n)
+    AsyncContext(n)),
+    "AsyncContext must not be constructible from a bare ContextNodeBase " &
+    "via distinct-style positional conversion — that was exactly the " &
+    "forgery route this guardrail exists to close."
+  doAssert not compiles(block:
+    var n: ContextNodeBase
+    new(n)
+    AsyncContext(node: n)),
+    "AsyncContext must not be constructible from a bare ContextNodeBase " &
+    "via named-field object construction either — the `node` field must " &
+    "stay private to chronos/contextvars.nim."
+
+# =============================================================================
+# --- Capture-discipline guardrails (substrate-level, orthogonal to the
+#     key/macro API — carried over unchanged) ---------------------------------
+# =============================================================================
+
+# --- Guardrail: capture coverage is structural -------------------------------
+#
+# InternalAsyncCallback's fields are private to chronos/futures.nim;
+# only capturingCallback/bareCallback/contextCallback can construct one.
+
+static:
+  doAssert not compiles(InternalAsyncCallback(function: nil, udata: nil)),
+    "InternalAsyncCallback's fields must be private — raw construction " &
+    "outside `capturingCallback`/`bareCallback`/`contextCallback` must not " &
+    "compile. Use `capturingCallback(fn, udata)` for user-facing scheduling " &
+    "sites, `bareCallback(fn, udata)` for chronos-internal trampolines, " &
+    "or `contextCallback(fn, udata, ctx)` to reconstruct a callback from " &
+    "a context captured earlier (Windows IOCP completion dispatch). " &
+    "See docs/src/contextvars.md, 'Capture discipline'."
+  doAssert not compiles((var a: AsyncCallback; a.function = nil)),
+    "AsyncCallback's `function` field must be private — direct mutation " &
+    "outside chronos/futures.nim must not compile."
+  doAssert not compiles((var a: AsyncCallback; a.context = nil)),
+    "AsyncCallback's `context` field must be private — direct mutation " &
+    "would let a scheduling site silently skip context capture."
+
+# --- Guardrail: context is a native ref, not a manually-refcounted pointer ---
+#
+# A `pointer` field would need manual GC_ref/GC_unref at every drop
+# site — a latent leak under --mm:refc since keepItIf's shallowCopy
+# bypasses hooks. The native ref delegates lifecycle to Nim's MM.
+
+static:
+  doAssert InternalAsyncCallback.context is ContextNodeBase,
+    "InternalAsyncCallback.context must be `ContextNodeBase` (a native " &
+    "`ref` field) — see docs/src/contextvars.md, 'Implementation'. A " &
+    "`pointer` field with " &
+    "manual GC_ref/unref leaks under refc via `keepItIf`'s shallowCopy, " &
+    "and forces every new scheduling site to remember the manual ops."
+
+# --- Guardrail: AsyncCallback layout stable ----------------------------------
+#
+# If the struct gains a field or changes layout, this assertion drifts.
+# A cheap canary against accidental shape changes.
+
+static:
+  # CallbackFunc closure proc = 2 pointers (function + env), plus
+  # udata (1) and context: ContextNodeBase (a ref, 1 pointer) = 4.
+  doAssert sizeof(InternalAsyncCallback) == sizeof(pointer) * 4,
+    "InternalAsyncCallback expected to be 4 pointer-sized fields " &
+    "(function: 2-word closure proc, udata: pointer, context: ref); " &
+    "actual size = " & $sizeof(InternalAsyncCallback)
+
+# Public-surface minimality lives in tests/testcontextvarssurface.nim,
+# which imports only public paths.
+
+# --- Guardrail: InternalCancelCallback ---------------------------------------
+#
+# Same structural-privacy discipline as InternalAsyncCallback above,
+# mirrored for this 3-word type (no udata field).
+
+static:
+  doAssert not compiles(InternalCancelCallback(function: nil, context: nil)),
+    "InternalCancelCallback's fields must be private — raw construction " &
+    "outside `capturingCancelCallback` (or the no-capture site in " &
+    "`internalInitFutureBase`) must not compile. Use " &
+    "`capturingCancelCallback(fn)`. See docs/src/contextvars.md, 'Capture " &
+    "discipline'."
+  doAssert not compiles((var c: InternalCancelCallback; c.function = nil)),
+    "InternalCancelCallback's `function` field must be private — direct " &
+    "mutation outside chronos/futures.nim must not compile."
+  doAssert not compiles((var c: InternalCancelCallback; c.context = nil)),
+    "InternalCancelCallback's `context` field must be private — direct " &
+    "mutation would let a scheduling site silently skip context capture."
+
+  doAssert InternalCancelCallback.context is ContextNodeBase,
+    "InternalCancelCallback.context must be `ContextNodeBase` (a native " &
+    "`ref` field) — same MM-delegated lifetime discipline as " &
+    "`InternalAsyncCallback.context` (guardrail above)."
+
+  # CallbackFunc closure proc (2 words) + context: ContextNodeBase (1) = 3.
+  doAssert sizeof(InternalCancelCallback) == sizeof(pointer) * 3,
+    "InternalCancelCallback expected to be 3 pointer-sized fields " &
+    "(function: 2-word closure proc, context: ref); " &
+    "actual size = " & $sizeof(InternalCancelCallback)
+
+# --- A trivial runtime assertion to keep the test file unittest-recognized ---
+
+suite "contextvars: drift guardrails":
+  test "compile-time guardrails passed":
+    # The static checks above are the real guardrails; this just
+    # gives the runner a green dot.
+    check true

--- a/tests/testcontextvarsleakguard.nim
+++ b/tests/testcontextvarsleakguard.nim
@@ -1,0 +1,161 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## This file pins chronos's chronosDebug context-corruption detection net
+## layer by layer: `withRestoredContext`'s identity-arm postcondition
+## assert (chronos/futures.nim, ~231-236), the restore arm's unconditional
+## `finally` self-heal (same file, ~237-240), and the cross-batch guard in
+## `processCallbacks` (chronos/internal/asyncengine.nim, ~262-267).
+##
+## The cross-batch guard is pinned indirectly, through Nim's finally-unwind
+## replacement rather than through anything the guard alone detects: a
+## callback that corrupts `currentAsyncContext` through the identity arm
+## fails both the identity arm's own postcondition assert and the batch
+## guard's assert, since both compare the same corrupted value against the
+## same pre-corruption snapshot. The batch guard's assert runs later, in
+## the `finally` unwinding the identity arm's already-propagating Defect,
+## and its own failure there replaces that Defect as the one a caller of
+## `poll()` observes. The surfaced message therefore pins the batch guard's
+## presence: delete or weaken it and the message flips to the identity
+## arm's, failing that case. It is not proof the batch guard independently
+## catches anything the identity arm misses - on every current dispatch
+## path the identity arm's own postcondition already fires first, so the
+## batch guard remains defense-in-depth against a future dispatch path that
+## bypasses `withRestoredContext`, not a second independent detector today.
+##
+## Split out like tests/testcontextvarslock.nim rather than folded into
+## testall.nim: the identity-arm and cross-batch cases leave an escaped
+## AssertionDefect (and a stray, disconnected context node) behind, which
+## would leave the dispatcher unsound for every other suite sharing that
+## binary. In CI this file is isolated per-process via
+## tests/testcontextvarsstandalone.nim's orchestrate mode; sharing a
+## binary with another suite is only possible in that driver's no-args
+## single-process mode, where this file must still run first for the
+## same reason. The net itself only exists under `chronosDebug`, so
+## every test here skips cleanly without it.
+
+import std/strutils
+import unittest2
+import ../chronos/contextvars
+import ../chronos/internal/contextnode
+  # Whitebox: the identity-arm case constructs a bare `ContextNodeBase`
+  # directly, which `chronos/contextvars.nim` does not expose.
+import ../chronos/futures
+  # Whitebox: `currentAsyncContext` is the threadvar the net inspects, and
+  # `withRestoredContext` is the template under test; neither is reachable
+  # through `import chronos`.
+import ../chronos
+  # Brings in `callSoon`/`poll`.
+
+{.used.}
+
+var leakGuardVarKey: ContextVar[int]
+var leakGuardVarConstructed = false
+
+proc leakGuardVar(): ContextVar[int] {.gcsafe.} =
+  ## Constructed on first call rather than via a top-level
+  ## `{.contextVar.}` `let`: this suite is linked into the same binary
+  ## as tests/testcontextvarsrecorderdeath.nim (see
+  ## tests/testcontextvarsstandalone.nim), and a top-level construction
+  ## runs during module init, before unittest2 filters which suite's
+  ## tests actually execute — claiming the process-global recorder slot
+  ## in every child the orchestrate driver spawns, including
+  ## recorderdeath's, and leaving it no process in which to observe an
+  ## unclaimed slot. Deferring construction into the first test that
+  ## needs it keeps this suite's own tests unaffected while leaving the
+  ## slot free in any process where none of its tests are selected.
+  {.cast(gcsafe).}:
+    if not leakGuardVarConstructed:
+      leakGuardVarKey = newContextVar("leakGuardVar", 0, private = true)
+      leakGuardVarConstructed = true
+    leakGuardVarKey
+
+const contextVarsLeakGuardSuiteName* =
+  "contextvars: chronosDebug context-corruption detection net"
+
+suite contextVarsLeakGuardSuiteName:
+
+  test "control: a callback that binds and unwinds through withValue trips nothing":
+    when defined(chronosDebug):
+      var ran = false
+      proc goodCb(udata: pointer) {.gcsafe, raises: [].} =
+        leakGuardVar().withValue(1):
+          discard leakGuardVar().value
+        ran = true
+
+      callSoon(goodCb, nil)
+      poll()
+      check ran
+    else:
+      skip()
+
+  test "identity-arm layer: withRestoredContext's postcondition assert fires when its body corrupts currentAsyncContext":
+    when defined(chronosDebug):
+      # Called directly rather than through callSoon+poll(): processCallbacks'
+      # own chronosDebug batch guard wraps every dispatch in a try/finally
+      # whose doAssert, given this same corruption, also fails - and when a
+      # second doAssert fails while the first is still unwinding, Nim's
+      # finally semantics let the second's Defect replace the first. Routed
+      # through poll(), this case would therefore only ever surface the
+      # batch guard's message, not the identity arm's - confirmed empirically
+      # before writing this test. Calling withRestoredContext directly is
+      # the only way to observe the identity arm's own assert in isolation.
+      let ambient = currentAsyncContext
+      var caught = false
+      try:
+        withRestoredContext(ambient):
+          currentAsyncContext = ContextNodeBase()
+      except AssertionDefect as e:
+        caught = true
+        check "identity arm violated" in e.msg
+      check caught
+      currentAsyncContext = ambient
+    else:
+      skip()
+
+  test "restore-arm layer: a captured-context callback that corrupts currentAsyncContext is healed by the finally, no Defect escapes":
+    when defined(chronosDebug):
+      let preAmbient = currentAsyncContext
+      var ran = false
+      proc corruptingRestoreCb(udata: pointer) {.gcsafe, raises: [].} =
+        currentAsyncContext = ContextNodeBase()
+        ran = true
+
+      leakGuardVar().withValue(2):
+        # Scheduled inside withValue so capturingCallback embeds a real,
+        # non-nil chain - the restore arm only runs when the captured
+        # context differs from the ambient ready to receive it.
+        callSoon(corruptingRestoreCb, nil)
+
+      poll()
+      check ran
+      check currentAsyncContext == preAmbient
+    else:
+      skip()
+
+  test "cross-batch guard layer: a callback captured at nil ambient context that corrupts currentAsyncContext surfaces the batch guard's message via finally-replacement":
+    when defined(chronosDebug):
+      # Ordered last and restores currentAsyncContext itself: this case
+      # leaves the ambient corrupted for the duration of the escaping
+      # Defect (neither failed assert writes anything), so it must not run
+      # ahead of a case that assumes a clean ambient.
+      let ambient = currentAsyncContext
+      proc corruptingCb(udata: pointer) {.gcsafe, raises: [].} =
+        currentAsyncContext = ContextNodeBase()
+
+      callSoon(corruptingCb, nil)
+      var caught = false
+      try:
+        poll()
+      except AssertionDefect as e:
+        caught = true
+        check "context leaked across a callback batch" in e.msg
+      check caught
+      currentAsyncContext = ambient
+    else:
+      skip()

--- a/tests/testcontextvarslock.nim
+++ b/tests/testcontextvarslock.nim
@@ -1,0 +1,42 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## The one-way `chronosDebug` construction lock for `newContextVar`
+## (chronos/contextvars.nim, `lockContextVarConstruction()`), split into
+## its own file so that its permanent, process-lifetime lock doesn't
+## impose an import order on the other contextvars test files: every
+## other file constructs keys at runtime and would hit the lock if it
+## ran after this one in the same binary. Not imported from
+## tests/testall.nim for the same reason — the lock must not be live for
+## any other suite in that binary. In CI,
+## tests/testcontextvarsstandalone.nim's orchestrate mode gives this
+## suite its own process, so the lock's one-way nature can no longer
+## affect another suite; import order only matters for the driver's
+## no-args single-process mode, where this file must still run last.
+##
+## `when defined(chronosDebug)` guards the lock itself, mirroring
+## tests/testcontextvarsbalance.nim: this file compiles on every leg but
+## is only meaningful on the `chronosDebug` ones.
+
+import unittest2
+import ../chronos/contextvars
+
+{.used.}
+
+const contextVarsLockSuiteName* =
+  "contextvars (raw key): chronosDebug construction lock"
+
+suite contextVarsLockSuiteName:
+
+  test "newContextVar after lockContextVarConstruction() asserts":
+    when defined(chronosDebug):
+      lockContextVarConstruction()
+      expect AssertionDefect:
+        discard newContextVar("afterLock", 1)
+    else:
+      skip()

--- a/tests/testcontextvarsrecorderdeath.nim
+++ b/tests/testcontextvarsrecorderdeath.nim
@@ -1,0 +1,81 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## The automatic cross-thread construction guard
+## (chronos/contextvars.nim, `newContextVar`/`newRequiredContextVar`'s
+## unconditional thread-generation check) against a dead recording
+## thread — split out like tests/testcontextvarslock.nim and run
+## alongside it from tests/testcontextvarsstandalone.nim, for the same
+## per-process isolation reasons documented there.
+##
+## OS thread-id recycling cannot be forced deterministically from
+## userspace: there is no portable way to make a new thread receive a
+## specific exited thread's id. This suite instead pins the state a
+## recycled id could falsely satisfy — the recording thread has
+## already exited — which is exactly where a generation identity must
+## keep refusing and an OS-TID identity could wrongly accept a new
+## thread. Runs in every build, not only under `chronosDebug`: the
+## guard it tests is unconditional (see chronos/contextvars.nim).
+##
+## Adaptive because the recording slot is process-global and other
+## suites may have already claimed it before this one runs (see the
+## two branches below).
+
+import unittest2
+import ../chronos/contextvars
+
+{.used.}
+
+const contextVarsRecorderDeathSuiteName* =
+  "contextvars (raw key): guard against a dead recording thread"
+
+suite contextVarsRecorderDeathSuiteName:
+
+  test "guard still trips once the recording thread has exited":
+    type AttemptResult = tuple[constructed, tripped: bool]
+
+    proc constructOnThread(resultAddr: ptr AttemptResult) {.thread, nimcall.} =
+      try:
+        {.cast(gcsafe).}:
+          discard newContextVar("recorderDeathKey", 0)
+        resultAddr[] = (constructed: true, tripped: false)
+      except AssertionDefect:
+        resultAddr[] = (constructed: false, tripped: true)
+
+    var resultA: AttemptResult
+    var threadA: Thread[ptr AttemptResult]
+    createThread(threadA, constructOnThread, addr resultA)
+    joinThread(threadA)
+
+    if resultA.constructed:
+      # This process had no prior construction: thread A is the
+      # recorder, and by the time control returns here it has already
+      # exited — the exact state OS-TID recycling exploits, where a
+      # later thread reusing A's id would wrongly read as "the"
+      # recorder. A generation identity keeps refusing regardless, so
+      # both a main-thread and a fresh worker-thread construction must
+      # still trip the guard; this is the real pin.
+      expect AssertionDefect:
+        discard newContextVar("recorderDeathAfterMain", 1)
+
+      var resultB: AttemptResult
+      var threadB: Thread[ptr AttemptResult]
+      createThread(threadB, constructOnThread, addr resultB)
+      joinThread(threadB)
+      check not resultB.constructed
+      check resultB.tripped
+    else:
+      # A prior suite sharing this process (leak-guard or cross-thread,
+      # in the driver's legacy no-args order) already recorded the main
+      # thread, so thread A tripped instead of becoming the recorder.
+      # The recorder-death scenario is unreachable in this process;
+      # degrade to consistency checks — the recorder is still the main
+      # thread, so a main-thread construction still succeeds.
+      check resultA.tripped
+      let k = newContextVar("recorderDeathMainStillRecorder", 2)
+      check k.value == 2

--- a/tests/testcontextvarsstandalone.nim
+++ b/tests/testcontextvarsstandalone.nim
@@ -1,0 +1,72 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Driver for the contextvars suites that cannot share a process with
+## tests/testall.nim, or with each other:
+##
+## - tests/testcontextvarsleakguard.nim lets an AssertionDefect escape
+##   poll() under chronosDebug, leaving the dispatcher unsound for any
+##   suite sharing that binary afterward.
+## - tests/testcontextvarscrossthread.nim constructs a key from a second
+##   thread and must not run after the lock is engaged, since the lock
+##   makes every construction in the process assert, including its own
+##   control construction on the main thread.
+## - tests/testcontextvarsrecorderdeath.nim's full scenario needs a
+##   process where no key has been constructed yet, so its worker thread
+##   is the one that records; it must run before the lock is engaged for
+##   the same reason as the cross-thread suite, and after the
+##   leak-guard/cross-thread suites so their main-thread construction
+##   has already claimed the recorder in this mode, exercising its
+##   degraded branch instead — which orchestrate mode's per-suite
+##   process avoids, giving it the full scenario there.
+## - tests/testcontextvarslock.nim's chronosDebug construction lock is
+##   one-way for the process's lifetime: once engaged, every later
+##   `newContextVar`/`newRequiredContextVar` call in the process asserts.
+##
+## Three invocation modes, selected by argv:
+##
+## - No arguments: all four suites run in one process, in the import
+##   order below (dev convenience). Import order is load-bearing only in
+##   this mode.
+## - `orchestrate`: this process becomes a parent that spawns itself once
+##   per suite, each child given `"<suite name>::*"` as its sole argument
+##   — a unittest2 filter that runs only that suite — so isolation is by
+##   construction (separate processes) rather than by import order.
+##   `orchestrate` also doubles as a unittest2 filter in the parent's own
+##   process: no test is named "orchestrate" and it contains neither `::`
+##   nor `*`, so it matches nothing, and the parent's own exit-time test
+##   run is an empty no-op that leaves the aggregate exit code to the
+##   `quit` call below.
+## - Any other argument: passed through to unittest2 unchanged, e.g. to
+##   run a single suite directly (`<binary> "<suite name>::*"`).
+import std/[os, osproc]
+import ./testcontextvarsleakguard
+import ./testcontextvarscrossthread
+import ./testcontextvarsrecorderdeath
+import ./testcontextvarslock
+
+const orchestrateArg = "orchestrate"
+
+if paramCount() >= 1 and paramStr(1) == orchestrateArg:
+  let suiteNames = [
+    contextVarsLeakGuardSuiteName,
+    contextVarsCrossThreadSuiteName,
+    contextVarsRecorderDeathSuiteName,
+    contextVarsLockSuiteName,
+  ]
+  var allOk = true
+  for suiteName in suiteNames:
+    let child = startProcess(
+      getAppFilename(), args = [suiteName & "::*"], options = {poParentStreams}
+    )
+    let code = waitForExit(child)
+    close(child)
+    echo "[testcontextvarsstandalone] ", suiteName, ": exit ", code
+    if code != 0:
+      allOk = false
+  quit(if allOk: 0 else: 1)

--- a/tests/testcontextvarssurface.nim
+++ b/tests/testcontextvarssurface.nim
@@ -1,0 +1,277 @@
+#                Chronos Test Suite
+#            (c) Copyright 2018-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+## Public-surface guardrail for continuation-local storage.
+##
+## Verifies that `import chronos` plus `import chronos/contextvars`
+## expose only the intended public API — no dispatcher-internal or
+## key-runtime-internal primitives. Kept separate from
+## testcontextvarsguardrails.nim, whose checks pin representation/
+## identity properties (using the same public symbols) rather than
+## surface reachability.
+
+import unittest2
+import ../chronos
+import ../chronos/contextvars
+  # Looks unused to the compiler (declared() doesn't mark usage) but is
+  # load-bearing for every assert below.
+
+{.used.}
+
+# --- Required public surface -------------------------------------------------
+
+static:
+  doAssert declared(ContextVar),       "ContextVar[T] type must be public"
+  doAssert declared(newContextVar),    "newContextVar must be public"
+  doAssert declared(newRequiredContextVar),
+    "newRequiredContextVar (the must-bind constructor) must be public"
+  when (NimMajor, NimMinor) >= (2, 0):
+    # The `{.contextVar.}` pragma itself is 2.x-only — macro pragmas on
+    # `let`/`var` sections don't exist in the 1.6 compiler — so this probe
+    # doesn't even parse-expand on 1.6.
+    doAssert declared(contextVar),     "the {.contextVar.} pragma macro must be public"
+  doAssert declared(AsyncContext),     "AsyncContext type must be public"
+  doAssert declared(currentContext),   "currentContext proc must be public"
+  doAssert declared(withContext),      "withContext template must be public"
+  doAssert declared(dumpContext),      "dumpContext proc must be public"
+  doAssert declared(ContextVarEntry),  "ContextVarEntry type must be public"
+  doAssert declared(UnboundContextVarDefect),
+    "UnboundContextVarDefect must be public — it's the type a caller " &
+    "needs to name to catch an unbound must-bind read"
+  doAssert UnboundContextVarDefect is Defect,
+    "UnboundContextVarDefect must be a Defect (not a CatchableError) " &
+    "— see docs/src/contextvars.md, 'Required variables'"
+
+let surfaceProbeKey = newContextVar("surfaceProbeKey", 0)
+
+static:
+  doAssert compiles(newContextVar("x", 0)),
+    "newContextVar[T](name, default, private = false) must be public and callable"
+  doAssert compiles(newRequiredContextVar[int]("x")),
+    "newRequiredContextVar[T](name, private = false) must be public " &
+    "and callable"
+  doAssert compiles(surfaceProbeKey.value),
+    "ContextVar[T].value must be public and callable"
+  doAssert compiles(currentContext()[surfaceProbeKey]),
+    "`[]`(AsyncContext, ContextVar[T]): T must be public and callable"
+  doAssert compiles((block:
+    surfaceProbeKey.withValue(1):
+      discard)),
+    "ContextVar[T].withValue must be public and callable"
+  doAssert compiles(surfaceProbeKey in currentContext()),
+    "`contains`(AsyncContext, ContextVar[T]): bool (`cv in ctx`) must " &
+    "be public and callable"
+  doAssert compiles(surfaceProbeKey.isBound),
+    "ContextVar[T].isBound must be public and callable"
+  doAssert compiles(hash(surfaceProbeKey)),
+    "hash(cv: ContextVarBase): Hash must be public and callable, making " &
+    "ContextVar[T] usable as a Table/HashSet key"
+  doAssert compiles(surfaceProbeKey.name),
+    "ContextVar[T].name must be public and callable"
+  doAssert compiles(currentContext() == currentContext()),
+    "`==`(a, b: AsyncContext): bool must be public and callable"
+  doAssert compiles(hash(currentContext())),
+    "hash(ctx: AsyncContext): Hash must be public and callable"
+  doAssert compiles($(currentContext())),
+    "`$`(ctx: AsyncContext): string must be public and callable"
+
+when (NimMajor, NimMinor) >= (2, 0):
+  # A must-bind key declared via the pragma (`var name* {.contextVar.}: T`,
+  # no default) must be legal syntax; this probe (module-scope, so it runs
+  # regardless of which test below executes) pins that the surface accepts
+  # it. 2.x-only, same as the `declared(contextVar)` probe above — the
+  # pragma doesn't even parse-expand on 1.6.
+  var surfaceMustBind* {.contextVar.}: int
+
+# --- Deliberately absent surface ---------------------------------------------
+#
+# An imperative token API (set/reset) is deliberately not part of the
+# frozen surface — withValue and withContext/currentContext cover every
+# known need. (`reset` itself can't be negatively asserted here:
+# system.reset makes declared(reset) true in every module — see
+# testcontextvarsguardrails.nim's guardrail 4 for the call-shape probes
+# that work around this.)
+when declared(AsyncContextToken):
+  {.error: "`AsyncContextToken` must not be public: the imperative " &
+           "token API was deliberately dropped from the frozen surface. " &
+           "See the comment above this check.".}
+
+# --- Anti-leak: key-runtime internals must not be reachable -----------------
+#
+# `ContextNodeBase`'s bare name must NOT be reachable through this
+# surface: `AsyncContext` wraps its chain head in a field private to
+# chronos/contextvars.nim (see that module's top-of-file comment and
+# docs/src/contextvars.md, "Implementation"), so nothing public needs to
+# name the base chain-node type anymore — unlike the old macro design,
+# which needed it nameable for its own reasons. Whitebox probes of
+# `ContextNodeBase` itself (its `next` field's privacy, the forgery
+# guardrail) live in tests/testcontextvarsguardrails.nim, which imports
+# chronos/internal/contextnode directly rather than going through this
+# public surface.
+
+when declared(ContextNodeBase):
+  {.error: "`ContextNodeBase` must not leak through the public API — " &
+           "`AsyncContext` wraps it in a private field, so no public " &
+           "symbol needs to name the base chain-node type anymore. See " &
+           "chronos/contextvars.nim's top-of-file comment and " &
+           "docs/src/contextvars.md, \"Implementation\".".}
+
+when declared(nextNode):
+  {.error: "`nextNode` (chain traversal getter) must not leak through " &
+           "the public API — it lives in chronos/internal/contextnode.nim " &
+           "for chronos/contextvars.nim's own walkers only.".}
+
+when declared(linkNode):
+  {.error: "`linkNode` (chain link writer) must not leak through the " &
+           "public API — a reachable link primitive would reopen chain " &
+           "mutation from user code.".}
+
+when declared(ContextNode):
+  {.error: "`ContextNode[T]` must not leak through the public API — no " &
+           "nameable per-key chain-node type exists anymore (the old " &
+           "macro design's per-arm nameable slot subtype is exactly what " &
+           "made the old cycle attack representable in the first place); " &
+           "chronos/contextvars.nim builds and walks nodes from its own " &
+           "definitions only.".}
+
+when declared(ContextNodeKeyed):
+  {.error: "`ContextNodeKeyed` must not leak through the public API " &
+           "either — same reasoning as `ContextNode[T]` above.".}
+
+when declared(currentAsyncContext):
+  {.error: "`currentAsyncContext` threadvar must not leak through the " &
+           "public API. Users must use `withContext` only.".}
+
+when declared(registeredVars):
+  {.error: "`registeredVars` (the registry-walking iterator) must not " &
+           "leak through the public API — analogous to the old design's " &
+           "`contextVarRegistry`, it is invoked by `dumpContext` only; " &
+           "`dumpContext`/`ContextVarEntry` are the public surface " &
+           "over the registry.".}
+
+static:
+  doAssert not compiles((let k = newContextVar("surfaceDefault", 0); discard k.default)),
+    "ContextVarBase's `default` field must not be reachable at all " &
+    "outside chronos/contextvars.nim — it's on the RFC's public-surface " &
+    "Forbidden list."
+  doAssert not compiles((let k = newContextVar("surfaceRender", 0); discard k.render)),
+    "ContextVarBase's `render` field (the dumpContext render hook) must " &
+    "not be reachable at all outside chronos/contextvars.nim."
+  doAssert not compiles((let k = newContextVar("surfaceReg", 0); discard k.nextRegistered)),
+    "ContextVarBase's `nextRegistered` field (the intrusive registry " &
+    "link) must not be reachable at all outside chronos/contextvars.nim."
+
+when declared(capturingCallback):
+  {.error: "`capturingCallback` must not leak through the public API. It lives " &
+           "in chronos/futures.nim, excluded from `asyncengine.nim`'s " &
+           "`export futures`, and is used by dispatcher code only.".}
+
+when declared(bareCallback):
+  {.error: "`bareCallback` must not leak through the public API.".}
+
+when declared(contextCallback):
+  {.error: "`contextCallback` must not leak through the public API. It " &
+           "lives in chronos/futures.nim, excluded from `asyncengine.nim`'s " &
+           "`export futures`, and is used by Windows IOCP completion " &
+           "dispatch (`poll()`) only.".}
+
+when declared(capturingCancelCallback):
+  {.error: "`capturingCancelCallback` must not leak through the public API. It " &
+           "lives in chronos/futures.nim, excluded from `asyncengine.nim`'s " &
+           "`export futures`, and is used by `cancelCallback=` only — " &
+           "otherwise plain `import chronos` code could manufacture an " &
+           "`InternalCancelCallback` and assign it directly to " &
+           "`internalCancelcb`, bypassing `cancelCallback=`'s discipline.".}
+
+when declared(withRestoredContext):
+  {.error: "`withRestoredContext` must not leak through the public API. " &
+           "It lives in chronos/futures.nim (placed there because " &
+           "`asyncengine.nim` cannot name `ContextNodeBase` for its " &
+           "typed parameter), excluded from `asyncengine.nim`'s `export " &
+           "futures`, and is used by the dispatcher's fire sites only.".}
+
+when declared(pinContext):
+  {.error: "`pinContext` must not leak through the public API. It lives " &
+           "in chronos/futures.nim beside `withRestoredContext`, excluded " &
+           "from `asyncengine.nim`'s `export futures`, and is used by " &
+           "continuation-pump resume guards only.".}
+
+when declared(captureContextInto):
+  {.error: "`captureContextInto` must not leak through the public API. " &
+           "It lives in chronos/futures.nim (the shared " &
+           "construction-discipline template), excluded from " &
+           "`asyncengine.nim`'s `export futures`, and is used by " &
+           "`capturingCallback`/`capturingCancelCallback` only — a reachable capture " &
+           "primitive would let plain `import chronos` code write " &
+           "`currentAsyncContext` into arbitrary fields, bypassing the " &
+           "construction discipline entirely.".}
+
+# --- Dispatcher queue fields and their backing type ---------------------------
+#
+# DispatcherBase.callbacks/idlers/ticks (backed by CallbackQueue) must
+# stay private to chronos/internal/asyncengine.nim; only
+# getThreadDispatcher() itself is public.
+
+static:
+  doAssert not compiles(getThreadDispatcher().callbacks),
+    "`DispatcherBase.callbacks` must not be readable via `import chronos` " &
+    "— it is private to chronos/internal/asyncengine.nim."
+  doAssert not compiles(getThreadDispatcher().idlers),
+    "`DispatcherBase.idlers` must not be readable via `import chronos` " &
+    "— it is private to chronos/internal/asyncengine.nim."
+  doAssert not compiles(getThreadDispatcher().ticks),
+    "`DispatcherBase.ticks` must not be readable via `import chronos` " &
+    "— it is private to chronos/internal/asyncengine.nim."
+
+when declared(CallbackQueue):
+  {.error: "`CallbackQueue` must not leak through the " &
+           "public API. It backs the privatized `callbacks`/`idlers`/" &
+           "`ticks` dispatcher fields and has no public-facing purpose " &
+           "— unlike `std/deques.Deque` before it, which stayed exported " &
+           "only because the fields it backed were themselves public.".}
+
+# `context` is InternalAsyncCallback's (and InternalCancelCallback's)
+# read-only getter, used by the dispatcher's fireWithContext/
+# fireCancelCallback. Excluded from asyncengine.nim's `export futures`
+# by name, which covers both overloads at once.
+static:
+  doAssert not compiles(default(AsyncCallback).context),
+    "`context` getter must not leak through the public API. It lives " &
+    "in chronos/futures.nim, excluded from `asyncengine.nim`'s " &
+    "`export futures`, and is used by the dispatcher's " &
+    "`fireWithContext` only."
+  doAssert not compiles(default(InternalCancelCallback).context),
+    "`InternalCancelCallback`'s `context` getter must not leak through " &
+    "the public API either — same exclusion, same reasoning, used by " &
+    "the dispatcher's `fireCancelCallback` only."
+
+# --- Windows: CompletionData.context must not be reachable -------------------
+#
+# A public field here would make `ContextNodeBase` structurally
+# reachable via plain `import chronos` on Windows, same class of leak
+# as the `AsyncCallback`/`InternalCancelCallback` `context` getters
+# above. Compiled only on the `--os:windows --compileOnly` CI leg.
+
+when defined(windows):
+  static:
+    doAssert not compiles((var cd: CompletionData; discard cd.context)),
+      "`CompletionData.context` must not be readable via `import " &
+      "chronos` — it is private to chronos/internal/asyncengine.nim, " &
+      "reached only through the `captureContextInto(var CompletionData)` " &
+      "overload (write) and same-module code (read)."
+    doAssert not compiles((var cd: CompletionData; cd.context = nil)),
+      "`CompletionData.context` must not be writable via `import " &
+      "chronos` either."
+
+# --- A trivial runtime assertion to keep the test file unittest-recognized ---
+
+suite "contextvars: public surface":
+  test "compile-time guardrails passed":
+    # The static checks above are the real guardrails; this just
+    # gives the runner a green dot.
+    check true

--- a/tests/testutils.nim
+++ b/tests/testutils.nim
@@ -11,6 +11,7 @@ import ../chronos, ../chronos/config
 {.used.}
 
 suite "Asynchronous utilities test suite":
+
   when chronosFutureTracking:
     proc getCount(): uint =
       # This procedure counts number of Future[T] in double-linked list via list


### PR DESCRIPTION
## Summary

This PR adds `chronos/contextvars`: continuation-local storage for chronos, in the spirit of Python's `contextvars`/PEP 567. A context variable's binding follows a logical task through `await` suspensions, callback registrations, and combinators (`race`, `allFutures`, ...), while concurrent tasks stay isolated from each other. Typical uses are request IDs, authenticated users, tracing spans, and other "ambient" data that would otherwise have to be threaded through every procedure signature by hand.

We run this in production downstream and will maintain the branch regardless; it is offered upstream because both the feature and the queue fix it surfaced seem generally useful. No pressure or timeline attached: this is shared in the spirit of open source, and we're equally content if it lands, gets split up, or simply serves as a reference.

```nim
import chronos
import chronos/contextvars

type User = object
  name: string

let currentUser* {.contextVar.} = User(name: "anonymous")

proc audit(action: string) =
  echo currentUser.value.name, ": ", action

proc handleRequest(user: User) {.async.} =
  currentUser.withValue(user):
    await sleepAsync(10.milliseconds)   # binding survives suspension
    audit("query")                      # sees `user`, not the default
```

A context variable is a first-class typed key, `ContextVar[T]`. The `{.contextVar.}` pragma declares one as an ordinary `let`, deriving the variable's name and its introspection visibility from the declaration itself (`let` with a default, `var` without one for a required variable, enforced at compile time); the raw `newContextVar` and `newRequiredContextVar` constructors are the underlying primitives and stay public. The pragma requires Nim 2.x, since macro pragmas on `let`/`var` sections are a 2.x language capability; on 1.6 the constructors are the declaration path and the feature is otherwise identical, with the pragma compiled out entirely rather than emulated. Every operation is an ordinary generic defined once in the library: the ambient read `cv.value`, the snapshot read `ctx[cv]`, the scoped binder `cv.withValue(value): body` (which binds for the dynamic extent of `body` and restores on every exit path: normal, exception, cancellation), and the boundness probes `cv in ctx` / `cv.isBound`. Nothing mints per-variable identifiers, so declarations cannot collide with existing API, and keys are ordinary values: they can be passed to procs, stored in collections, and used as `Table` keys. Reading a required variable while unbound raises a `Defect` (unbound-read is a contract violation, and using a `Defect` keeps readers out of `raises` effect tracking, so `{.async: (raises: []).}` procedures can read context variables freely). Bindings nest, innermost wins, and propagate into tasks spawned within the binder's extent. Two further primitives, `currentContext()` and `withContext(ctx, body)`, snapshot and restore the full binding chain for cases that fall outside a single dynamic extent, such as a resource's independently-registered setup and teardown callbacks, which share no call stack. Snapshots are first-class values: they compare with `==` (chain identity), read with `ctx[cv]` without installing anything, and `dumpContext(ctx)`/`$` render a snapshot's contents for logs and debugging, backed by a registry that keeps every key alive for the life of the process and lists only keys registered as visible. There is no imperative token API (PEP 567's `ContextVar.set()`/`Token.reset()`): within one logical task `withValue` already expresses every binding lifecycle, and across independently-scheduled callbacks a token could not work, since the dispatcher's restore-at-fire discipline unwinds any push a callback leaves behind regardless.

Full usage, semantics, and implementation notes are in `docs/src/contextvars.md` (added by this PR).

## Performance

The design goal is cost proportional to use: a program that never declares a context variable should pay a cost indistinguishable, on each hot path, from a build without the feature at all.

**Headline (refc: chronos's flagship consumer, nimbus-eth2, pins `--mm:refc` unconditionally).** Cross-commit comparison of the submitted commits against their pre-contextvars base, `callSoon` schedule+fire (the hottest path a contextvars-free program pays on), 15 interleaved trials per side: **refc 1.04x**, bootstrap 95% CI [0.82, 1.26], Mann-Whitney p = 0.76, statistically indistinguishable from the base. **orc 0.99x**, CI [0.80, 1.20]. Earlier independent measurement sessions during development read 1.01x–1.11x on refc; the raw per-trial data behind the final numbers is retained and reproducible.

Per-call-class bill, both memory managers, verified by inspecting the generated C at each site (not inferred from throughput alone):

- **leaf-callback fire**: one TLS load + one predicted branch. On refc this compiles to a bare pointer load with no write barrier; on orc the same load is wrapped in ORC's owning-copy/destroy hooks, cheap for the common nil case.
- **continuation resume**: the above plus one unconditional TLS save/restore pair, required for correctness (a suspended continuation must not leak a stale binding into whatever fires next).
- **capturing-callback construction** (any callback that must observe registration-time bindings): one TLS load + one predicted branch; barrier-free on refc, and on orc the context-copy is skipped entirely when no binder is live.
- **heap-field registration** (e.g. registering a future's cancel callback): one write-barrier call per ref field under refc, paid once, at the point ownership transfers into the heap field.

Bound-value lookup walks the binding chain comparing key identities: one pointer compare per node, with no per-node runtime type test (measured: reading through a 16-deep binding chain costs ~12 ns on refc).

Struct growth: `sizeof(AsyncCallback)` +8 B (one pointer field); `sizeof(Future)` +16 B after accounting for two embedded callbacks.

Both-worlds intra-commit detail, measured on the submitted series (release builds; unused arm = no binder active in the whole program; bound arm = one context variable bound around the hot loop), refc:

| metric | unused | bound |
|---|---|---|
| callSoon schedule+fire | 31.3 ns/op | 26.7 ns/op |
| sleepAsync(0) await chain | 741.8 ns/op | 913.3 ns/op |
| future create/await | 105.6 ns/op | 97.7 ns/op |

orc:

| metric | unused | bound |
|---|---|---|
| callSoon schedule+fire | 36.9 ns/op | 48.0 ns/op |
| sleepAsync(0) await chain | 753.0 ns/op | 910.2 ns/op |
| future create/await | 89.6 ns/op | 96.0 ns/op |

(Rows where the bound column is at or below the unused column are within run-to-run noise of each other; construction skips the context copy entirely when no binder is live. The sleepAsync rows carry the largest run-to-run spread, with individual runs swinging between the bound arm faster and the bound arm slower, so their bound-vs-unused deltas are noise-dominated; the callSoon rows are the tighter signal for the schedule/fire path.)

`benchmarks/bench_contextvars.nim` (included in this PR) reproduces these tables; the cross-commit comparisons above used a small self-contained harness that needs a second checkout to compare against, which we are happy to provide if useful.

## Queue transport: a named, separate improvement

While measuring the above, a pre-existing defect in chronos's callback queue surfaced: `std/deques.popFirst` returns its element by value, which is a `proc`, not a template, so every dequeue pays a copy-out and, under refc, three write-barrier calls per ref field (a dead zero-initialization of the hidden return slot, the copy-out itself, and clearing the vacated slot). This cost existed before this PR, on the queue's original single ref field (the callback's closure environment); adding contextvars' second ref field (the captured context) doubled it, and that doubling is what our own benchmarks caught.

This PR fixes it by replacing the three internal `Deque` fields on the dispatcher (`callbacks`, `idlers`, `ticks`) with a small purpose-built `CallbackQueue`, in `chronos/internal/callbackqueue.nim`, whose dequeue is a template with a barrier-free copy-out. Effect on refc: the dequeue side drops from three write-barrier calls per ref field to one, restoring per-hop cost to parity with what the pre-contextvars codebase already paid on its single ref field. orc is unaffected either way: its ownership model does not incur this cost regardless of queue shape, and the orc cross-commit ratio above shows no shift.

This change is the first, standalone commit of the series; it has no dependency on contextvars and is structured to be reviewable and cherry-pickable on its own. If maintainers would prefer to review and merge the queue fix as a preliminary PR before the contextvars feature itself, we are glad to split it out; the commit boundary already does the work.

## Test coverage

- Synchronous semantics: declaration (pragma and raw constructor), defaults, nesting/shadowing, restore-on-every-exit-path (normal, exception, cancellation), and the binder contract.
- Async propagation: isolation across interleaved tasks, survival across sequential `await`s, exception and cancellation paths, spawn-time inheritance into tasks started within a binder's extent, and per-scheduling-site capture coverage (`callSoon`, `setTimer`/ `sleepAsync`, `callIdle`, `addReader`, `race`/`allFutures`, `closeSocket`/`closeHandle`).
- Key identity and lifetime: same-name keys never alias (binding one is unobservable through the other), two same-type keys bound simultaneously each read back their own value, keys as `Table` keys and generic-proc parameters, and a captured context outliving a key's declaration scope stays sound.
- The "bridging independent callbacks" pattern: `currentContext()`/`withContext()` carrying a binding from an enter hook into a separately-scheduled exit hook.
- Compile-time drift detection: private-field/constructor-only enforcement on the internal callback types and chain nodes, the `{.contextVar.}` pragma's one-symbol expansion and its `let`/`var` grammar (on Nim 2.x, where the pragma exists), no custom `==` on keys, coexistence with `std/tables.withValue`, and constructor-string fidelity in `dumpContext` and `UnboundContextVarDefect.varName`, so a future refactor that reopens a capture bypass fails to compile rather than silently regressing.
- Public-surface pins: `import chronos` plus `import chronos/contextvars` expose exactly the intended API and none of the dispatcher internals; introspection-visibility semantics for pragma (star-driven) and raw-constructor (`private` param) declarations, including the registration/export decoupling case.
- A dedicated suite for the new `CallbackQueue` (growth during reentrant drain across capacity boundaries, zero-value-empty, sentinel fidelity, front-insertion ordering, queue integrity across a `Defect` unwind, and repeated-growth-under-memory-pressure coverage for the ref-field payload case).
- Restore-on-unwind is pinned on the load-bearing paths: a `Defect` raised from a callback fired under a binding that differs from the ambient context (the write-and-restore arm, for both the normal and the cancel-callback fire sites) leaves the prior ambient context intact; `await` inside `withContext` is pinned against the suspend-across-binder hazard; and the cross-thread `callSoon` empty-context contract has a dedicated test (bound origin thread, posting thread, receiving callback observes the default).
- Context snapshots: identity `==`, `ctx[cv]` snapshot reads, boundness probes, required (must-bind) variables including async propagation, and `dumpContext`/`$` rendering (including the placeholder path for value types without a `$`).
- The construction-ordering checks (keys are constructed on one thread, before threads start) run in a standalone driver binary that isolates each hostile suite in its own subprocess: one suite deliberately lets an AssertionDefect escape `poll()`, and the opt-in construction lock is one-way for the process's lifetime.
- The `nimble test` matrix gains one leg combining `-d:chronosDebug` with `-d:chronosPreviewV5`, so the strict-reentrancy callback-drain discipline is exercised together with the debug-mode invariant asserts rather than only apart from them.
- The full `nimble test` matrix passes unmodified on both `--mm:refc` and `--mm:orc`. The new queue module additionally compiles under `--os:standalone`, keeping it available to bare-metal configurations (cf. #697).
- One incidental fix: the `nimble test` task's benchmark-compile step matched `startsWith("bench_")` against paths returned by `walkDirRec`, which always carry the `benchmarks/` prefix, so the step had never compiled anything. This PR corrects the match (and passes `--threads:on` explicitly, since Nim 1.6 has no threaded default), which puts the benchmark files back under CI's compile check; the re-enabled check exposed two latent 32-bit integer-division truncations in `bench_http_fetch.nim`, also fixed here.

## Platform semantics, non-goals, and known gaps

- No compile-time opt-out flag is included. We measured the always-on cost first; if maintainers want a `chronosFutureTracking`-style build flag as a condition of merging, we can add one; happy to discuss the tradeoff (double test surface, a define that does not compose through nimble) given the measured numbers above.
- Windows completion paths carry the registration-time context: the completion-bearing state captures the active context when the operation is armed (`registerWaitable`, stream-server `start()`, explicit `accept()`), and the completion dispatch fires under it, so Windows waitable and stream-server callbacks propagate context like their epoll/kqueue counterparts (verified by a dedicated test on Windows CI). Low-level per-operation read/write completion trampolines intentionally stay context-free: they only drive an internal future, whose awaiter carries its own captured context.
- Cross-thread `callSoon` (the MPSC mechanism from #694) fires its callbacks with an empty context, by construction: the queue's payload is a bare `nimcall` proc and a raw pointer, and a captured context chain is a GC ref that must not cross thread-local heaps under refc. This fails closed: bindings from another thread's tasks can never leak in; propagation begins at the first in-loop scheduling point on the receiving thread. This contract has a dedicated test.
- Reads inside a caller's own `{.cast(gcsafe).}` block interact with a Nim compiler defect: when a nested cast block exits, it cancels the enclosing block's cast for the statements that follow, so code after a `.value` read inside such a block is flagged as not GC-safe. The documentation carries a hoist-the-read workaround. The compiler defect is fixed upstream (nim-lang/Nim#26092, fix merged in nim-lang/Nim#26093); the fix lives on devel only, so the workaround stays relevant for released toolchains.
- Key construction is supported before thread creation (module-level declarations, as in every example). Every build, including release, automatically asserts that all keys are constructed on one thread, using a chronos-assigned per-thread generation rather than an OS thread id (which is recycled after a thread exits); the check is one compare-exchange on the cold construction path. A `chronosDebug` build additionally carries an opt-in assertion hook for embedders who want the stricter before-any-thread boundary checked at their own thread-creation point. Registered keys live for the life of the process, matching static-global semantics.
- No `--os:standalone` verification of the contextvars substrate itself (the queue module compiles standalone; `asyncengine.nim` does not, for a pre-existing, unrelated reason: an unconditional "operation system is not yet supported" import guard that predates this PR).

## Public API surface

Frozen for this PR: `ContextVar[T]` with `newContextVar` (defaulted) and `newRequiredContextVar` (distinct procs, because a bool-typed default in the second positional slot would be ambiguous against the trailing `private` visibility param under a single overloaded name), the `{.contextVar.}` declaration pragma, `value`, `[]`, `withValue`, `contains`/`in` and `isBound`, the `name`/`hasDefault`/`private` read-only accessors and an identity `hash` on keys, `AsyncContext` with `==`, `hash`, and `$`, `currentContext`, `withContext`, `dumpContext` and `ContextVarEntry`, and `UnboundContextVarDefect` (carrying `varName`). No other new public identifiers. No version bump is included; that is left to maintainers' release process.

