### PR TITLE
specify the versions of dependencies

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -2,7 +2,7 @@ mode = ScriptMode.Verbose
 
 packageName   = "chronos"
 # keep in sync: chronos/apps/http/httpagent.nim
-version       = "4.4.1"
+version       = "4.4.0"
 author        = "Status Research & Development GmbH"
 description   = "Networking framework with async/await support"
 license       = "MIT or Apache License 2.0"

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -2,18 +2,18 @@ mode = ScriptMode.Verbose
 
 packageName   = "chronos"
 # keep in sync: chronos/apps/http/httpagent.nim
-version       = "4.4.0"
+version       = "4.4.1"
 author        = "Status Research & Development GmbH"
 description   = "Networking framework with async/await support"
 license       = "MIT or Apache License 2.0"
 skipDirs      = @["tests"]
 
 requires "nim >= 1.6.16",
-         "results",
+         "bearssl >= 0.2.13",
+         "httputils >= 0.5.1",
+         "results >= 0.5.0",
          "stew >= 0.5.0",
-         "bearssl >= 0.2.8",
-         "httputils",
-         "unittest2"
+         "unittest2 >= 0.2.0"
 
 import os, strutils
 


### PR DESCRIPTION
Otherwise, nimble's `--resolver:minver` picks up too low versions, which don't work.