### PR TITLE
Fix multipart boundary parsing when trailing \r\n missing

### DIFF
--- a/chronos/apps/http/multipart.nim
+++ b/chronos/apps/http/multipart.nim
@@ -348,15 +348,15 @@ proc getPart*(mpr: var MultiPartReader): Result[MultiPart, string] =
       # If we have <-><-><boundary><-><-> it means we have found last boundary
       # of multipart message.
       mpr.offset += 2
+      
       if len(mpr.buffer) <= mpr.offset + 1:
-        if mpr.buffer[mpr.offset] == 0x0D'u8 and
-           mpr.buffer[mpr.offset + 1] == 0x0A'u8:
-          mpr.offset += 2
-          return err("End of multipart form encountered")
-        else:
-          return err("Incorrect multipart last boundary")
-      else:
         return err("Incomplete multipart form")
+      if mpr.buffer[mpr.offset] == 0x0D'u8 and
+          mpr.buffer[mpr.offset + 1] == 0x0A'u8:
+        mpr.offset += 2
+        return err("End of multipart form encountered")
+      else:
+        return err("Incorrect multipart last boundary")
 
     if mpr.buffer[mpr.offset] == 0x0D'u8 and
        mpr.buffer[mpr.offset + 1] == 0x0A'u8:

--- a/chronos/apps/http/multipart.nim
+++ b/chronos/apps/http/multipart.nim
@@ -348,7 +348,7 @@ proc getPart*(mpr: var MultiPartReader): Result[MultiPart, string] =
       # If we have <-><-><boundary><-><-> it means we have found last boundary
       # of multipart message.
       mpr.offset += 2
-      
+
       if len(mpr.buffer) <= mpr.offset + 1:
         return err("Incomplete multipart form")
       if mpr.buffer[mpr.offset] == 0x0D'u8 and

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -591,8 +591,9 @@ suite "HTTP server testing suite":
       for o in 0 .. 2:  # Incomplete trailing \r\n
         var mpreader = MultiPartReader.init(
           body.toOpenArray(0, body.high - o), boundary)
-        for (name, value) in [
-            ("key1", "value1"), ("key2", "value2"), ("key2", "value4")]:
+        const ExpectedParts = [
+          ("key1", "value1"), ("key2", "value2"), ("key2", "value4")]
+        for (name, value) in ExpectedParts:
           let part = mpreader.getPart()
           if part.isErr() or
               part.get().name != name or part.get().getString() != value:

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -560,8 +560,8 @@ suite "HTTP server testing suite":
       server.start()
       let address = server.instance.localAddress()
 
-      const boundary = "------------------------ab5706ba6f80b795"
-      let
+      const
+        boundary = "------------------------ab5706ba6f80b795"
         body =
           "--" & boundary & "\r\n" &
           "Content-Disposition: form-data; name=\"key1\"\r\n\r\n" &

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -578,7 +578,7 @@ suite "HTTP server testing suite":
           "Host: 127.0.0.1:30080\r\n" &
           "User-Agent: curl/7.55.1\r\n" &
           "Accept: */*\r\n" &
-          "Content-Length: " & $(len(body) + 2) & "\r\n" &
+          "Content-Length: " & $len(body) & "\r\n" &
           "Content-Type: multipart/form-data; " &
           "boundary=" & boundary & "\r\n\r\n" &
           body

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -560,29 +560,47 @@ suite "HTTP server testing suite":
       server.start()
       let address = server.instance.localAddress()
 
-      let message =
-        "POST / HTTP/1.0\r\n" &
-        "Host: 127.0.0.1:30080\r\n" &
-        "User-Agent: curl/7.55.1\r\n" &
-        "Accept: */*\r\n" &
-        "Content-Length: 343\r\n" &
-        "Content-Type: multipart/form-data; " &
-        "boundary=------------------------ab5706ba6f80b795\r\n\r\n" &
-        "--------------------------ab5706ba6f80b795\r\n" &
-        "Content-Disposition: form-data; name=\"key1\"\r\n\r\n" &
-        "value1\r\n" &
-        "--------------------------ab5706ba6f80b795\r\n" &
-        "Content-Disposition: form-data; name=\"key2\"\r\n\r\n" &
-        "value2\r\n" &
-        "--------------------------ab5706ba6f80b795\r\n" &
-        "Content-Disposition: form-data; name=\"key2\"\r\n\r\n" &
-        "value4\r\n" &
-        "--------------------------ab5706ba6f80b795--\r\n"
+      const boundary = "------------------------ab5706ba6f80b795"
+      let
+        body =
+          "--" & boundary & "\r\n" &
+          "Content-Disposition: form-data; name=\"key1\"\r\n\r\n" &
+          "value1\r\n" &
+          "--" & boundary & "\r\n" &
+          "Content-Disposition: form-data; name=\"key2\"\r\n\r\n" &
+          "value2\r\n" &
+          "--" & boundary & "\r\n" &
+          "Content-Disposition: form-data; name=\"key2\"\r\n\r\n" &
+          "value4\r\n" &
+          "--" & boundary & "--\r\n"
+        message =
+          "POST / HTTP/1.0\r\n" &
+          "Host: 127.0.0.1:30080\r\n" &
+          "User-Agent: curl/7.55.1\r\n" &
+          "Accept: */*\r\n" &
+          "Content-Length: " & $(len(body) + 2) & "\r\n" &
+          "Content-Type: multipart/form-data; " &
+          "boundary=" & boundary & "\r\n\r\n" &
+          body
       let data = await httpClient(address, message)
       let expect = "TEST_OK:key1:value1:key2:value2:key2:value4"
       await server.stop()
       await server.closeWait()
-      return serverRes and (data.find(expect) >= 0)
+
+      var bufferRes = true
+      for o in 0 .. 2:  # Incomplete trailing \r\n
+        var mpreader = MultiPartReader.init(
+          body.toOpenArray(0, body.high - o), boundary)
+        for (name, value) in [
+            ("key1", "value1"), ("key2", "value2"), ("key2", "value4")]:
+          let part = mpreader.getPart()
+          if part.isErr() or
+              part.get().name != name or part.get().getString() != value:
+            bufferRes = false
+        if mpreader.getPart().isOk():
+          bufferRes = false
+
+      return serverRes and (data.find(expect) >= 0) and bufferRes
 
     check waitFor(testPostMultipart()) == true
 

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -578,7 +578,7 @@ suite "HTTP server testing suite":
           "Host: 127.0.0.1:30080\r\n" &
           "User-Agent: curl/7.55.1\r\n" &
           "Accept: */*\r\n" &
-          "Content-Length: " & $len(body) & "\r\n" &
+          "Content-Length: " & Base10.toString(uint64(len(body))) & "\r\n" &
           "Content-Type: multipart/form-data; " &
           "boundary=" & boundary & "\r\n\r\n" &
           body


### PR DESCRIPTION
Avoid IndexDefect when boundary \r\n is incomplete in multipart message.