### PR TITLE
Chore: Import apps in main module

### DIFF
--- a/chronos.nim
+++ b/chronos.nim
@@ -12,3 +12,6 @@
 
 import chronos/[asyncloop, asyncsync, handles, transport, timer, debugutils]
 export asyncloop, asyncsync, handles, transport, timer, debugutils
+
+{.warning[UnusedImport]: off.}
+import chronos/apps/http/[httpclient, httpserver]

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -123,11 +123,4 @@ task test_libbacktrace, "test with libbacktrace":
 task docs, "Generate API documentation":
   exec "mdbook build docs"
   tryExec nimc & " doc " &
-    "--git.url:https://github.com/status-im/nim-chronos --git.commit:master --outdir:docs/book/api --project chronos"
-
-  # Build the docs for modules that aren't part of the main module.
-  for item in walkDir("chronos/apps/http"):
-    if item.kind == pcFile and item.path.splitFile().ext == ".nim":
-      tryExec nimc & " doc " &
-        "--git.url:https://github.com/status-im/nim-chronos --git.commit:master --outdir:docs/book/api/chronos/apps/http " &
-        item.path
+    "--git.url:https://github.com/status-im/nim-chronos --git.commit:master --outdir:docs/book/api --project --index:on chronos"

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -6,12 +6,12 @@ transformation features provided by Nim.
 
 Features include:
 
-* Asynchronous socket and process I/O
-* HTTP client / server with SSL/TLS support out of the box (no OpenSSL needed)
-* Synchronization primitivies like queues, events and locks
-* [Cancellation](./concepts.md#cancellation)
-* Efficient dispatch pipeline with excellent multi-platform support
-* Exception [effect support](./guide.md#error-handling)
+- Asynchronous socket and process I/O
+- HTTP client / server with SSL/TLS support out of the box (no OpenSSL needed)
+- Synchronization primitivies like queues, events and locks
+- [Cancellation](./concepts.md#cancellation)
+- Efficient dispatch pipeline with excellent multi-platform support
+- Exception [effect support](./guide.md#error-handling)
 
 ## Installation
 
@@ -39,21 +39,24 @@ There are more [examples](./examples.md) throughout the manual!
 
 Several platforms are supported, with different backend [options](./concepts.md#compile-time-configuration):
 
-* Windows: [`IOCP`](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports)
-* Linux: [`epoll`](https://en.wikipedia.org/wiki/Epoll) / `poll`
-* OSX / BSD: [`kqueue`](https://en.wikipedia.org/wiki/Kqueue) / `poll`
-* Android / Emscripten / posix: `poll`
+- Windows: [`IOCP`](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports)
+- Linux: [`epoll`](https://en.wikipedia.org/wiki/Epoll) / `poll`
+- OSX / BSD: [`kqueue`](https://en.wikipedia.org/wiki/Kqueue) / `poll`
+- Android / Emscripten / posix: `poll`
 
 ## API documentation
 
 This guide covers basic usage of chronos - for details, see the API reference:
-- [chronos](api/chronos.html)
-- [httpagent](api/chronos/apps/http/httpagent.html)
-- [httpbodyrw](api/chronos/apps/http/httpbodyrw.html)
-- [httpclient](api/chronos/apps/http/httpclient.html)
-- [httpcommon](api/chronos/apps/http/httpcommon.html)
-- [httpdebug](api/chronos/apps/http/httpdebug.html)
-- [httpserver](api/chronos/apps/http/httpserver.html)
-- [httptable](api/chronos/apps/http/httptable.html)
-- [multipart](api/chronos/apps/http/multipart.html)
-- [shttpserver](api/chronos/apps/http/shttpserver.html)
+
+- [API index](api/theindex.html)
+- Modules:
+  - [chronos](api/chronos.html)
+  - [httpagent](api/chronos/apps/http/httpagent.html)
+  - [httpbodyrw](api/chronos/apps/http/httpbodyrw.html)
+  - [httpclient](api/chronos/apps/http/httpclient.html)
+  - [httpcommon](api/chronos/apps/http/httpcommon.html)
+  - [httpdebug](api/chronos/apps/http/httpdebug.html)
+  - [httpserver](api/chronos/apps/http/httpserver.html)
+  - [httptable](api/chronos/apps/http/httptable.html)
+  - [multipart](api/chronos/apps/http/multipart.html)
+  - [shttpserver](api/chronos/apps/http/shttpserver.html)


### PR DESCRIPTION
HTTP apps are currently not part of the main package. They're basically external packages sitting inside Chronos.

It makes it problematic to generate API documentation and index.

I've added imports for the apps to chronos.nim. AFAIK this shouldn't affect any consumers as even if you import chronos and never use httpserver or httpclient your code won't have them as this will be dead code.