### PR TITLE
Avoid double advancing stream when reading bounded stream

### DIFF
--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -181,7 +181,9 @@ proc readBounded(
       raise exc
     except AsyncStreamIncompleteError:
       raise newBoundedStreamIncompleteError()
-  rstream.offset += n.uint
+  else:
+    if rstream.state == AsyncStreamState.Running:
+      rstream.state = AsyncStreamState.Finished
 
   # TODO https://github.com/nim-lang/Nim/issues/25057
   move(res)

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -1507,8 +1507,11 @@ suite "AsyncStream/BoundedStream":
         case stest
         of SizeReadWrite:
           let response = await rbstream.read()
+          check:
+            response == message
+            len(await rbstream.read()) == 0
+            rbstream.atEof()
           await rbstream.closeWait()
-          check response == message
 
         of SizeOverflow:
           let response = await rbstream.read()
@@ -1574,7 +1577,8 @@ suite "AsyncStream/BoundedStream":
   asyncTest "read small chunks":
     proc checkVector(inputstr: seq[byte],
                      writeChunkSize: int,
-                     readChunkSize: int): Future[seq[byte]] {.async.} =
+                     readChunkSize: int,
+                     cmp: BoundCmp): Future[seq[byte]] {.async.} =
       proc serveClient(server: StreamServer,
                        transp: StreamTransport) {.async: (raises: []).} =
         try:
@@ -1602,8 +1606,14 @@ suite "AsyncStream/BoundedStream":
       server.start()
       var transp = await connect(server.localAddress())
       var rstream = newAsyncStreamReader(transp)
-      var rstream2 = newBoundedStreamReader(rstream, 1048576,
-                                            comparison = BoundCmp.LessOrEqual)
+      let boundSize =
+        case cmp
+        of BoundCmp.Equal:
+          uint64(len(inputstr))
+        of BoundCmp.LessOrEqual:
+          1048576'u64
+      var rstream2 = newBoundedStreamReader(rstream, boundSize,
+                                            comparison = cmp)
       var res: seq[byte]
       while not(rstream2.atEof()):
         var chunk = await rstream2.read(readChunkSize)
@@ -1617,8 +1627,9 @@ suite "AsyncStream/BoundedStream":
     proc testSmallChunk(datasize: int, writeChunkSize: int,
                         readChunkSize: int) {.async.} =
       var data = createBigMessage("0123456789ABCDEFGHI", datasize)
-      var check = await checkVector(data, writeChunkSize, readChunkSize)
-      check (data == check)
+      for cmp in [BoundCmp.Equal, BoundCmp.LessOrEqual]:
+        var check = await checkVector(data, writeChunkSize, readChunkSize, cmp)
+        check (data == check)
 
     await testSmallChunk(4457, 128, 1)
     await testSmallChunk(65600, 1024, 17)


### PR DESCRIPTION
`readExactly` already advances the offset via `readOnce`, no need to advance it in `readBounded` (potential `RangeDefect`). Also fix EOF. Regression from #643.