### PR TITLE
fix(ipnet): stop classifying IPv4 multicast as unicast

### DIFF
--- a/chronos/transports/ipnet.nim
+++ b/chronos/transports/ipnet.nim
@@ -735,7 +735,7 @@ proc isUnicast*(address: TransportAddress): bool =
   ## Any address that is not a IPv6 multicast address `FF00::/8` is unicast.
   case address.family
   of AddressFamily.IPv4:
-    not(isZero(address) and not isMulticast(address))
+    not(isZero(address) or isMulticast(address))
   of AddressFamily.IPv6:
     not(isMulticast(address))
   else:

--- a/tests/testnet.nim
+++ b/tests/testnet.nim
@@ -164,6 +164,14 @@ suite "Network utilities test suite":
       initTAddress("240.0.0.0:0").isMulticast() == false
       initTAddress("223.0.0.0:0").isMulticast() == false
 
+      initTAddress("8.8.8.8:0").isUnicast() == true
+      initTAddress("223.255.255.255:0").isUnicast() == true
+      initTAddress("224.0.0.0:0").isUnicast() == false
+      initTAddress("230.0.0.0:0").isUnicast() == false
+      initTAddress("239.255.255.255:0").isUnicast() == false
+      initTAddress("240.0.0.0:0").isUnicast() == true
+      initTAddress("0.0.0.0:0").isUnicast() == false
+
       initTAddress("224.0.0.0:0").isLinkLocalMulticast() == true
       initTAddress("224.0.0.255:0").isLinkLocalMulticast() == true
       initTAddress("225.0.0.0:0").isLinkLocalMulticast() == false
@@ -286,6 +294,10 @@ suite "Network utilities test suite":
         "[FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF]:0"
       ).isMulticast() == true
       initTAddress("[F000::]:0").isMulticast() == false
+
+      initTAddress("[2001:db8::1]:0").isUnicast() == true
+      initTAddress("[FF00::]:0").isUnicast() == false
+      initTAddress("[FF02::1]:0").isUnicast() == false
 
       initTAddress("[::]:0").isAnyLocal() == true
       initTAddress("[::1]:0").isAnyLocal() == false


### PR DESCRIPTION
`isUnicast` returns `true` for every IPv4 multicast address, so an address reports as both multicast and unicast at once:

```nim
initTAddress("224.0.0.1:0").isMulticast()  # true
initTAddress("224.0.0.1:0").isUnicast()    # true
```

## Cause

The IPv4 branch reads:

```nim
not(isZero(address) and not isMulticast(address))
```

That is `not(A and not B)`, which is true whenever the address is non-zero, regardless of what `isMulticast` says. For a multicast address `A` is false, so the conjunction is false and the negation is true. The multicast term can only matter when `isZero` is true, and there it is false anyway, so it never changes the result.

The intended predicate is `not(A or B)`.

The IPv6 branch is already `not(isMulticast(address))`, and the doc comment above the proc describes multicast as the thing being excluded, so the two families disagreed only because of this expression.

## Observed

```
address              isUnicast   isMulticast
8.8.8.8              true        false        ok
224.0.0.1            true        true         wrong
239.255.255.255      true        true         wrong
232.1.2.3            true        true         wrong
0.0.0.0              false       false        ok
2001:db8::1          true        false        ok   (IPv6 branch)
ff02::1              false       true         ok   (IPv6 branch)
```

## Fix

```nim
not(isZero(address) or isMulticast(address))
```

`0.0.0.0` stays non-unicast exactly as today, `224.0.0.0/4` becomes non-unicast, and everything outside both ranges is unchanged, including `240.0.0.0/4`.

## Tests

`isUnicast` had no direct coverage: `testnet.nim` only exercised `isUnicastLinkLocal`. Added IPv4 cases either side of the multicast range plus the zero address, and IPv6 cases as a control, following the existing `isMulticast` block's style.

Against the unfixed branch, exactly the three multicast assertions fail:

```
Check failed: initTAddress("224.0.0.0:0").isUnicast() == false
Check failed: initTAddress("230.0.0.0:0").isUnicast() == false
Check failed: initTAddress("239.255.255.255:0").isUnicast() == false
[Summary] 15 tests run: 14 OK, 1 FAILED
```

With the fix, `15 OK, 0 FAILED`. The unicast, `240.0.0.0/4`, zero-address and IPv6 cases pass either way, so this is a correction rather than a loosening.

## Note on downstream impact

I came at this from nim-eth, where `isGlobalUnicast` (`isGlobal() and isUnicast()`) gates which advertised addresses are accepted into the discv5 routing table. With the current behaviour an IPv4 multicast address passes that check. I have not tried to establish whether that is exploitable, and I am not presenting it as a security issue; it is just the path that surfaced the predicate. Happy to route this differently if you would rather it were handled privately.
