### PR TITLE
`asyncproc`: fix hang waiting for a child process to exit (Windows)

### DIFF
--- a/chronos/asyncproc.nim
+++ b/chronos/asyncproc.nim
@@ -1078,7 +1078,8 @@ proc createPipe(kind: StandardKind
       when defined(windows):
         let
           readFlags: set[DescriptorFlag] = {DescriptorFlag.NonBlock}
-          writeFlags: set[DescriptorFlag] = {DescriptorFlag.NonBlock}
+          writeFlags: set[DescriptorFlag] =
+            {DescriptorFlag.NonBlock, DescriptorFlag.CloseOnExec}
         ? createOsPipe(readFlags, writeFlags)
       else:
         let
@@ -1090,7 +1091,8 @@ proc createPipe(kind: StandardKind
     let pipes =
       when defined(windows):
         let
-          readFlags: set[DescriptorFlag] = {DescriptorFlag.NonBlock}
+          readFlags: set[DescriptorFlag] =
+            {DescriptorFlag.NonBlock, DescriptorFlag.CloseOnExec}
           writeFlags: set[DescriptorFlag] = {DescriptorFlag.NonBlock}
         ? createOsPipe(readFlags, writeFlags)
       else:

--- a/tests/testproc.nim
+++ b/tests/testproc.nim
@@ -164,6 +164,34 @@ suite "Asynchronous process management test suite":
       finally:
         await process.closeWait()
 
+  asyncTest "Closing STDIN gives the child end of file":
+    let
+      command =
+        when defined(windows):
+          ("tests\\testproc.bat", "stdin")
+        else:
+          ("tests/testproc.sh", "stdin")
+      stdoutExpected =
+        when defined(windows):
+          "STDIN DATA: \r\n".toBytes()
+        else:
+          "STDIN DATA: \n".toBytes()
+      process = await startProcess(command[0], arguments = @[command[1]],
+                                   stdinHandle = AsyncProcess.Pipe,
+                                   stdoutHandle = AsyncProcess.Pipe)
+    try:
+      await process.stdinStream.tsource.closeWait()
+      let
+        stdoutFut = process.stdoutStream.read()
+        res = await process.waitForExit(InfiniteDuration)
+      await allFutures(stdoutFut)
+      let stdoutData = stdoutFut.read()
+      check:
+        res == 0
+        stdoutData == stdoutExpected
+    finally:
+      await process.closeWait()
+
   asyncTest "STDOUT and STDERR streams test":
     let options = {AsyncProcessOption.EvalCommand}
 


### PR DESCRIPTION
On Windows a child spawned with `stdinHandle = AsyncProcess.Pipe` never sees EOF on stdin, even after parent close.

Changes:

- Add `CloseOnExec` to `writeFlags` for stdin, `readFlags` for stdout/stderr.
- Add regression tests which hang without the fix.
