### PR TITLE
deprecate `one`

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -1061,7 +1061,7 @@ proc allFinished*[F: SomeFuture](futs: varargs[F]): Future[seq[F]] {.
 
   return retFuture
 
-template oneImpl: untyped =
+template raceImpl: untyped =
   # If one of the Future[T] already finished we return it as result
   when declared(fut0):
     if fut0.finished():
@@ -1093,6 +1093,7 @@ template oneImpl: untyped =
           retFuture.complete(move(fut))
         else:
           fut.removeCallback(cbc2)
+      cbc2 = nil # clear for refc
 
   proc cancellation(udata: pointer) =
     # On cancel we remove all our callbacks only.
@@ -1113,7 +1114,8 @@ template oneImpl: untyped =
   retFuture
 
 proc one*(fut0: SomeFuture, futs: varargs[SomeFuture]): Future[SomeFuture] {.
-    async: (raw: true, raises: [CancelledError]).} =
+    async: (raw: true, raises: [CancelledError]),
+    deprecated: "Use `race` instead".} =
   ## Waits for one of the given futures to finish and returns it.
   ##
   ## If any of the futures is already finished, returns immediately.
@@ -1125,10 +1127,11 @@ proc one*(fut0: SomeFuture, futs: varargs[SomeFuture]): Future[SomeFuture] {.
   ## This function is a synonym for `race`.
   let retFuture = newFuture[SomeFuture]("chronos.one()")
 
-  oneImpl
+  raceImpl
 
 proc one*(futs: openArray[SomeFuture]): Future[SomeFuture] {.
-    async: (raw: true, raises: [ValueError, CancelledError]).} =
+    async: (raw: true, raises: [ValueError, CancelledError]),
+    deprecated: "Use `race` instead".} =
   ## Waits for one of the given futures to finish and returns it.
   ##
   ## If any of the futures is already finished, returns immediately.
@@ -1146,7 +1149,11 @@ proc one*(futs: openArray[SomeFuture]): Future[SomeFuture] {.
     retFuture.fail(newException(ValueError, "Empty Future[T] list"))
     return retFuture
 
-  oneImpl
+  raceImpl
+
+proc one*(_: typeof([])) {.
+    error: "`one` requires at least one future",
+    deprecated: "Use `race` instead".}
 
 proc race*(fut0: FutureBase, futs: varargs[FutureBase]): Future[FutureBase] {.
     async: (raw: true, raises: [CancelledError]).} =
@@ -1159,9 +1166,7 @@ proc race*(fut0: FutureBase, futs: varargs[FutureBase]): Future[FutureBase] {.
   ## On cancel futures in ``futs`` WILL NOT BE cancelled.
   let retFuture = newFuture[FutureBase]("chronos.race()")
 
-  oneImpl
-
-proc one*(_: typeof([])) {.error: "`one` requires at least one future".}
+  raceImpl
 
 proc race*(futs: openArray[FutureBase]): Future[FutureBase] {.
     async: (raw: true, raises: [ValueError, CancelledError]).} =
@@ -1180,9 +1185,9 @@ proc race*(futs: openArray[FutureBase]): Future[FutureBase] {.
     retFuture.fail(newException(ValueError, "Empty Future[T] list"))
     return retFuture
 
-  oneImpl
+  raceImpl
 
-proc race*(fut0: SomeFuture, futs: openArray[SomeFuture]): Future[SomeFuture] {.
+proc race*(fut0: SomeFuture, futs: varargs[SomeFuture]): Future[SomeFuture] {.
     async: (raw: true, raises: [CancelledError]).} =
   ## Waits for one of the given futures to finish and returns it.
   ##
@@ -1193,7 +1198,7 @@ proc race*(fut0: SomeFuture, futs: openArray[SomeFuture]): Future[SomeFuture] {.
   ## On cancel futures in ``futs`` WILL NOT BE cancelled.
   let retFuture = newFuture[SomeFuture]("chronos.race()")
 
-  oneImpl
+  raceImpl
 
 proc race*(futs: openArray[SomeFuture]): Future[SomeFuture] {.
     async: (raw: true, raises: [ValueError, CancelledError]).} =
@@ -1212,7 +1217,7 @@ proc race*(futs: openArray[SomeFuture]): Future[SomeFuture] {.
     retFuture.fail(newException(ValueError, "Empty Future[T] list"))
     return retFuture
 
-  oneImpl
+  raceImpl
 
 proc race*(_: typeof([])) {.error: "`race` requires at least one future".}
 

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -303,10 +303,10 @@ proc runUntil(rws: TLSAsyncStream, target: cuint): Future[void] {.
         if not(rws.writeFut.isNil):
           race(rws.readFut, rws.writeFut)
         else:
-          race(rws.readFut) # await without reading the underlying future outcome
+          race(FutureBase(rws.readFut)) # await without reading the underlying future outcome
       else:
         doAssert not(rws.writeFut.isNil), "We must have created at least one future above"
-        race(rws.writeFut) # await without reading the underlying future outcome
+        race(FutureBase(rws.writeFut)) # await without reading the underlying future outcome
     try:
       discard await readWriteDone
     except CancelledError as exc:

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -723,12 +723,12 @@ suite "Future[T] behavior test suite":
       not(fut.failed())
       len(fut.read()) == 2
 
-  test "one(zero) test":
+  test "race(zero) test":
     var tseq = newSeq[Future[int]]()
-    var fut = one(tseq)
+    var fut = race(tseq)
     check: fut.finished and fut.failed
 
-  asyncTest "one(varargs) test":
+  asyncTest "race(varargs) test":
     proc vlient1() {.async.} =
       await sleepAsync(100.milliseconds)
 
@@ -753,17 +753,17 @@ suite "Future[T] behavior test suite":
     var fut11 = vlient1()
     var fut12 = vlient2()
     var fut13 = vlient3()
-    var res1 = await one(fut11, fut12, fut13)
+    var res1 = await race(fut11, fut12, fut13)
 
     var fut21 = vlient2()
     var fut22 = vlient1()
     var fut23 = vlient3()
-    var res2 = await one(fut21, fut22, fut23)
+    var res2 = await race(fut21, fut22, fut23)
 
     var fut31 = vlient3()
     var fut32 = vlient2()
     var fut33 = vlient1()
-    var res3 = await one(fut31, fut32, fut33)
+    var res3 = await race(fut31, fut32, fut33)
 
     check:
       fut11 == res1
@@ -773,24 +773,24 @@ suite "Future[T] behavior test suite":
     var cut11 = client1()
     var cut12 = client2()
     var cut13 = client3()
-    var res4 = await one(cut11, cut12, cut13)
+    var res4 = await race(cut11, cut12, cut13)
 
     var cut21 = client2()
     var cut22 = client1()
     var cut23 = client3()
-    var res5 = await one(cut21, cut22, cut23)
+    var res5 = await race(cut21, cut22, cut23)
 
     var cut31 = client3()
     var cut32 = client2()
     var cut33 = client1()
-    var res6 = await one(cut31, cut32, cut33)
+    var res6 = await race(cut31, cut32, cut33)
 
     check:
       cut11 == res4
       cut22 == res5
       cut33 == res6
 
-  asyncTest "one(seq) test":
+  asyncTest "race(seq) test":
     proc vlient1() {.async.} =
       await sleepAsync(100.milliseconds)
 
@@ -815,17 +815,17 @@ suite "Future[T] behavior test suite":
     var v10 = vlient1()
     var v11 = vlient2()
     var v12 = vlient3()
-    var res1 = await one(@[v10, v11, v12])
+    var res1 = await race(@[v10, v11, v12])
 
     var v20 = vlient2()
     var v21 = vlient1()
     var v22 = vlient3()
-    var res2 = await one(@[v20, v21, v22])
+    var res2 = await race(@[v20, v21, v22])
 
     var v30 = vlient3()
     var v31 = vlient2()
     var v32 = vlient1()
-    var res3 = await one(@[v30, v31, v32])
+    var res3 = await race(@[v30, v31, v32])
 
     check:
       res1 == v10
@@ -835,24 +835,24 @@ suite "Future[T] behavior test suite":
     var c10 = client1()
     var c11 = client2()
     var c12 = client3()
-    var res4 = await one(@[c10, c11, c12])
+    var res4 = await race(@[c10, c11, c12])
 
     var c20 = client2()
     var c21 = client1()
     var c22 = client3()
-    var res5 = await one(@[c20, c21, c22])
+    var res5 = await race(@[c20, c21, c22])
 
     var c30 = client3()
     var c31 = client2()
     var c32 = client1()
-    var res6 = await one(@[c30, c31, c32])
+    var res6 = await race(@[c30, c31, c32])
 
     check:
       res4 == c10
       res5 == c21
       res6 == c32
 
-  test "one(completed) test":
+  test "race(completed) test":
     proc client1(): Future[int] {.async.} =
       result = 1
 
@@ -867,11 +867,11 @@ suite "Future[T] behavior test suite":
     var f10 = client1()
     var f20 = client2()
     var f30 = client3()
-    var fut1 = one(f30, f10, f20)
+    var fut1 = race(f30, f10, f20)
     var f11 = client1()
     var f21 = client2()
     var f31 = client3()
-    var fut2 = one(f31, f21, f11)
+    var fut2 = race(f31, f21, f11)
 
     check:
       fut1.finished()
@@ -881,11 +881,11 @@ suite "Future[T] behavior test suite":
       not(fut2.failed())
       fut2.read() == f21
 
-  asyncTest "one() exception effect":
+  asyncTest "race() exception effect":
     proc checkraises() {.async: (raises: [CancelledError]).} =
       let f = Future[void].Raising([CancelledError]).init()
       f.complete()
-      one(f).cancelSoon()
+      race(f).cancelSoon()
 
     await checkraises()
 


### PR DESCRIPTION
`one` is effectively subset of `race` as of
265236724af61fc4719d5ead4f18337e427d1371 (released in v4.2.0).

This PR also fixes one remaining difference that v4.2.0 did not catch - this updates the return type to be slightly more expressive again - expressions that combine different futures might need an explicit conversion as seen in tlsstream.