### PR TITLE
Fix `RangeDefect` when requesting large response buffer

### DIFF
--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -56,6 +56,9 @@ template newBoundedStreamIncompleteError(): ref BoundedStreamError =
 template newBoundedStreamOverflowError(): ref BoundedStreamOverflowError =
   newException(BoundedStreamOverflowError, "Stream boundary exceeded")
 
+func numRemainingBytes(rstream: BoundedStreamReader): int =
+  int(min(rstream.boundSize.get() - rstream.offset, uint64(high(int))))
+
 proc readUntilBoundary(
     rstream: BoundedStreamReader, pbytes: pointer, nbytes: int
 ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
@@ -130,7 +133,7 @@ proc readOnce(
           rstream.state = AsyncStreamState.Finished
           return 0
 
-        min(int(rstream.boundSize[] - rstream.offset), nbytes)
+        min(rstream.numRemainingBytes(), nbytes)
       else:
         nbytes
 
@@ -171,16 +174,21 @@ proc readBounded(
     rstream: BoundedStreamReader
 ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
   # Fast path for reading all bytes up to the count-baased boundary
-  let n = (rstream.boundSize.get() - rstream.offset).int
-  var res = newSeqUninit[byte](n)
-  if res.len > 0:
-    try:
-      await rstream.readExactly(addr res[0], res.len)
-    except CancelledError as exc:
-      rstream.state = AsyncStreamState.Stopped
-      raise exc
-    except AsyncStreamIncompleteError:
-      raise newBoundedStreamIncompleteError()
+  let n = rstream.numRemainingBytes()
+  var res = newSeqUninit[byte](min(n, 128 * 1024))
+  if n > 0:
+    var o = 0
+    while o < n:
+      if o == res.len:
+        res.setLenUninit(int(min(uint64(n), uint64(res.len) shl 1)))
+      try:
+        await rstream.readExactly(addr res[o], res.len - o)
+        o = res.len
+      except CancelledError as exc:
+        rstream.state = AsyncStreamState.Stopped
+        raise exc
+      except AsyncStreamIncompleteError:
+        raise newBoundedStreamIncompleteError()
   else:
     if rstream.state == AsyncStreamState.Running:
       rstream.state = AsyncStreamState.Finished
@@ -204,7 +212,7 @@ proc initReaderVtbl(bufferSize: int): AsyncStreamReaderVtbl =
     let rstream = BoundedStreamReader(rstream)
     if rstream.boundSize.isSome() and rstream.boundary.len == 0 and
         rstream.cmpop == BoundCmp.Equal and
-        (n == 0 or n == (rstream.boundSize.get - rstream.offset).int):
+        (n == 0 or n == rstream.numRemainingBytes()):
       # Special case for draining the rest of the stream, as happens when
       # reading a http body for example
       readBounded(rstream)

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -180,7 +180,10 @@ proc readBounded(
     var o = 0
     while o < n:
       if o == res.len:
-        res.setLenUninit(int(min(uint64(n), uint64(res.len) shl 1)))
+        if res.len <= static(high(int) div 2):
+          res.setLenUninit(min(n, res.len shl 1))
+        else:
+          res.setLenUninit(min(n, high(int)))
       try:
         await rstream.readExactly(addr res[o], res.len - o)
         o = res.len

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -183,7 +183,7 @@ proc readBounded(
         if res.len <= static(high(int) div 2):
           res.setLenUninit(min(n, res.len shl 1))
         else:
-          res.setLenUninit(min(n, high(int)))
+          res.setLenUninit(n)
       try:
         await rstream.readExactly(addr res[o], res.len - o)
         o = res.len

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -1445,7 +1445,8 @@ suite "AsyncStream/BoundedStream":
         check clientRes
 
       proc boundedTest(stest: BoundarySizeTest,
-                       size: int, cmp: BoundCmp) {.async.} =
+                       size: int, cmp: BoundCmp,
+                       boundarySize = Opt.none(uint64)) {.async.} =
         let messagePart = createBigMessage("ABCDEFGHIJKLMNOP",
                                            int(itemSize) div 10)
         var message: seq[byte]
@@ -1502,7 +1503,8 @@ suite "AsyncStream/BoundedStream":
         server.start()
         var conn = await connect(server.localAddress())
         var rstream = newAsyncStreamReader(conn)
-        var rbstream = newBoundedStreamReader(rstream, uint64(size),
+        var rbstream = newBoundedStreamReader(rstream,
+                                              boundarySize.get(uint64(size)),
                                               comparison = cmp)
         case stest
         of SizeReadWrite:
@@ -1553,6 +1555,14 @@ suite "AsyncStream/BoundedStream":
         await boundedTest(SizeOverflow, itemSize, itemComp)
       asyncTest "BoundedStream(size) incomplete test [" & suffix & "]":
         await(boundedTest(SizeIncomplete, itemSize, itemComp))
+      asyncTest "BoundedStream(size) incomplete test, large [" & suffix & "]":
+        for boundarySize in [
+            1'u64 shl 30, 1'u64 shl 31, 1'u64 shl 40, 1'u64 shl 53,
+            uint64(high(int32)), uint64(high(int32)) + 1,
+            uint64(high(int64)), uint64(high(int64)) + 1,
+            high(uint64)]:
+          await(boundedTest(SizeIncomplete, itemSize, itemComp,
+                              Opt.some(boundarySize)))
       asyncTest "BoundedStream(size) empty message test [" & suffix & "]":
         await(boundedTest(SizeEmpty, itemSize, itemComp))
       asyncTest "BoundedStream(boundary) reading test [" & suffix & "]":

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -1345,7 +1345,7 @@ suite "AsyncStream/BoundedStream":
       BoundaryEmpty
 
   for itemComp in [BoundCmp.Equal, BoundCmp.LessOrEqual]:
-    for itemSize in [100, 60000]:
+    for itemSize in [100, 60000, 300000]:
 
       proc boundaryTest(btest: BoundaryBytesTest,
                         size: int, boundary: seq[byte],


### PR DESCRIPTION
Large uint value doesn't necessarily fit into int