### PR TITLE
Run Windows waitForSingleObject continuation in waiting thread

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -1618,7 +1618,7 @@ when defined(windows):
        async: (raises: [AsyncError, CancelledError], raw: true).} =
     ## Waits until the specified object is in the signaled state or the
     ## time-out interval elapses. WaitForSingleObject() for asynchronous world.
-    let flags = WT_EXECUTEONLYONCE
+    let flags = WT_EXECUTEINWAITTHREAD or WT_EXECUTEONLYONCE
 
     var
       retFuture = newFuture[WaitableResult]("chronos.waitForSingleObject()")


### PR DESCRIPTION
> By default, the callback function is queued to a non-I/O worker thread

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerwaitforsingleobject

Set `WT_EXECUTEINWAITTHREAD` when waiting for an object to avoid mixing up different threads. This is in line with `addProcess2` / `addSignal2`.