### PR TITLE
fix(asyncengine): wake both callbacks on Event.Error (#709)

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1166,13 +1166,20 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       let events = loop.keys[i].events
 
       withData(loop.selector, cint(fd), adata) do:
-        if (Event.Read in events) or (events == {Event.Error}):
+        # `Event.Error` must wake up both the reader and the writer: when it is
+        # paired with only one direction (e.g. `{Read, Error}` when the send
+        # buffer is full, or `{Write, Error}` when there is no data to read), the
+        # other side would otherwise never be resumed, leaking its pending future
+        # (a parked `readOnce`/`write`). Some backends (kqueue) report the error
+        # separately per filter, so a callback may be scheduled more than once -
+        # the stream reader/writer loops are written to tolerate spurious calls.
+        if {Event.Read, Event.Error} * events != {}:
           if not isNil(adata.reader.function):
             loop.callbacks.addLast(adata.reader)
           else:
             hasWakeup = true
 
-        if (Event.Write in events) or (events == {Event.Error}):
+        if {Event.Write, Event.Error} * events != {}:
           if not isNil(adata.writer.function):
             loop.callbacks.addLast(adata.writer)
 

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -1469,28 +1469,34 @@ else:
     let transp = cast[StreamTransport](udata)
 
     # During close, we inject an artifical reader event to clear the pending
-    # reader - the socket gets unregistered from further events in `closeSocket`
-    if TransportState.Closed notin transp.state:
-      let progress = transp.readIntoBuffer()
-      doAssert progress, "Expecting progress since we're being notified"
+    # reader - the socket gets unregistered from further events in `closeSocket`.
+    #
+    # We only read when reading is actually active: if `ReadPaused` is set, the
+    # reader has already been removed from the selector and the buffer might be
+    # full - reading again would either make no progress or overflow the buffer.
+    # This guards against spurious/duplicate notifications which can happen when
+    # `Event.Error` is reported to both the read and write callbacks and, on
+    # kqueue, arrives as separate `{Read, Error}` / `{Write, Error}` events for
+    # the same descriptor (see the dispatcher's `poll`).
+    if {TransportState.Closed, ReadPaused} * transp.state == {}:
+      if transp.readIntoBuffer():
+        # The reader callback mechanism is level-triggered meaning that another
+        # callback will happen automatically unless we remove ourselves from the
+        # selector.
+        if (transp.state * {ReadEof, ReadError}) != {} or
+            (transp.buffer.len() > 0 and transp.buffer.availSpace() == 0) or
+            transp.buffer.len() == 0:
+          # Disable further read events if:
+          # * there's an error (no more reads possible)
+          # * we're using the buffer and it is full (must consume buffer first!)
+          # * we're using direct reads (direct reads will continue in readLoop)
+          transp.state.incl(ReadPaused)
 
-      # The reader callback mechanism is level-triggered meaning that another
-      # callback will happen automatically unless we remove ourselves from the
-      # selector.
-      if (transp.state * {ReadEof, ReadError}) != {} or
-          (transp.buffer.len() > 0 and transp.buffer.availSpace() == 0) or
-          transp.buffer.len() == 0:
-        # Disable further read events if:
-        # * there's an error (no more reads possible)
-        # * we're using the buffer and it is full (must consume buffer first!)
-        # * we're using direct reads (direct reads will continue in readLoop)
-        transp.state.incl(ReadPaused)
-
-        removeReader2(transp.fd).isOkOr:
-          # This should never happen but if it does, don't overwrite existing
-          # error
-          if ReadError notin transp.state:
-            transp.setReadError(error)
+          removeReader2(transp.fd).isOkOr:
+            # This should never happen but if it does, don't overwrite existing
+            # error
+            if ReadError notin transp.state:
+              transp.setReadError(error)
 
     transp.completeReader()
 

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -134,6 +134,46 @@ suite "Asynchronous issues test suite":
     check waitFor(testOrDeadlock()) == true
 
   when defined(posix):
+    test "{Event.Read, Event.Error} handling [poll()] test":
+      # `Event.Error` must wake up both the read and write callbacks: when the
+      # error is paired with only one direction (here `{Read, Error}` because the
+      # send buffer is full so `Event.Write` is not set), the other side would
+      # otherwise never be resumed, leaking its pending future.
+      var sockets: array[2, cint]
+      check:
+        socketpair(osdefs.AF_UNIX, osdefs.SOCK_STREAM, 0, sockets) == 0
+        setDescriptorBlocking(sockets[0], false).isOk()
+
+      # Ensure {Event.Read} and {Event.Error} (EOF) are set
+      var b = 42.byte
+      check:
+        handleEintr(osdefs.write(sockets[1], addr b, 1)) == 1
+        osdefs.shutdown(SocketHandle(sockets[1]), cint(SHUT_WR)) == 0
+
+      # Avoid {Event.Write} being set, by filling up the send buffer
+      var buf: array[65536, byte]
+      while handleEintr(osdefs.write(sockets[0], baseAddr buf, buf.len)) > 0:
+        discard
+
+      func setFlag(udata: pointer) =
+        let flag = cast[ptr bool](udata)
+        doAssert not(flag[])
+        flag[] = true
+
+      var readerFlag, writerFlag: bool
+      check:
+        register2(AsyncFD(sockets[0])).isOk()
+        addReader2(AsyncFD(sockets[0]), setFlag, addr readerFlag).isOk()
+        addWriter2(AsyncFD(sockets[0]), setFlag, addr writerFlag).isOk()
+      poll()
+      check:
+        readerFlag and writerFlag
+        unregister2(AsyncFD(sockets[0])).isOk()
+
+      discard osdefs.close(sockets[0])
+      when chronosEventEngine != "poll":
+        discard osdefs.close(sockets[1])
+
     asyncTest "Reader notification after buffer got full [poll()] test":
       var sockets: array[2, cint]
       check:


### PR DESCRIPTION
Fixes #709.

## Problem

`poll()` only resumes an I/O callback for its *own* direction: `Event.Error` wakes a side only when the event is *exactly* `{Error}`. When the kernel coalesces the error with the opposite direction — e.g. `{Read, Error}` (send buffer full, so no `EPOLLOUT`) or `{Write, Error}` (nothing to read) — the other side's callback is never scheduled. Its  readLoop`/`writeStreamLoop` never resumes, so a parked `readOnce`/`write` future is never completed: the consumer hangs forever and the future leaks.

This is the leak fixed by #672 and re-introduced by #700, which reverted #672 because its blunt form caused a kqueue double-callback crash and deferred "a proper fix." This is an attempt at a final fix.

## Change

1. `chronos/internal/asyncengine.nim` — `poll()` schedules the reader on `{Read, Error}` and the writer on `{Write, Error}`, so neither side is left un-resumed:
```nim
   if {Event.Read,  Event.Error} * events != {}: ...schedule reader...
   if {Event.Write, Event.Error} * events != {}: ...schedule writer...
   ```
2. `chronos/transports/stream.nim` — `readerCb` now tolerates the resulting spurious/duplicate wakeups (kqueue reports `{Read, Error}` and `{Write, Error}` as separate events for the same fd): it skips reading when `{Closed, ReadPaused}` is already set, and uses `if readIntoBuffer():` instead of `doAssert progress`. `completeReader()` still runs unconditionally so the close-injected event and genuine EOF/error still complete the parked read. `writeStreamLoop` is already idempotent (an empty queue simply re-pauses), so it needs no change.
3. `tests/testbugs.nim` — restores the dispatcher-level regression test (both reader and writer callbacks must fire on `{Read, Error}`). It fails on `master` (`writerFlag == false`) and passes with this change, on both the epoll and poll engines. #700's kqueue "Reader notification after buffer got full" test continues to pass.

## Verification

Deterministic dispatcher test, before/after:

```
# master:          readerFlag=true writerFlag=false   -> FAILED
# with this fix:   readerFlag=true writerFlag=true     -> OK   (epoll and poll)
```

Reproduced the leak end-to-end under Valgrind (Docker `nimlang/nim:2.2.10`, Linux aarch64, Valgrind 3.24.0, ORC + `-d:useMalloc`, epoll engine). A `consumer` coroutine awaits a future resolved by a writer callback (standing in for
`writeStreamLoop`), with the fd held in `{Read, Error}`; the repro is in #709.

**Before (on `master`):** `parked-future.finished = false`

```
==119== 376 (136 direct, 240 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 15
==119==    by 0x10D963: nimNewObj (arc.nim:116)
==119==    by 0x125F03: asyncfutures::newFutureImpl (asyncfutures.nim:80)
==119==    by 0x128D4F: leakrepro::run (leakrepro.nim:20)
==119==
==119== LEAK SUMMARY:
==119==    definitely lost: 136 bytes in 1 blocks
==119==    indirectly lost: 240 bytes in 3 blocks
==119==      possibly lost: 12,864 bytes in 11 blocks
==119==    still reachable: 0 bytes in 0 blocks
==119== ERROR SUMMARY: 12 errors from 12 contexts (suppressed: 0 from 0)
```

**After (this PR):** `consumer resumed`, `parked-future.finished = true`

```
==119== LEAK SUMMARY:
==119==    definitely lost: 0 bytes in 0 blocks
==119==    indirectly lost: 0 bytes in 0 blocks
==119==      possibly lost: 12,864 bytes in 11 blocks
==119==    still reachable: 0 bytes in 0 blocks
==119== ERROR SUMMARY: 11 errors from 11 contexts (suppressed: 0 from 0)
```

The `definitely`/`indirectly lost` blocks (the orphaned future and its suspended
`consumer` frame) go from `136`/`240` to `0`/`0`. The `possibly lost`
`12,864 bytes in 11 blocks` is unchanged between the two builds — ORC/dispatcher
interior-pointer bookkeeping, unrelated to this bug.

Suites pass on both engines: `testbugs`, `teststream`, `testasyncstream`,
`testhttpclient`, `testshttpserver` (TLS), `testserver`, `testfut`, `testsoon`,
`testsignal`, `testdatagram`.
